### PR TITLE
Auth0 to Descope Migration Skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "descope-skills",
   "description": "Skills for integrating Descope authentication and managing projects with Terraform",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Descope",
     "email": "support@descope.com"
@@ -9,5 +9,5 @@
   "homepage": "https://docs.descope.com",
   "repository": "https://github.com/descope/skills",
   "license": "MIT",
-  "keywords": ["descope", "authentication", "terraform", "oauth", "sso", "passkey", "mfa"]
+  "keywords": ["descope", "authentication", "terraform", "quickstart", "migration", "mfa", "security", "oauth", "sso", "passkey", "ci-cd", "deployment"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ coverage/
 # Build
 dist/
 build/
+
+*.zip

--- a/README.md
+++ b/README.md
@@ -40,6 +40,32 @@ Integrate Descope authentication into applications with support for passwordless
 </details>
 
 <details>
+<summary><b>auth0-to-descope</b> — Migrate from Auth0 to Descope</summary>
+
+Step-by-step migration guidance from Auth0 to Descope, covering scope assessment, migration path selection, framework-specific code changes, and verification. Handles Auth0 SDK replacements across multiple languages and frameworks.
+
+**Use when:**
+- "How do I migrate from Auth0 to Descope?"
+- "Replace Auth0 with Descope in my app"
+- "We're moving off Auth0"
+- "My app uses nextjs-auth0 / express-openid-connect / auth0-fastapi and I want to switch"
+- "How does Descope handle Auth0 Actions / Organizations / FGA?"
+
+**Frameworks supported:**
+- Next.js (`nextjs-auth0` → `@descope/nextjs-sdk`)
+- Node.js / Express (`express-openid-connect` → `@descope/node-sdk`)
+- Python / FastAPI (`auth0-fastapi` → Descope Python SDK)
+- Any framework with a Descope SDK
+
+**Features:**
+- **Pre-generation protocol** - Verifies SDK exports, wrapper types, and package versions before writing code
+- **Feature mapping** - Auth0 Actions → Descope Connectors/Webhooks, Organizations → Tenants, FGA → RBAC/ReBAC
+- **Descope Docs MCP integration** - Uses live docs for accurate SDK lookups when available
+- **Cascading change detection** - Finds all call sites affected by async conversions and import removals
+
+</details>
+
+<details>
 <summary><b>descope-terraform</b> — Manage Descope projects as infrastructure-as-code</summary>
 
 Manage Descope projects as infrastructure-as-code using the official [Terraform provider](https://registry.terraform.io/providers/descope/descope/latest/docs). Generates valid HCL configurations for authentication methods, RBAC, connectors, and project settings.
@@ -119,6 +145,27 @@ Add OAuth login (Google and GitHub) using Descope
 </details>
 
 <details>
+<summary><b>auth0-to-descope examples</b></summary>
+
+```
+Migrate my Next.js app from nextjs-auth0 to Descope
+```
+
+```
+How do I replace Auth0 Actions with Descope?
+```
+
+```
+Help me migrate our Auth0 Organizations setup to Descope
+```
+
+```
+Our Express API uses express-openid-connect — how do we switch to Descope?
+```
+
+</details>
+
+<details>
 <summary><b>descope-terraform examples</b></summary>
 
 ```
@@ -158,12 +205,16 @@ skills/
 │       ├── nextjs.md - Next.js App Router patterns
 │       ├── react.md - React SPA patterns
 │       └── backend.md - Node.js/Python validation
-└── descope-terraform/
-    ├── SKILL.md - Provider setup, common configurations, and guardrails
+├── descope-terraform/
+│   ├── SKILL.md - Provider setup, common configurations, and guardrails
+│   └── references/
+│       ├── project-resource.md - Full descope_project schema
+│       ├── other-resources.md - descope_management_key and descope_descoper schemas
+│       └── connectors.md - All 60+ supported connector types
+└── auth0-to-descope/
+    ├── SKILL.md - Migration protocol, feature mapping, and framework-specific guidance
     └── references/
-        ├── project-resource.md - Full descope_project schema
-        ├── other-resources.md - descope_management_key and descope_descoper schemas
-        └── connectors.md - All 60+ supported connector types
+        └── implementation-nuances.md - Verified migration patterns and Auth0→Descope mappings
 ```
 
 </details>

--- a/skills/auth0-to-descope/SKILL.md
+++ b/skills/auth0-to-descope/SKILL.md
@@ -1,0 +1,938 @@
+---
+name: auth0-to-descope
+description: >
+  Use this skill whenever anyone asks about migrating from Auth0 to Descope — whether they're
+  a developer doing it themselves or a technical lead evaluating the move. Triggers on: "how
+  do I migrate from Auth0", "replace Auth0 with Descope", "we're moving off Auth0", "Auth0 to
+  Descope", "switch from Auth0", "our app uses express-openid-connect / nextjs-auth0 / auth0-fastapi / other Auth0 SDK and we want to use Descope instead",
+  or any question about Auth0 features (Actions, FGA, Organizations, Token Vault, CIBA) in the
+  context of Descope. Works for any language or framework with a Descope SDK. Always use this
+  skill before producing migration guidance — do not rely on memory alone.
+---
+
+# Auth0 → Descope Migration Skill
+
+This skill guides self-service migrations from Auth0 to Descope: assessing scope,
+choosing a migration path, executing framework-specific changes, and verifying the result.
+
+**Primary reference:** `references/implementation-nuances.md` (in this skill's directory) — read the
+relevant sections before answering specific questions. It contains verified migration
+patterns for several frameworks and Auth0 feature-to-Descope mappings. For frameworks not
+covered there, use the Descope docs and SDK type declarations to apply the same principles.
+
+**Always verify current Descope capabilities** before writing migration guidance. The Descope
+Docs MCP (`search-descope-docs`, `ask-question-about-descope`) is the most reliable source
+for current API signatures, SDK methods, and feature availability — use it in preference to
+training data, which may be stale.
+
+**Before proceeding, check whether the Descope Docs MCP is available.** Try calling
+`search-descope-docs` with a simple query. If the tool is not available, tell the user:
+
+> "For the most accurate migration guidance, the Descope Docs MCP is recommended. You can
+> set it up at **https://docs-mcp.descope.com/** — it takes a few minutes and significantly
+> improves the quality of SDK lookups during migration. Would you like to set it up before
+> we continue, or proceed with static documentation?"
+
+If they choose to proceed without it, fall back to the reference links at the bottom of this
+file and the Descope SDK type declarations. Flag any SDK-specific answers as "based on last
+known documentation — verify against current SDK."
+
+---
+
+## Pre-Generation Protocol (apply before writing any code)
+
+These checks must run before generating imports, wrapper types, or helper functions for
+any framework. Skipping them produces code that compiles but fails at runtime. The examples
+below use TypeScript/Node.js, but the same principles apply to every language — check Go
+SDK godoc, Python SDK type hints, Java SDK javadoc, etc.
+
+**1. Verify SDK exports before writing any import.**
+Do not assume an export exists because the name looks plausible or analogous to the source
+framework. For TypeScript, resolve the target package's type declarations
+(`node_modules/<pkg>/dist/types/` or its `package.json` `types` field) and confirm the exact
+exported name and its signature. For Go, run `go doc`. For Python, check the SDK source or
+stubs. Reading the actual SDK takes seconds and prevents inventing non-existent exports like
+`getServerSession`.
+
+This check applies to **every SDK call you write**, not just the first import in a file.
+Field names on option objects (`sendMail` vs `sendEmail`), hook return shapes (`useDescope()`
+returns the SDK directly, not `{ sdk }`), and subpath exports (`/client` vs root) are equally
+likely to differ. When in doubt, grep the installed type declarations rather than inferring
+from the source framework's naming.
+
+**1a. After rewriting any module, grep for remaining imports of the removed package across
+the whole project.**
+Rewriting one file doesn't guarantee its sibling pages, layouts, or form files are clean.
+After each module, run:
+```bash
+grep -r "from '@/lib/auth0'\|from '@auth0/" --include="*.ts" --include="*.tsx" .
+```
+(or the equivalent for the removed package) and add any files still importing it to the
+work list before moving on.
+
+**2. Derive wrapper types from the actual return type, not the source framework's shape.**
+When writing a typed wrapper around a third-party function, read the function's declared return
+type and build the wrapper to match. Do not infer the shape from what Auth0 returned — field
+names, nesting, and flags differ. For example, `session()` from `@descope/nextjs-sdk` returns
+`AuthenticationInfo` (`{ jwt, token, cookies? }`), not an `{ isAuthenticated, claims, user }`
+object.
+
+**3. Check dependency versions before generating framework-specific code.**
+APIs change between major versions. For Next.js specifically: `cookies()` and `headers()` from
+`next/headers` are synchronous in v14 and async in v15. Read `package.json` (or `go.mod`,
+`requirements.txt`, etc.) before writing framework-specific code.
+
+**4. When making a helper async, immediately propagate to all callers.**
+In TypeScript, adding `async` to a shared utility silently breaks all call sites that don't add
+`await`. In Python, switching from sync to async has the same cascade. Before finishing any
+async conversion: grep for all call sites of the changed function and update them in the same
+pass. The cascade can span 10–20 files.
+
+**5. Verify published package versions before writing to `package.json` or running `npm install`.**
+Do not reuse the Auth0 SDK's version number as a substitute for the Descope equivalent, and do
+not rely on version numbers from training data — Descope SDK versions don't follow Auth0's
+versioning and hallucinated versions will cause install failures or install the wrong package.
+Before writing any install command or `package.json` entry, run:
+```bash
+npm view @descope/node-sdk version          # or dist-tags.latest
+npm view @descope/nextjs-sdk version
+# etc. for each package
+```
+Use the version returned. If npm is unavailable (no network), leave the version as `"latest"`
+and flag it for the user to pin after install.
+
+---
+
+## Step 0: Triage (BLOCKING — requires `AskUserQuestion`)
+
+**Use the `AskUserQuestion` tool to gather the information below. Do not infer answers
+from memory, prior conversations, or assumptions — even if you think you already know.**
+The migration path differs significantly based on these answers; getting them wrong wastes
+the user's time and produces incorrect guidance.
+
+Do not proceed to Step 0.5 until the user has answered.
+
+**First `AskUserQuestion` call (up to 4 questions):**
+
+1. **Backend language / framework** — Present the most likely options based on any cues
+   in the conversation (e.g., Express, Next.js, Flask/FastAPI, Go). The user can always
+   pick "Other."
+2. **Migration goal** — Full cut-over, incremental/phased migration, or just evaluating.
+3. **Existing user base** — Are they migrating an app with active users in Auth0, or
+   starting fresh? This determines whether user migration planning is needed (password
+   hashes, bulk import, phased vs. big-bang cutover, forced re-login on cutover).
+
+**Second `AskUserQuestion` call — Auth0 feature usage (use `multiSelect: true`):**
+
+4. **Which Auth0 features are in use?** Present the highest-impact categories:
+   - Actions / Rules / Hooks (custom login logic)
+   - Organizations (multi-tenancy / B2B)
+   - FGA / fine-grained authorization
+   - Social login / Enterprise SSO
+
+   The user can add others via "Other." Follow up on anything selected — e.g., if
+   Organizations is selected, ask about tenant-scoped SSO, SCIM, and invitations. If
+   FGA is selected, ask about the authorization model.
+
+   Also surface in a follow-up `AskUserQuestion` if not yet covered:
+   - Token Vault / Connected Accounts usage
+   - M2M / client credentials apps
+   - Custom email templates, Log Streams, Attack Protection, custom domains
+
+After both calls are answered, summarize what you learned and flag any high-complexity
+items (CIBA, Token Vault, FGA) before proceeding to Step 0.5.
+
+---
+
+## Step 0.5: Engineer Review Checkpoint (BLOCKING — requires `AskUserQuestion`)
+
+These questions surface blockers that aren't visible from the framework alone. **Use
+`AskUserQuestion` to gather answers before proceeding to Step 1.** Do not skip questions
+you think you already know the answer to — ask anyway.
+
+Batch these into `AskUserQuestion` calls (up to 4 questions per call). Prioritize the
+questions that are most relevant given what you learned in Step 0 — you don't need to
+ask all of them if some are clearly not applicable (e.g., don't ask about user migration
+planning if the user already said they're starting fresh).
+
+**Access and credentials**
+- Do they have access to the Descope Console and a Project ID? (If not, see Step 1.5.)
+- Do they need a Management Key? (Required for user CRUD, role management, ReBAC, Outbound Apps.)
+
+**Codebase scope**
+- Are there places in the app that read claims directly from the session token (e.g. `token.email`, `req.auth.permissions`)? These need a JWT Template configured before they'll work.
+- Do they have Auth0 Actions, Rules, or Hooks? Each one needs to be recreated as a Descope Flow step or JWT Template.
+- Are there multiple services or microservices validating Auth0 tokens? Each needs to be updated to validate Descope JWTs.
+
+**Deployment and risk**
+- Do they have multiple environments (dev / staging / prod)? Each needs its own Descope project and Project ID.
+- Is there a maintenance window, or does this need to be zero-downtime?
+
+**User migration** (if they indicated existing users in Step 0)
+- How many users? Under 1,000 → the migration script can pull directly from the Auth0 API. Over 1,000 → Auth0 API pagination breaks; they'll need to export a JSON file via Auth0's User Import/Export extension first.
+- Do they use passwords? If yes, they need to open a support ticket with Auth0 to get password hash exports — this takes time, plan for it. Without hashes, users will need to reset passwords or switch to passwordless.
+- Big-bang cutover or phased? For zero-disruption, Descope supports session migration (beta) — active Auth0 sessions can be exchanged for Descope tokens without re-auth, but users must already exist in Descope. For phased, the `freshlyMigrated` custom attribute (set automatically by the migration script) can be used in Flow conditionals to give first-time post-migration users a special onboarding path.
+- Are they aware that Auth0 sessions will be invalidated on cutover if not using session migration? Plan for a forced re-login or phased rollout.
+- Point them to the `descope/descope-migration` script (Step 3) and recommend a dry run (`--dry-run`) before any live run.
+
+**Gaps to flag immediately** (don't ask — flag these proactively based on Step 0 answers)
+- If they're using CIBA or `@auth0/ai` wrappers: flag before going further — these have no Descope equivalent and require custom implementation (see Step 3).
+- If they're using Auth0 Token Vault in an AI agent: the migration is Medium complexity; no SDK wrapper exists.
+- If they're using Auth0 Log Streams: set up Descope's Audit Webhook Connector before cutover to avoid gaps in event logging.
+
+Once you have answers, summarize any blockers explicitly before proceeding to Step 1.
+
+---
+
+## Step 1: Choose a Migration Path
+
+**Use `AskUserQuestion` to ask which path the user wants.** Present both options with
+their trade-offs so the user can make an informed choice. Do not pick for them.
+
+### Path A: OIDC Compatibility (lower risk, incremental)
+
+Descope exposes standard OIDC endpoints. If the app uses an OIDC client library
+(`express-openid-connect`, `go-oidc`, `authlib`, etc.), it can point at Descope's OIDC
+issuer instead of Auth0's with minimal code changes:
+
+| Endpoint | Auth0 | Descope |
+|---|---|---|
+| Issuer | `https://YOUR_DOMAIN.auth0.com` | `https://api.descope.com` |
+| Authorization | `https://YOUR_DOMAIN.auth0.com/authorize` | `https://api.descope.com/oauth2/v1/authorize` |
+| Token | `https://YOUR_DOMAIN.auth0.com/oauth/token` | `https://api.descope.com/oauth2/v1/token` |
+| UserInfo | `https://YOUR_DOMAIN.auth0.com/userinfo` | `https://api.descope.com/oauth2/v1/userinfo` |
+| JWKS | `https://YOUR_DOMAIN.auth0.com/.well-known/jwks.json` | `https://api.descope.com/__ProjectID__/.well-known/jwks.json` |
+
+**Good for:** Teams that want to swap the IdP first, then refactor to Descope-native SDKs
+later. Preserves existing OIDC client code.
+
+**Caveats to flag:** Claim shapes differ (`nickname`, `email_verified` vs `verifiedEmail`),
+token lifetimes may differ, and any Auth0 Actions logic will need to be rebuilt in
+Descope Flows regardless of which path is taken.
+
+### Path B: Full Native Migration (recommended for new projects or clean breaks)
+
+Replace Auth0 SDKs with Descope SDKs. The frontend handles authentication via the
+Descope web component or client SDK; the backend validates JWTs only. No server-side
+OAuth callback, no code exchange, no session store.
+
+**Good for:** Teams willing to refactor auth once for a cleaner long-term architecture.
+Fewer dependencies, fewer env vars, less backend plumbing.
+
+---
+
+## Step 1.5: Descope Project Setup & Console Configuration
+
+Many parts of a Descope migration require setup in the Descope Console that cannot be done
+through code or config files alone. The code will compile fine without these, but it won't
+work at runtime.
+
+**Use `AskUserQuestion` to check which of these the user has already done.** A good
+opening question: whether they already have a Descope project set up with a Project ID
+and working Flow — options: "Yes, already set up", "No, need to create one", "Not sure."
+If they already have a Project ID and a working Flow, move on — but still check items 5–7
+below via `AskUserQuestion`, since these are easy to miss even for existing projects.
+
+### 1. Create a project and get your Project ID
+- Sign in at [console.descope.com](https://console.descope.com)
+- Your **Project ID** appears in the top-left project selector and under **Project → Settings**. It starts with `P` (e.g. `P2abc123...`).
+- For Next.js client-side code, this becomes `NEXT_PUBLIC_DESCOPE_PROJECT_ID`. For all server-side SDKs, it's `DESCOPE_PROJECT_ID`.
+
+### 2. Get a Management Key (if needed)
+Required for: user management API, role/permission management, tenant operations, ReBAC
+(FGA), Outbound Apps, SCIM configuration. If the app does any server-side user or tenant
+management, they need this.
+- Console → **Company → Management Keys → Generate Key**
+- Store as `DESCOPE_MANAGEMENT_KEY`. Treat like a secret — never expose client-side.
+- Use `AskUserQuestion` to ask whether the app does any server-side user/role/admin
+  operations — if so, they need a Management Key.
+
+### 3. Choose or create a Flow
+A Flow is the authentication UI and logic sequence users go through. You reference it by
+its Flow ID in the web component.
+
+- Console → **Authentication → Flows**
+- The built-in **"sign-up-or-in"** flow handles email/password, OTP, and social login out
+  of the box. Use this for most migrations — it's the quickest path.
+- To customise: duplicate "sign-up-or-in", rename it, then edit steps in the visual builder.
+- The Flow ID is shown in the URL when editing a flow and in the flow list. Pass it as the
+  `flowId` prop to the Descope component (e.g. `flowId="sign-up-or-in"`).
+- If the Auth0 app uses MFA: the Flow needs an MFA step added. MFA enrollment in Descope
+  is managed through Flows, not the Management SDK — there's no equivalent to Auth0
+  Guardian enrollment tickets. Use `AskUserQuestion` to ask whether the app has a
+  self-service MFA settings page — if so, plan how to handle it with Descope Flows or
+  the UserProfile widget.
+
+### 4. Configure authentication methods
+- Console → **Authentication** → select methods (Email OTP, Magic Link, Social, SSO, etc.)
+- For social providers (Google, GitHub, etc.): configure OAuth credentials here, then add
+  the provider step to your Flow. The web component renders configured providers automatically.
+- For enterprise SSO (SAML/OIDC): Console → **SSO** → configure per tenant.
+
+### 5. Configure a JWT Template (almost always needed)
+Auth0 includes `email`, `name`, and `picture` in tokens by default. Descope does not.
+- Console → **Authorization → JWT Templates → New Template**
+- Add claims: `{"email": "{{user.email}}", "name": "{{user.name}}", "picture": "{{user.picture}}"}`
+- Apply the template to your project. Without this step, any code reading `token.email`
+  will get `undefined` after migration.
+- Use `AskUserQuestion` to ask whether the app displays user name, email, or avatar
+  anywhere — if so, a JWT Template must be configured before those will work.
+
+### 6. Create roles in the Console (if using RBAC)
+Descope roles are referenced by **name**, not by ID. If the app expects roles like `admin`
+and `member` to exist, they must be created manually in the Console before the code that
+assigns them will work. Unlike Auth0 where role IDs come from env vars, Descope role names
+are hardcoded strings — `addTenantRoles()` will fail if the role doesn't exist.
+- Console → **Authorization → RBAC → + Role**
+- Create each role the app references (e.g. `admin`, `member`)
+- Use `AskUserQuestion` to ask what roles the app uses — they must be created in the
+  Descope Console under Authorization → RBAC before role assignment code will work.
+
+### 7. Define custom attributes (if using tenant/user metadata)
+If the Auth0 app stores data in Organization `metadata` or User `app_metadata`, the Descope
+equivalent is `customAttributes` on tenants or users. These attributes must be pre-defined
+in the Console schema before they can be set via the SDK.
+- Console → **Project → Custom Attributes**
+- Use `AskUserQuestion` to ask whether the app stores custom data on organizations or
+  users (verification tokens, feature flags, plan info, etc.) — these need to be declared
+  as custom attributes in the Console before they can be set via the SDK.
+
+### 8. Env var summary
+| Variable | Where to get it | Used by |
+|---|---|---|
+| `DESCOPE_PROJECT_ID` | Console → Project Settings | All server-side SDKs |
+| `NEXT_PUBLIC_DESCOPE_PROJECT_ID` | Same value as above | Next.js `AuthProvider` (client-side) |
+| `DESCOPE_MANAGEMENT_KEY` | Console → Company → Management Keys | Management SDK, Outbound Apps API |
+
+---
+
+## Step 2: Framework-Specific Migration
+
+Read the relevant section of `references/implementation-nuances.md` before answering framework-specific
+questions. The notes contain tested, verified patterns for each of these.
+
+### Express.js
+- Remove `express-openid-connect`; add `@descope/node-sdk` + `cookie-parser`
+- Replace `app.use(auth(config))` with ~20-line custom middleware reading the `DS` cookie
+  and calling `descopeClient.validateSession()`
+- Add `/login` route rendering `<descope-wc>` web component (EJS, plain HTML, etc.)
+- Logout: POST to `descopeClient.logout(refreshToken)` + clear `DS`/`DSR` cookies
+
+**Key gotchas:**
+- `express-openid-connect` handled CSRF and cookie parsing internally. You need
+  `cookie-parser` explicitly.
+- `req.oidc.user` → `req.user` (set from validated JWT claims after `validateSession()`)
+- `requiresAuth()` is 3 lines of custom code, not an SDK import.
+
+### Flask / Python
+- Remove `authlib`; add `descope` Python SDK
+- Remove `/callback` route entirely — no code exchange needed
+- `/login` renders the Descope web component instead of calling `authorize_redirect()`
+- Logout: `descope_client.logout(refresh_token)` + delete cookies
+- Drop Flask `session`; state lives in `DS`/`DSR` cookies
+
+**Key gotchas:**
+- `authlib` stored `access_token`, `id_token`, `userinfo` in Flask server-side session.
+  Descope doesn't use Flask sessions. Drop `APP_SECRET_KEY` and `session` imports.
+- `validate_session()` returns a dict of JWT claims. Profile fields aren't there by
+  default — configure a JWT Template first (see Step 3 below).
+
+### Next.js
+- `@auth0/nextjs-auth0` → `@descope/nextjs-sdk` + `@descope/node-sdk`
+- `UserProvider` → `AuthProvider` (takes `projectId` prop; must use `NEXT_PUBLIC_` prefix)
+- `useUser()` → `useSession()` + `useUser()` (Descope separates session state from user data)
+- Remove `pages/api/auth/[...auth0].tsx` catch-all — no server-side OIDC handling
+- Add `/login` page with `<Descope>` component rendering `sign-up-or-in` flow
+- `withPageAuthRequired` → manual `useSession()` check + redirect
+- `withApiAuthRequired` → call `session()` at handler top, return 401 manually
+- Logout: `sdk.logout()` via `useDescope()` hook (not a link to `/api/auth/logout`)
+
+**Server-side session — exact SDK API (verify before generating):**
+
+The `@descope/nextjs-sdk/server` entry exports exactly:
+- `session(config?)` — reads session from request headers/cookies in a server component or server action. No `req` argument. Returns `Promise<AuthenticationInfo | undefined>`.
+- `getSession(req, config?)` — reads from an explicit `NextApiRequest`. API routes only.
+- `authMiddleware(options)` — Next.js middleware factory.
+
+`getServerSession` **does not exist**. The name looks plausible but isn't exported. Before writing any import, open `node_modules/@descope/nextjs-sdk/dist/types/server/index.d.ts` and confirm the export list.
+
+**Session return type — `AuthenticationInfo`, not an Auth0-style session object:**
+
+`session()` returns `AuthenticationInfo | undefined` from `@descope/node-sdk`:
+```ts
+interface AuthenticationInfo {
+  jwt: string    // raw session JWT
+  token: Token   // decoded claims: { sub?, exp?, iss?, [claim: string]: unknown }
+  cookies?: string[]
+}
+```
+There is no `isAuthenticated`, no `claims` field, and no `user` wrapper. Do not generate a wrapper type that adds these — write an adapter function instead:
+```ts
+import { session as sdkSession } from "@descope/nextjs-sdk/server"
+
+export async function getDescopeSession() {
+  const authInfo = await sdkSession()
+  if (!authInfo) return null
+  return { isAuthenticated: true as const, jwt: authInfo.jwt, token: authInfo.token }
+}
+```
+Then generate all server components using `getDescopeSession()` from this local file, not from the SDK directly.
+
+**For apps with a separate API server (Express):**
+- Remove `express-jwt` + `jwks-rsa`; replace with `descopeClient.validateSession()`
+- Forward the `DS` cookie as `Authorization: Bearer <DS>` from Next.js to the API
+- No separate access token — the session token is the bearer token
+
+### FastAPI / Python
+- Remove `auth0-fastapi` (AuthConfig, auto-mounted `/api/auth/*` routes, require_session)
+- Add custom `TokenVerifier` class: reads `Authorization` header, validates against
+  Descope JWKS, attaches claims as FastAPI `Security()` dependency
+- No auto-mounted routes; no session store
+
+### Go
+- Remove `go-oidc` + `golang.org/x/oauth2`; add `descope/go-sdk`
+- Remove login/callback/logout backend endpoints (~150 lines) — only keep token validation
+- Session validation: `descopeClient.Auth.ValidateSessionWithToken(ctx, token)` returns
+  `(bool, *descope.Token, error)`. `Token.Claims` is `map[string]interface{}`
+- `sub` claim maps directly to your auth handler's user ID (same claim name as Auth0, different issuer)
+- Auth config: ClientID + ClientSecret + Domain + RedirectURL → ProjectID only
+
+---
+
+## Step 2.5: Non-Code File Updates
+
+Code changes alone don't make a migrated app usable. After updating source files, scan
+for and update all non-code files that contain Auth0 references. These are the ones most
+likely to be stale and cause confusion for the next person running the app.
+
+**What to update — in order of priority:**
+
+### `.env.example` / `.env.template` / `.env.sample`
+These are the first place a new developer looks. Replace Auth0 variables with Descope equivalents:
+```
+# REMOVE
+AUTH0_CLIENT_ID=
+AUTH0_CLIENT_SECRET=
+AUTH0_ISSUER_BASE_URL=
+AUTH0_AUDIENCE=
+AUTH0_BASE_URL=
+SECRET=
+
+# ADD
+DESCOPE_PROJECT_ID=            # Console → Project Settings
+NEXT_PUBLIC_DESCOPE_PROJECT_ID= # Next.js only — same value as above
+DESCOPE_MANAGEMENT_KEY=        # Console → Company → Management Keys (only if using management SDK)
+```
+Use `grep -r "AUTH0"` (or `grep -r "auth0"`) to find all env var references across the project,
+including `.env.example`, Docker configs, CI files, and any shell scripts.
+
+### README / docs
+Search for Auth0 references in all `.md` files. At minimum, update:
+- **Setup section** — replace "create an Auth0 app" instructions with Descope Console setup steps
+  (create project, get Project ID, configure a Flow, set up JWT Template)
+- **Environment variables section** — reflect the reduced env var set
+- **Run instructions** — if the README includes steps like "configure Auth0 tenant," replace them
+  with the equivalent Descope Console steps
+- **Auth flow diagrams or descriptions** — if the README describes the OIDC callback flow or
+  session handling, update to reflect Descope's cookie-based approach
+
+### Docker / CI files
+Check `Dockerfile`, `docker-compose.yml`, `.github/workflows/`, and any CI config for
+`AUTH0_*` env var declarations. Update them to `DESCOPE_*`. Missing these means the app
+will boot with empty auth config in CI and production even if local dev works.
+
+### `AskUserQuestion` before editing docs
+Before rewriting setup docs, ask: "Does this project have a README or other documentation
+with Auth0-specific setup instructions?" If yes, read those files first and update them
+in-place rather than rewriting from scratch — preserves project-specific context and keeps
+the diff minimal.
+
+---
+
+## Step 3: Feature Migration Mapping
+
+### Auth0 Actions / Rules → Descope Flows + JWT Templates
+
+| Auth0 pattern | Descope equivalent |
+|---|---|
+| Custom claims in tokens | [JWT Templates](https://docs.descope.com/management/jwt-templates) (static/dynamic claims) |
+| Custom logic during auth | [Descope Flows](https://docs.descope.com/flows) — visual pipeline with conditional branching |
+| Post-login webhooks | Flows → [Connectors](https://docs.descope.com/customize/connectors) (HTTP calls to external endpoints) |
+| Role assignment at login | Flow actions → RBAC role assignment steps |
+
+Auth0 Actions are imperative Node.js. Descope Flows are declarative and visual, with
+custom JS escape hatches. Business logic must be restructured around the visual pipeline.
+
+### Social Login → Descope Social Auth
+- Configure providers in the Descope Console under Authentication → Social
+- Add them to a Flow (no code changes)
+- The Descope web component renders configured providers automatically
+
+### RBAC: Auth0 Roles/Permissions → Descope RBAC
+Auth0 embeds roles via Actions; Descope embeds them in the JWT by default (no action needed).
+
+| Auth0 | Descope |
+|---|---|
+| `req.auth.permissions.includes('read:messages')` | `token.permissions.includes('read:messages')` (same pattern, different source) |
+| Role claim via namespace in Actions | `roles` array in JWT (built-in) |
+| M2M token for Management API | `DESCOPE_MANAGEMENT_KEY` for management SDK |
+
+SDK: `descopeClient.management.role.create(name, description, permissionNames, tenantId)`
+
+### Multi-Tenancy: Auth0 Organizations → Descope Tenants
+- Auth0 `org_id` (flat string) → Descope `tenants` (nested object: `{ tenantId: { roles, permissions } }`)
+- Auth0 org-scoped login → Descope routes by email domain or tenant-specific URLs
+- Tenant-level SSO enforcement available in Descope (SAML/OIDC required for all tenant users)
+- Users are project-level in Descope; associated with tenants, not created per-tenant
+
+### Auth0 FGA (OpenFGA) → Descope ReBAC
+
+Schema translation example:
+```
+# Auth0/OpenFGA
+type doc
+  relations
+    define owner: [user]
+    define viewer: [user, user:*]
+    define can_view: owner or viewer
+
+# Descope ReBAC DSL
+type doc
+  relation owner: user
+  relation viewer: user
+  permission can_view: owner or viewer
+```
+
+API shape differences:
+- OpenFGA: `{ user, relation, object }` tuples (e.g., `user:alice`, `owner`, `doc:123`)
+- Descope: `{ target, targetType, relation, resource, resourceType }` — explicit typed fields
+
+| Operation | Auth0 FGA | Descope ReBAC |
+|---|---|---|
+| Write relation | `fgaClient.write({ writes: [...] })` | `descopeClient.management.fga.createRelations([...])` |
+| Check | `fgaClient.check({ user, relation, object })` | `descopeClient.management.fga.check([...])` |
+| List objects | `fgaClient.listObjects(...)` | `descopeClient.management.authz.whatCanTargetAccessWithRelation(...)` |
+
+Note: `FGARetriever` from `@auth0/ai-langchain` has no Descope equivalent. Build a custom
+retriever that calls `descopeClient.management.fga.check()` per candidate document.
+
+### Token Vault / Connected Accounts → Descope Outbound Apps
+
+Users connect accounts via `sdk.outbound.connect(appId, { redirectURL, scopes })` on the client.
+
+Fetch stored tokens server-side:
+```
+POST https://api.descope.com/v1/mgmt/outbound/app/user/token
+Authorization: Bearer {projectId}:{managementKey}
+Body: { "appId": "google-calendar", "userId": "U2abc...", "scopes": [...] }
+```
+
+No AI-framework wrapper exists (`withTokenVault()` from `@auth0/ai` has no equivalent).
+Build a custom tool wrapper that calls the Outbound Apps API directly.
+
+### CIBA / Async Authorization → Custom Implementation Required
+
+Descope has **no CIBA equivalent**. `withAsyncAuthorization()` from `@auth0/ai` requires
+a custom replacement. Recommended approach:
+1. Agent creates a pending approval record in your database
+2. Frontend polls for it (or uses WebSocket)
+3. User approves via Descope Flow or custom UI
+4. Agent receives approval signal and continues
+
+Flag this explicitly — it's the highest-complexity migration item.
+
+### M2M / Client Credentials → Descope Access Keys
+Auth0 M2M apps use the client credentials grant. Descope's equivalent is
+[Access Keys](https://docs.descope.com/management/m2m-access-keys) — create one in
+Console → Access Keys, exchange it for a JWT via `descopeClient.auth.exchangeAccessKey()`,
+and validate the resulting token the same way as user tokens. Access keys support tenant
+and role scoping, IP restrictions, and configurable expiration.
+
+### User Migration → Descope Migration Script
+
+Descope provides a Python CLI tool — [`descope/descope-migration`](https://github.com/descope/descope-migration) — that handles bulk import of users, roles, permissions, and Auth0 organizations (→ Descope tenants) in one run.
+
+**Two import modes (based on user count):**
+- **Auth0 API** — use when fewer than 1,000 users (Auth0 API pagination limit)
+- **JSON export** — use when 1,000+ users; export via Auth0's User Import/Export extension, then pass the file to the script with `--from-json`
+
+**Setup:**
+```bash
+git clone git@github.com:descope/descope-migration.git
+cd descope-migration
+python3 -m venv venv && source venv/bin/activate
+pip3 install -r requirements.txt
+cp .env.example .env  # populate with values below
+```
+
+Required `.env` variables:
+| Variable | Where to get it |
+|---|---|
+| `AUTH0_TOKEN` | Auth0 Management API → [token explorer](https://manage.auth0.com/#/apis/management/explorer) (24h token) |
+| `AUTH0_TENANT_ID` | Your Auth0 dashboard URL, e.g. `dev-xyz` from `manage.auth0.com/dashboard/us/dev-xyz/` |
+| `DESCOPE_PROJECT_ID` | Descope Console → Project Settings |
+| `DESCOPE_MANAGEMENT_KEY` | Descope Console → Company → Management Keys |
+
+**Always dry-run first:**
+```bash
+# Via Auth0 API (< 1,000 users), without passwords
+python3 src/main.py auth0 --dry-run
+
+# Via JSON export, with passwords
+python3 src/main.py auth0 --dry-run --from-json ./export.json --with-passwords ./password_hashes.json
+```
+
+Add `-v` / `--verbose` for detailed output. The dry run shows exactly what would be migrated: users, roles, permissions, organizations/tenants — without touching anything.
+
+**Password migration:** optional. Requires opening a support ticket with Auth0 to get a password hash export file, then passing it via `--with-passwords`. Without it, users will need to reset passwords or use passwordless methods after migration.
+
+**What gets migrated:** users, roles, permissions, Auth0 organizations → Descope tenants.
+
+**Auto-created custom attributes:** the script creates two custom attributes in Descope automatically:
+- `connection` (text) — the Auth0 connection type for each user
+- `freshlyMigrated` (boolean) — set to `true` on import; use this in Flow conditionals to give newly migrated users a special first-login experience (e.g., prompt to verify email, set a password, or enroll in MFA), then flip it to `false` once done
+
+**Live run (after dry-run passes):**
+```bash
+python3 src/main.py auth0 --from-json ./export.json --with-passwords ./password_hashes.json
+```
+
+A log file is generated at `migration_log_auth0_<timestamp>.log`. Any failed items are listed with their error.
+
+**Session migration (beta):** for zero-disruption cutovers, Descope also supports [session migration](https://docs.descope.com/migrate/session-migration) — users with active Auth0 sessions can exchange their existing token for a Descope token without re-authenticating. Requires users to already exist in Descope (import first), and is currently in beta with no JIT user creation support.
+
+**Hybrid migration:** if a full cut-over isn't possible immediately, Descope can be configured as a federated IdP inside Auth0 — users authenticate via Descope Flows while Auth0 remains in place. Requires completing the import step first, then following the [Descope-as-IdP-for-Auth0 guide](https://docs.descope.com/identity-federation/applications/setup-guides/auth0).
+
+For phased migrations without the script, the [Batch Create User API](https://docs.descope.com/api/management/users/batch-create-users) also supports bcrypt hash import directly.
+
+### Email Templates → Descope Messaging Templates
+Auth0 email templates (verification, password reset, invitation) map to Descope
+[Messaging Templates](https://docs.descope.com/management/messaging-templates), configured
+per authentication method in the Console. Templates support HTML and dynamic content.
+
+### Log Streams → Descope Audit Webhook
+Auth0 Log Streams map to Descope's
+[Audit Webhook Connector](https://docs.descope.com/connectors/connector-configuration-guides/network/audit-webhook).
+Configure it in Console → Connectors to stream auth events to your own HTTP endpoint. Set
+this up before cutover to avoid gaps in event logging.
+
+### Custom Domains
+Auth0 custom domains map to Descope
+[custom domains](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
+CNAME `auth.example.com` → `cname.descope.com`, verify in Console, then pass `baseUrl` to
+the Descope SDK. Plan this before cutover.
+
+### Attack Protection → Descope Flow Security
+Auth0 Attack Protection (bot detection, brute force, breached passwords) maps to Descope
+Flow steps using security connectors: Arkose Bot Manager, Google reCAPTCHA, Fingerprint,
+Have I Been Pwned, AbuseIPDB. These are composable (add detection steps to Flows) rather
+than toggle-based. Not configured by default — flag this if the Auth0 app relies on Attack
+Protection.
+
+---
+
+## Step 4: Critical Gotchas (Always Cover These)
+
+These are the most common migration mistakes. Surface them proactively.
+
+### JWT Claims Are Not the Same
+Descope session JWTs contain `sub`, `amr`, `drn`, `tenants`, `roles`, `permissions` by
+default. They do **not** contain `email`, `name`, or `picture`. Auth0 ID tokens include
+these by default.
+
+**Action required:** Configure a JWT Template in the Descope Console to add `email`,
+`name`, and any other profile fields the app reads from the token. Without this, code
+reading `token.email` or `token.name` will get `undefined`.
+
+### Audience Validation Is Opt-In
+Descope session tokens have no `aud` claim by default. Apps using `AUTH0_AUDIENCE` for
+API access control must:
+1. Configure a custom `aud` claim in JWT Templates
+2. Pass `audience` to `validateSession()` on the backend
+
+Easy to miss; without it, any valid Descope token passes backend validation.
+
+### Logout Is Two Steps
+1. Call `descopeClient.logout(refreshToken)` to invalidate server-side
+2. Clear `DS` and `DSR` cookies
+
+Skipping either step leaves a broken state. Both are required.
+
+### Cookie Names Are Configurable (And May Conflict)
+Default: `DS` (session JWT), `DSR` (refresh JWT). Configure custom names in the Descope
+Console under the Flow's End action when running multiple Descope projects on the same
+root domain.
+
+### One Token, Not Two
+Auth0 issues separate ID tokens and access tokens (scoped to `audience`). Descope has
+one token: the session JWT (`DS` cookie). Forward it as `Authorization: Bearer <DS>` to
+API servers. No separate token endpoint.
+
+### No Drop-In Middleware
+Descope has no `express-openid-connect` equivalent package. The middleware is ~20 lines
+of custom code. This is a feature (simpler, no hidden behavior) but users expecting
+a drop-in replacement need to know upfront.
+
+### `cookies()` and `headers()` Are Async in Next.js 15
+`cookies()` and `headers()` from `next/headers` return a `Promise` in Next.js 15+. Code
+generated against Next.js 14 assumptions (synchronous `cookies()`) will compile but throw
+at runtime. Before generating any server-side helper that reads cookies:
+
+1. Check the project's `package.json` for the Next.js version.
+2. If ≥ 15: write `await cookies()` and mark the containing function `async`.
+3. Trace upward — making a cookie-reading helper async cascades to every caller.
+   A single `getActiveTenantId` becoming async can require `await` additions across
+   10–20 files. Plan for this before starting edits.
+
+### Async Cascade: Trace All Callers Before Finishing
+When a shared utility (e.g., `getActiveTenantId`, `getRole`) becomes async, TypeScript
+accepts `await` on non-Promises without error — so callers that forget `await` silently
+return a Promise object instead of the resolved value. Always grep for all call sites of
+any utility you make async and update them in the same pass.
+
+### Env Var Reduction
+Auth0: `CLIENT_ID`, `CLIENT_SECRET`, `ISSUER_BASE_URL`, `SECRET`, `AUTH0_AUDIENCE` (5+).
+Descope: `DESCOPE_PROJECT_ID` only (+ `DESCOPE_MANAGEMENT_KEY` for management ops). No
+client secret for frontend flows.
+
+---
+
+## Step 5: Automated Testing
+
+Do not hand the user a checklist and stop. Run the app and verify it actually works.
+A migration where "the code compiles" is not done — a migration where "the app starts,
+serves the login page, and protects routes correctly" is done.
+
+Work through the phases below in order. Stop and surface any failure immediately rather
+than continuing past a broken state.
+
+### Phase 1: Install, compile, and start
+
+```bash
+# Install dependencies (use whatever package manager the project uses)
+npm install   # or: pip install -r requirements.txt / go mod tidy
+```
+
+**Run the compile check immediately after making code changes — before setting up `.env` or
+starting the server.** Compilation does not require env vars to be populated. This catches
+stale Auth0 imports, wrong return-type destructuring, and async cascade gaps before they become
+runtime surprises. It takes seconds and saves far more.
+
+```bash
+# TypeScript
+npx tsc --noEmit
+
+# Go
+go build ./...
+
+# Java / Kotlin (Maven)
+mvn compile -q
+
+# Java / Kotlin (Gradle)
+./gradlew compileJava compileKotlin
+
+# .NET / C#
+dotnet build
+```
+
+**Do not report the migration as complete, and do not move to Step 6, until this exits with
+zero errors.** A passing compile is the minimum bar — it catches stale imports, wrong
+return-type destructuring, and async cascade gaps that code review misses.
+
+Compilation errors at this stage typically mean:
+- An Auth0 import was removed from the package but is still referenced in code
+- A type that was wrapped around an Auth0 shape no longer exists
+- An async cascade wasn't fully propagated (TypeScript: `Promise<X>` where `X` was expected)
+
+Fix all compile errors before starting the server. A server that starts despite type errors
+(e.g., `ts-node` with loose settings) can hide bugs that will surface in production.
+
+```bash
+# Start the development server
+npm run dev   # or: python main.py / go run . / flask run / etc.
+```
+
+Watch startup output for:
+- Missing env var errors (most common first-run failure — means `.env` wasn't populated)
+- Module not found / import errors (means an Auth0 package is still referenced somewhere)
+- Port conflicts or config errors
+
+If the server fails to start, fix it before proceeding. Do not move to Phase 2.
+
+### Phase 2: Run existing tests
+
+If the project has a test suite, run it now:
+```bash
+npm test          # or: pytest / go test ./... / etc.
+```
+
+Auth-related test failures at this point usually mean:
+- A mock or fixture still uses Auth0 token shapes or env vars
+- A test directly imports an Auth0 SDK function that was removed
+- A test validates JWT claims that are now missing (e.g., `email` without a JWT Template)
+
+Fix failing tests before proceeding. If there are no existing tests, note this and continue.
+
+### Phase 3: Smoke test the running app
+
+With the server running, verify the core auth paths using `curl` or the browser automation
+tools available to you. At minimum, check:
+
+**Unauthenticated access (should redirect or 401):**
+```bash
+# For a web app — expect redirect to /login
+curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/dashboard
+
+# For an API — expect 401
+curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/api/protected
+```
+
+**Login page loads:**
+```bash
+curl -s http://localhost:<port>/login | grep -i "descope"
+# Should find the Descope web component or SDK reference
+# If it returns Auth0 references, something was missed in Step 2
+```
+
+**Protected routes without a session return 401 or redirect:**
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/protected-route
+# Expect: 302 (redirect to login) or 401
+```
+
+**Session validation endpoint (if one exists):**
+```bash
+# Pass a deliberately invalid token — expect 401
+curl -s -H "Cookie: DS=invalid_token" http://localhost:<port>/api/me
+```
+
+### Phase 4: Verify JWT claims (if JWT Template is configured)
+
+If the user confirmed a JWT Template was set up in the Console, verify claims are present.
+Obtain a valid `DS` cookie via the login flow (have the user log in and copy the cookie
+from DevTools, or use a test credential if available), then:
+
+```bash
+# Decode the JWT payload (no verification needed for claim inspection)
+echo "<DS_cookie_value>" | cut -d'.' -f2 | base64 -d 2>/dev/null | python3 -m json.tool
+```
+
+Check that `email`, `name`, and any other expected claims are present. If they're missing,
+the JWT Template wasn't applied — flag this explicitly.
+
+### Phase 5: Report results
+
+After running the phases above, produce a brief test summary:
+
+```
+## Test Results
+
+**Server startup:** ✅ Started successfully on port 3000
+**Existing tests:** ✅ 12 passed / ❌ 2 failed (list failures)
+**Unauthenticated /dashboard:** ✅ 302 → /login
+**Unauthenticated /api/protected:** ✅ 401
+**Login page loads Descope component:** ✅
+**JWT claims (email, name):** ✅ Present / ❌ Missing — JWT Template not yet configured
+
+**Blockers before going live:**
+- [ ] (list anything that failed or needs manual action)
+```
+
+If something can't be tested automatically (e.g., completing a full login flow requires
+a real browser and test credentials), say so explicitly and tell the user exactly what
+to do and what to look for. Do not silently skip it.
+
+---
+
+## Step 6: Post-Migration Summary (Required)
+
+Every migration must produce a `MIGRATION-SUMMARY.md` at the end. This captures what was
+done, what still needs manual setup, and what behavioral differences the user should
+be aware of before going to production. A migration isn't done when the code compiles —
+it's done when the user knows exactly what they need to set up, verify, and watch out
+for.
+
+### MIGRATION-SUMMARY.md
+
+Include the following sections:
+
+1. **What was migrated** — a table mapping each Auth0 concept to its Descope replacement
+   (SDK, session handling, middleware, login UI, organizations, roles, SSO, SCIM, MFA,
+   user management, invitations, env vars, etc.). Only include rows relevant to this
+   specific migration.
+
+2. **Behavioral differences and open questions** — a numbered list of the significant
+   differences between the Auth0 and Descope implementations that the user should
+   understand. For each item, briefly describe the Auth0 behavior, the Descope behavior,
+   and any action required or question to verify. Focus on things that could cause
+   confusion or bugs: features with no SDK equivalent (e.g. MFA enrollment tickets, SCIM
+   management), model differences (e.g. invitation objects vs. invited-status users,
+   org-scoped login vs. multi-tenant JWTs), session/token refresh gaps (e.g. stale JWTs
+   after tenant creation requiring re-login), and anything where the code compiles but
+   won't work without Console configuration.
+
+3. **Pre-deploy checklist** — actionable checkbox items for everything that must happen
+   before the migrated app can run. This should prominently include all Console setup
+   tasks: creating the project, generating a Management Key, configuring a JWT Template,
+   creating roles, defining custom attributes, setting up Flows, etc. These are the
+   things easiest to forget because the code compiles without them.
+
+---
+
+## Step 7: Output Format
+
+Write a clear, numbered migration guide in Markdown, scoped to the user's specific
+stack. Prefer concrete code snippets and direct doc links over general descriptions.
+Always include the MIGRATION-SUMMARY.md deliverable (Step 6).
+
+For complex migrations (FGA, CIBA, AI tooling), flag the high-effort items explicitly
+with estimated complexity (Low/Medium/High) so the user can plan. Reference the
+migration difficulty table in `references/implementation-nuances.md` for the agentic AI scenario
+(LangChain/LangGraph + FGA + Token Vault + CIBA).
+
+---
+
+## Reference Files
+
+- `references/implementation-nuances.md` — Verified migration patterns, code-level diffs, and edge
+  cases for several frameworks. Use as a reference for the principles and patterns; apply
+  them to any language or framework the user is using.
+- Descope Docs: https://docs.descope.com
+- Auth0 Migration Guide: https://docs.descope.com/migrate/auth0
+- User Import (Custom): https://docs.descope.com/migrate/custom
+- Descope OIDC Endpoints: https://docs.descope.com/getting-started/oidc-endpoints
+- Descope Flows: https://docs.descope.com/flows
+- JWT Templates: https://docs.descope.com/management/jwt-templates
+- Access Keys (M2M): https://docs.descope.com/management/m2m-access-keys
+- Messaging Templates: https://docs.descope.com/management/messaging-templates
+- Audit Webhook: https://docs.descope.com/connectors/connector-configuration-guides/network/audit-webhook
+- Custom Domains: https://docs.descope.com/how-to-deploy-to-production/custom-domain
+- ReBAC: https://docs.descope.com/authorization/rebac
+- Outbound Apps: https://docs.descope.com/identity-federation/outbound-apps
+
+### Session Validation by Language
+- Node.js: https://docs.descope.com/getting-started/nodejs#implement-session-validation
+- Python: https://docs.descope.com/getting-started/python#implement-session-validation
+- Go: https://docs.descope.com/getting-started/golang#implement-session-validation
+- Ruby: https://docs.descope.com/getting-started/ruby#implement-session-validation
+- Java / Kotlin: https://docs.descope.com/getting-started/java#implement-session-validation
+- .NET / C#: https://docs.descope.com/getting-started/dotnet#implement-session-validation
+- Next.js: https://docs.descope.com/getting-started/nextjs#implement-session-validation
+- React: https://docs.descope.com/getting-started/react#implement-session-validation
+- Angular: https://docs.descope.com/getting-started/angular#implement-session-validation
+- Vue: https://docs.descope.com/getting-started/vue#implement-session-validation
+- Swift / iOS: https://docs.descope.com/getting-started/swift#implement-session-validation
+- Kotlin / Android: https://docs.descope.com/getting-started/android#implement-session-validation
+- Flutter: https://docs.descope.com/getting-started/flutter#implement-session-validation
+
+### SDKs (GitHub)
+- Node SDK: https://github.com/descope/node-sdk
+- Python SDK: https://github.com/descope/python-sdk
+- Go SDK: https://github.com/descope/go-sdk
+- Ruby SDK: https://github.com/descope/descope-ruby-sdk
+- Java SDK: https://github.com/descope/descope-java
+- .NET SDK: https://github.com/descope/descope-dotnet
+- Swift SDK: https://github.com/descope/swift-sdk
+- Kotlin SDK: https://github.com/descope/descope-kotlin
+- Flutter SDK: https://github.com/descope/descope-flutter
+- JS/TS monorepo (React, Angular, Vue, Next.js, Web Component, Web JS): https://github.com/descope/descope-js

--- a/skills/auth0-to-descope/SKILL.md
+++ b/skills/auth0-to-descope/SKILL.md
@@ -706,6 +706,26 @@ serves the login page, and protects routes correctly" is done.
 Work through the phases below in order. Stop and surface any failure immediately rather
 than continuing past a broken state.
 
+### Phase 0: Final stale-import sweep (BLOCKING)
+
+Before installing or starting anything, grep the entire project for remaining Auth0 references:
+
+```bash
+# Adjust patterns to match the Auth0 packages used in this project
+grep -r "@auth0\|auth0\|express-openid-connect\|nextjs-auth0" \
+  --include="*.ts" --include="*.tsx" --include="*.js" --include="*.py" --include="*.go" \
+  --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=dist \
+  .
+```
+
+If this returns any results, **stop and fix them before proceeding**. Every hit is a guaranteed crash once the Auth0 package is removed. Common files missed in the rewrite:
+- Layout files (`layout.tsx`, `_app.tsx`) that still wrap with Auth0 Provider
+- API route files that import `withApiAuthRequired`
+- Utility/helper files not on the main auth path
+- Test files that import Auth0 fixtures or mock the Auth0 SDK
+
+Do not proceed to Phase 1 until this grep returns zero results.
+
 ### Phase 1: Install, compile, and start
 
 ```bash
@@ -739,13 +759,13 @@ dotnet build
 zero errors.** A passing compile is the minimum bar — it catches stale imports, wrong
 return-type destructuring, and async cascade gaps that code review misses.
 
-Compilation errors at this stage typically mean:
-- An Auth0 import was removed from the package but is still referenced in code
-- A type that was wrapped around an Auth0 shape no longer exists
-- An async cascade wasn't fully propagated (TypeScript: `Promise<X>` where `X` was expected)
+**If compilation fails, diagnose by error message:**
+- `Cannot find module '@auth0/...'` → stale import missed by Phase 0 grep; expand the search pattern and re-run Phase 0
+- `Property 'X' does not exist on type 'AuthenticationInfo'` → wrapper type was built against the Auth0 shape; re-derive from the actual Descope SDK return type
+- `'await' expression is not allowed in synchronous contexts` → async cascade gap; trace the caller chain and add `async`/`await` up the tree
+- `Object is possibly 'undefined'` on session fields → `session()` returns `undefined` when unauthenticated; add a null check or early return guard
 
-Fix all compile errors before starting the server. A server that starts despite type errors
-(e.g., `ts-node` with loose settings) can hide bugs that will surface in production.
+**Do not proceed to Phase 2 if compilation fails.** Type errors are deterministic runtime crashes — fix all of them before starting the server.
 
 ```bash
 # Start the development server
@@ -753,9 +773,13 @@ npm run dev   # or: python main.py / go run . / flask run / etc.
 ```
 
 Watch startup output for:
-- Missing env var errors (most common first-run failure — means `.env` wasn't populated)
-- Module not found / import errors (means an Auth0 package is still referenced somewhere)
+- Missing env var errors (most common first-run failure — means `.env` wasn't populated with `DESCOPE_PROJECT_ID`)
+- `Cannot find module` at runtime → a dynamic `require()` or non-TS import was missed by the grep
 - Port conflicts or config errors
+
+**If the server starts but immediately exits:** check for `Missing env var` in logs and populate `.env`.
+
+**If the server starts but crashes on first request:** this is almost always an unresolved `Promise` — a function was made `async` but a caller was not updated with `await`. Add a `console.log` at the suspected call site and check whether it logs `Promise { <pending> }` instead of a value.
 
 If the server fails to start, fix it before proceeding. Do not move to Phase 2.
 
@@ -777,6 +801,16 @@ Fix failing tests before proceeding. If there are no existing tests, note this a
 
 With the server running, verify the core auth paths using `curl` or the browser automation
 tools available to you. At minimum, check:
+
+**Root path renders (app is alive):**
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/
+# Expect: 200 or 302 — any 5xx means a runtime crash in a root/layout component
+```
+
+If this returns 5xx, check server logs immediately. A 500 on the root path almost always
+means a runtime import error or an async crash in a layout or middleware that wraps all routes.
+Fix before continuing.
 
 **Unauthenticated access (should redirect or 401):**
 ```bash
@@ -841,6 +875,16 @@ After running the phases above, produce a brief test summary:
 If something can't be tested automatically (e.g., completing a full login flow requires
 a real browser and test credentials), say so explicitly and tell the user exactly what
 to do and what to look for. Do not silently skip it.
+
+**Do not proceed to Step 6 until ALL of the following are true:**
+- [ ] Phase 0 grep returns zero Auth0 references
+- [ ] Phase 1 compilation passes with zero errors
+- [ ] Phase 1 server starts and stays running
+- [ ] Phase 3 root path returns 2xx or 3xx (not 5xx)
+- [ ] Phase 3 protected routes return 302 or 401 (not 500)
+
+A migration that produces a crashing app is not complete. Fix all blockers inline before
+writing the summary.
 
 ---
 

--- a/skills/auth0-to-descope/SKILL.md
+++ b/skills/auth0-to-descope/SKILL.md
@@ -12,103 +12,72 @@ description: >
 
 # Auth0 → Descope Migration Skill
 
-This skill guides self-service migrations from Auth0 to Descope: assessing scope,
-choosing a migration path, executing framework-specific changes, and verifying the result.
+This skill guides self-service migrations from Auth0 to Descope. It runs in three parts:
 
-**Primary reference:** `references/implementation-nuances.md` (in this skill's directory) — read the
-relevant sections before answering specific questions. It contains verified migration
-patterns for several frameworks and Auth0 feature-to-Descope mappings. For frameworks not
-covered there, use the Descope docs and SDK type declarations to apply the same principles.
+1. **MCP Check** — confirm whether the Descope Docs MCP is available and suggest installing it if not
+2. **Migration Plan** — gather context via triage questions, analyze the codebase's auth touchpoints, and produce a human-readable `MIGRATION-PLAN.md` for the user to review
+3. **Execution** — if the user confirms they want to proceed, execute the plan
 
-**Always verify current Descope capabilities** before writing migration guidance. The Descope
-Docs MCP (`search-descope-docs`, `ask-question-about-descope`) is the most reliable source
-for current API signatures, SDK methods, and feature availability — use it in preference to
-training data, which may be stale.
+Do not collapse these parts or skip ahead. The plan must be reviewed before code changes begin.
 
-**Before proceeding, check whether the Descope Docs MCP is available.** Try calling
-`search-descope-docs` with a simple query. If the tool is not available, tell the user:
-
-> "For the most accurate migration guidance, the Descope Docs MCP is recommended. You can
-> set it up at **https://docs-mcp.descope.com/** — it takes a few minutes and significantly
-> improves the quality of SDK lookups during migration. Would you like to set it up before
-> we continue, or proceed with static documentation?"
-
-If they choose to proceed without it, fall back to the reference links at the bottom of this
-file and the Descope SDK type declarations. Flag any SDK-specific answers as "based on last
-known documentation — verify against current SDK."
+**Primary references** (both in this skill's directory):
+- `references/implementation-nuances.md` — verified migration patterns for each framework, Auth0 feature-to-Descope mappings, and known gotchas
+- `references/flows-and-widgets.md` — Descope terminology/lingo, Flow structure and templates, Widgets, SSO Setup Suite, Console-vs-code decision guide
 
 ---
 
-## Pre-Generation Protocol (apply before writing any code)
+## Guiding Principles
 
-These checks must run before generating imports, wrapper types, or helper functions for
-any framework. Skipping them produces code that compiles but fails at runtime. The examples
-below use TypeScript/Node.js, but the same principles apply to every language — check Go
-SDK godoc, Python SDK type hints, Java SDK javadoc, etc.
+**Console-first.** Before recommending SDK code for any user-facing auth feature, check whether the Console, a Flow, or a Widget covers the use case. Engineers integrate once (SDK setup + session validation). All subsequent auth evolution — new methods, MFA changes, UI updates — should happen in the Console without code deployments. See `references/flows-and-widgets.md` → Console vs. Code.
 
-**1. Verify SDK exports before writing any import.**
-Do not assume an export exists because the name looks plausible or analogous to the source
-framework. For TypeScript, resolve the target package's type declarations
-(`node_modules/<pkg>/dist/types/` or its `package.json` `types` field) and confirm the exact
-exported name and its signature. For Go, run `go doc`. For Python, check the SDK source or
-stubs. Reading the actual SDK takes seconds and prevents inventing non-existent exports like
-`getServerSession`.
+**Ask, don't assume.** At any design decision point — embed Flows vs. OIDC compatibility, Flow vs. custom code, Widget vs. custom page, MFA inline vs. separate enrollment, programmatic SSO vs. SSO Setup Suite — use `AskUserQuestion` rather than proceeding with an assumption. The cost of a wrong assumption compounds across 20+ files. Uncertainty about architecture or intent is always worth a question.
 
-This check applies to **every SDK call you write**, not just the first import in a file.
-Field names on option objects (`sendMail` vs `sendEmail`), hook return shapes (`useDescope()`
-returns the SDK directly, not `{ sdk }`), and subpath exports (`/client` vs root) are equally
-likely to differ. When in doubt, grep the installed type declarations rather than inferring
-from the source framework's naming.
-
-**1a. After rewriting any module, grep for remaining imports of the removed package across
-the whole project.**
-Rewriting one file doesn't guarantee its sibling pages, layouts, or form files are clean.
-After each module, run:
-```bash
-grep -r "from '@/lib/auth0'\|from '@auth0/" --include="*.ts" --include="*.tsx" .
-```
-(or the equivalent for the removed package) and add any files still importing it to the
-work list before moving on.
-
-**2. Derive wrapper types from the actual return type, not the source framework's shape.**
-When writing a typed wrapper around a third-party function, read the function's declared return
-type and build the wrapper to match. Do not infer the shape from what Auth0 returned — field
-names, nesting, and flags differ. For example, `session()` from `@descope/nextjs-sdk` returns
-`AuthenticationInfo` (`{ jwt, token, cookies? }`), not an `{ isAuthenticated, claims, user }`
-object.
-
-**3. Check dependency versions before generating framework-specific code.**
-APIs change between major versions. For Next.js specifically: `cookies()` and `headers()` from
-`next/headers` are synchronous in v14 and async in v15. Read `package.json` (or `go.mod`,
-`requirements.txt`, etc.) before writing framework-specific code.
-
-**4. When making a helper async, immediately propagate to all callers.**
-In TypeScript, adding `async` to a shared utility silently breaks all call sites that don't add
-`await`. In Python, switching from sync to async has the same cascade. Before finishing any
-async conversion: grep for all call sites of the changed function and update them in the same
-pass. The cascade can span 10–20 files.
-
-**5. Verify published package versions before writing to `package.json` or running `npm install`.**
-Do not reuse the Auth0 SDK's version number as a substitute for the Descope equivalent, and do
-not rely on version numbers from training data — Descope SDK versions don't follow Auth0's
-versioning and hallucinated versions will cause install failures or install the wrong package.
-Before writing any install command or `package.json` entry, run:
-```bash
-npm view @descope/node-sdk version          # or dist-tags.latest
-npm view @descope/nextjs-sdk version
-# etc. for each package
-```
-Use the version returned. If npm is unavailable (no network), leave the version as `"latest"`
-and flag it for the user to pin after install.
+**MCP over memory.** When the Docs MCP is available (confirmed in Part 1), use `ask-question-about-descope` to verify every SDK method name, option shape, and return type before writing it. Do not fall back to "verify the exact method name in the SDK type declarations" as a hedge — just verify it directly.
 
 ---
 
-## Step 0: Triage (BLOCKING — requires `AskUserQuestion`)
+## Part 1: MCP Check (BLOCKING)
+
+Before doing anything else, check whether the Descope Docs MCP is available by calling
+`search-descope-docs` with a simple query (e.g., "session validation").
+
+**If the tool is available:** proceed to Part 2 immediately.
+
+**If the tool is not available**, show this message and use `AskUserQuestion` to ask whether
+they want to install it first:
+
+> **Descope Docs MCP is not installed.**
+>
+> This skill uses the Descope Docs MCP to look up current API signatures, SDK methods, and
+> feature availability during migration. Without it, guidance is based on static training data,
+> which may be stale and can produce SDK calls that don't exist.
+>
+> You can install it in a few minutes at **https://docs-mcp.descope.com/** (server URL:
+> `https://docs-mcp.descope.com/mcp`). It significantly improves the accuracy of the
+> migration output — especially for SDK lookups and flow-specific configuration.
+>
+> **Would you like to install the MCP before we continue, or proceed without it?**
+
+- If they choose to install: pause and wait. Once they confirm it's installed, re-check by calling `search-descope-docs` again before proceeding.
+- If they choose to proceed without it: continue, but flag any SDK-specific answers as "based on last known documentation — verify against the current SDK."
+
+Do not proceed to Part 2 until this step is resolved.
+
+---
+
+## Part 2: Migration Plan
+
+Part 2 has two sub-steps:
+
+1. **Triage** — ask the questions needed to understand scope (migration questions go here since answers shape the plan)
+2. **Codebase Analysis + Plan File** — scan the project, produce `MIGRATION-PLAN.md`, and pause for review
+
+### Step 0: Triage (BLOCKING — requires `AskUserQuestion`)
 
 **Use the `AskUserQuestion` tool to gather the information below. Do not infer answers
-from memory, prior conversations, or assumptions — even if you think you already know.**
-The migration path differs significantly based on these answers; getting them wrong wastes
-the user's time and produces incorrect guidance.
+from memory, prior conversations, or assumptions — even if you think you know.**
+The migration path differs based on these answers; getting them wrong wastes the user's
+time and produces incorrect guidance.
 
 Do not proceed to Step 0.5 until the user has answered.
 
@@ -121,6 +90,7 @@ Do not proceed to Step 0.5 until the user has answered.
 3. **Existing user base** — Are they migrating an app with active users in Auth0, or
    starting fresh? This determines whether user migration planning is needed (password
    hashes, bulk import, phased vs. big-bang cutover, forced re-login on cutover).
+4. **Preferred migration style** — Do they want to embed Descope Flows/Widgets directly (full native migration), or preserve their existing OIDC client library and point it at Descope's OIDC endpoints (OIDC compatibility layer)? Note: B2B features (Organizations/SSO/SCIM management) have no OIDC-layer equivalent and require native SDK calls regardless of path.
 
 **Second `AskUserQuestion` call — Auth0 feature usage (use `multiSelect: true`):**
 
@@ -139,21 +109,18 @@ Do not proceed to Step 0.5 until the user has answered.
    - M2M / client credentials apps
    - Custom email templates, Log Streams, Attack Protection, custom domains
 
-After both calls are answered, summarize what you learned and flag any high-complexity
-items (CIBA, Token Vault, FGA) before proceeding to Step 0.5.
+After both calls, summarize findings and flag high-complexity items (CIBA, Token Vault, FGA)
+before proceeding to Step 0.5.
 
 ---
 
-## Step 0.5: Engineer Review Checkpoint (BLOCKING — requires `AskUserQuestion`)
+### Step 0.5: Engineer Review Checkpoint (BLOCKING — requires `AskUserQuestion`)
 
-These questions surface blockers that aren't visible from the framework alone. **Use
-`AskUserQuestion` to gather answers before proceeding to Step 1.** Do not skip questions
-you think you already know the answer to — ask anyway.
+These questions surface blockers the framework doesn't expose. Ask even the ones you think
+you know. Use `AskUserQuestion` before proceeding to codebase analysis.
 
-Batch these into `AskUserQuestion` calls (up to 4 questions per call). Prioritize the
-questions that are most relevant given what you learned in Step 0 — you don't need to
-ask all of them if some are clearly not applicable (e.g., don't ask about user migration
-planning if the user already said they're starting fresh).
+Batch into calls of up to 4 questions. Skip questions that are clearly inapplicable given
+Step 0 answers (e.g., skip user migration planning if they said they're starting fresh).
 
 **Access and credentials**
 - Do they have access to the Descope Console and a Project ID? (If not, see Step 1.5.)
@@ -180,58 +147,453 @@ planning if the user already said they're starting fresh).
 - If they're using Auth0 Token Vault in an AI agent: the migration is Medium complexity; no SDK wrapper exists.
 - If they're using Auth0 Log Streams: set up Descope's Audit Webhook Connector before cutover to avoid gaps in event logging.
 
-Once you have answers, summarize any blockers explicitly before proceeding to Step 1.
+**Console/Flow/Widget opportunities** (flag before codebase analysis, then ask):
+- If the app has a custom SSO settings page: ask whether the SSO Setup Suite + Tenant Profile Widget replaces that code.
+- If the app has a profile edit page or user management UI: ask whether a Descope Widget covers the use case.
+- If the app has a separate MFA enrollment page: ask whether MFA should be integrated into the main sign-in Flow as a step or subflow instead (almost always cleaner in Descope).
+- If any server-side code generates emails, initiates SSO, or runs logic during the auth journey: ask whether that logic can be a Flow step or Connector instead of server code.
+
+Summarize any blockers and Console/Flow opportunities before proceeding to codebase analysis.
 
 ---
 
-## Step 1: Choose a Migration Path
+### Step 1: Codebase Analysis
 
-**Use `AskUserQuestion` to ask which path the user wants.** Present both options with
-their trade-offs so the user can make an informed choice. Do not pick for them.
+Scan the codebase to map every auth touchpoint before writing the plan.
 
-### Path A: OIDC Compatibility (lower risk, incremental)
+**Run these searches (adapt file extensions to the user's language):**
 
-Descope exposes standard OIDC endpoints. If the app uses an OIDC client library
-(`express-openid-connect`, `go-oidc`, `authlib`, etc.), it can point at Descope's OIDC
-issuer instead of Auth0's with minimal code changes:
+```bash
+# Find all Auth0 import sites
+grep -rn "auth0\|@auth0\|express-openid-connect\|nextjs-auth0\|auth0-fastapi\|go-oidc" \
+  --include="*.ts" --include="*.tsx" --include="*.js" --include="*.py" --include="*.go" \
+  --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=dist --exclude-dir=venv \
+  . 2>/dev/null
 
-| Endpoint | Auth0 | Descope |
+# Find all Auth0 env var references
+grep -rn "AUTH0_\|auth0\." \
+  --include="*.ts" --include="*.tsx" --include="*.js" --include="*.py" --include="*.go" \
+  --include="*.env*" --include="*.yml" --include="*.yaml" --include="Dockerfile" \
+  --exclude-dir=node_modules --exclude-dir=.next \
+  . 2>/dev/null
+
+# Find claim / token access patterns (things that may need JWT Template)
+grep -rn "token\.\|claims\.\|req\.auth\.\|req\.oidc\.\|session()\." \
+  --include="*.ts" --include="*.tsx" --include="*.js" --include="*.py" --include="*.go" \
+  --exclude-dir=node_modules --exclude-dir=.next \
+  . 2>/dev/null
+
+# Find protected route declarations
+grep -rn "requiresAuth\|withPageAuthRequired\|withApiAuthRequired\|require_session\|@login_required\|authMiddleware\|isAuthenticated" \
+  --include="*.ts" --include="*.tsx" --include="*.js" --include="*.py" --include="*.go" \
+  --exclude-dir=node_modules --exclude-dir=.next \
+  . 2>/dev/null
+
+# Check package.json / go.mod / requirements.txt for Auth0 dependencies
+find . -maxdepth 3 \( -name "package.json" -o -name "go.mod" -o -name "requirements.txt" \) \
+  ! -path "*/node_modules/*" -exec grep -l "auth0" {} \;
+```
+
+For each hit, record:
+- **File path and line** — where the change happens
+- **What it does** — import, route protection, claim access, logout handler, etc.
+- **Complexity** — Low (drop-in replacement), Medium (logic rewrite), High (no equivalent)
+
+Read `package.json` (or equivalent) for the exact framework version — this affects async
+behavior (Next.js 15 vs 14) and SDK compatibility.
+
+If the Descope Docs MCP is available, use `search-descope-docs` or `ask-question-about-descope`
+to verify current SDK method names for anything you plan to reference in the plan.
+
+---
+
+### Step 2: Write MIGRATION-PLAN.md
+
+Write `MIGRATION-PLAN.md` to the working directory using the triage answers and codebase
+analysis.
+
+Two audiences: the engineer needs enough technical detail to execute; the PM or tech lead
+needs scope, risk, and timeline without decoding jargon. Use plain English. Explain
+technical terms on first use. Open each section with a sentence summarizing what it means
+before presenting tables or evidence. Say what breaks if a risk is missed, not just that it
+exists. Pair complexity labels with time estimates; skew toward the lower bound — SDK swaps and mechanical rewrites are usually faster than they look, and repetitive files in a group after the first go much faster. Group execution into phases so parallel vs. sequential work is clear.
+
+The plan must include these sections, in this order:
+
+#### Overview
+
+2–3 sentences: what's being replaced, what replaces it, and the recommended approach with a
+one-sentence rationale. Add one sentence on what doesn't change — user-facing login behavior,
+sessions, and existing accounts are preserved.
+
+Include a **Migration at a Glance** table:
+
+| | |
+|---|---|
+| **Approach** | Full native migration / OIDC compatibility layer |
+| **Files changing** | N source files across N areas |
+| **Console setup** | N configuration steps before launch |
+| **User impact** | No re-login required / Users will need to log in once after cutover |
+| **Estimated engineering effort** | N–N hours |
+| **Biggest risk** | One sentence naming the highest-complexity item |
+
+---
+
+#### What's Changing and Why
+
+Prose (not a table) describing what each part of the system does today and what it does
+after. Example:
+
+> Today, Auth0 handles everything related to login: it shows the login UI, issues tokens,
+> and validates them on every API request. After this migration, Descope takes over all of
+> those responsibilities. The login UI becomes a Descope component embedded in the app.
+> Token validation moves to the Descope SDK. The five Auth0 environment variables are
+> replaced by a single Descope Project ID.
+>
+> Auth0 features in use that need to carry over: [list in plain English, one clause each].
+
+Tailor to triage findings.
+
+---
+
+#### Auth Touchpoints: What the Code Analysis Found
+
+Open with the scope count (e.g., "11 files across 4 areas"). Group by area, not file path.
+Each group gets a sentence on what it does and what changes.
+
+**Session handling (3 files)** — These files read and validate the current user's login
+state. They'll be updated to use the Descope session SDK instead of Auth0's.
+
+| File | What it does today | What changes |
 |---|---|---|
-| Issuer | `https://YOUR_DOMAIN.auth0.com` | `https://api.descope.com` |
-| Authorization | `https://YOUR_DOMAIN.auth0.com/authorize` | `https://api.descope.com/oauth2/v1/authorize` |
-| Token | `https://YOUR_DOMAIN.auth0.com/oauth/token` | `https://api.descope.com/oauth2/v1/token` |
-| UserInfo | `https://YOUR_DOMAIN.auth0.com/userinfo` | `https://api.descope.com/oauth2/v1/userinfo` |
-| JWKS | `https://YOUR_DOMAIN.auth0.com/.well-known/jwks.json` | `https://api.descope.com/__ProjectID__/.well-known/jwks.json` |
+| `lib/auth.ts:34` | Returns Auth0 session with `isAuthenticated`, `user`, `claims` | Rewritten to return Descope `AuthenticationInfo`; a thin adapter layer preserves the shape callers expect |
+| `middleware.ts:12` | Blocks unauthenticated requests app-wide | Updated to call Descope session validation; logic is identical, SDK call changes |
 
-**Good for:** Teams that want to swap the IdP first, then refactor to Descope-native SDKs
-later. Preserves existing OIDC client code.
+**Login / logout routes (2 files)** — These handle the Auth0 redirect-based login flow.
+Descope replaces this with an embedded UI component; no redirect cycle is needed.
 
-**Caveats to flag:** Claim shapes differ (`nickname`, `email_verified` vs `verifiedEmail`),
-token lifetimes may differ, and any Auth0 Actions logic will need to be rebuilt in
-Descope Flows regardless of which path is taken.
+| File | What it does today | What changes |
+|---|---|---|
+| `pages/api/auth/[...auth0].ts` | Catch-all handler for OAuth callback, logout, session refresh | Deleted — Descope handles this client-side; no server route needed |
 
-### Path B: Full Native Migration (recommended for new projects or clean breaks)
+Cover all functional groupings. End with: "Total: N files. Estimated code-change effort: N–N hours."
 
-Replace Auth0 SDKs with Descope SDKs. The frontend handles authentication via the
-Descope web component or client SDK; the backend validates JWTs only. No server-side
-OAuth callback, no code exchange, no session store.
+---
 
-**Good for:** Teams willing to refactor auth once for a cleaner long-term architecture.
-Fewer dependencies, fewer env vars, less backend plumbing.
+#### Feature Migration: Auth0 → Descope
+
+For each Auth0 feature confirmed in triage, write a short paragraph: what it's trying to
+accomplish, the best Descope approach for that goal, what's different, and what action is
+required. The best approach may be a Flow, Widget, SSO Setup Suite, or Console configuration
+rather than a direct SDK equivalent — reason about the intent, not just the API surface. Only
+recommend SDK code when programmatic control is genuinely required. Example:
+
+> **Multi-tenancy (Auth0 Organizations → Descope Tenants)**
+> Auth0 Organizations group users by company and scope their permissions. Descope has the
+> same concept, called Tenants, and the migration script transfers them automatically.
+> The main difference is how tenant membership appears in the session token — Auth0 uses a
+> flat `org_id` string, while Descope uses a nested `tenants` object that includes per-tenant
+> roles. Any backend code that reads `req.auth.org_id` will need to be updated to read
+> `token.tenants`. This is a predictable, mechanical change.
+> **Effort: Medium (1–2 hours).** The migration script handles the data; code changes are
+> localized to token-reading logic.
+
+Only include confirmed features.
+
+---
+
+#### Before the Code Can Run: Required Configuration
+
+Some Descope behavior is configured in the console, not in code. List every item that must
+be set up before the app works, as checkboxes with a plain description of what it is, why
+it's needed, and roughly how long it takes. Group into "Required before any testing" and
+"Required before production":
+
+**Required before any testing:**
+- [ ] **Create a Descope project** — Takes 2 minutes. Produces a Project ID that replaces
+  all Auth0 credentials in the app's environment variables.
+- [ ] **Create an authentication flow** — Descope uses a visual "flow" to define the login
+  experience (what methods are offered, in what order). The built-in `sign-up-or-in` flow
+  works for most apps and requires no customization to start.
+- [ ] **Configure a user profile token template** — By default, Descope session tokens don't
+  include the user's name, email, or profile photo. This template needs to be configured so
+  the app can display user profile information. Without it, any part of the UI that shows the
+  user's name or email will show nothing after login. (~10 minutes)
+
+**Required before production:**
+- [ ] **Create roles: `admin`, `member`** (or whatever the codebase references) — Descope
+  roles must exist in the console before code that assigns them will work.
+- [ ] **Configure social login providers** (Google, GitHub, etc.) — OAuth credentials for
+  each provider need to be entered in the console. (~15 minutes per provider)
+- [ ] (continue for each item found in analysis)
+
+---
+
+#### Environment Variables
+
+Diff table with plain-English notes for each removal and addition:
+
+| Remove | Add | Why |
+|---|---|---|
+| `AUTH0_CLIENT_ID` | — | Auth0 identifies apps by client ID. Descope uses a Project ID instead — simpler, and shared across all apps in a project. |
+| `AUTH0_CLIENT_SECRET` | — | Not needed. Descope's browser-side flow doesn't require a secret. |
+| `AUTH0_ISSUER_BASE_URL` | — | The Auth0 tenant URL. Replaced by the Project ID. |
+| `AUTH0_AUDIENCE` | — | Used by Auth0 for API access scoping. Can be replicated in Descope via token templates if needed. |
+| `SECRET` | — | Used by Auth0's SDK to encrypt server-side sessions. Descope doesn't use server-side sessions. |
+| — | `DESCOPE_PROJECT_ID` | The single identifier for the Descope project. Replaces all of the above. |
+| — | `NEXT_PUBLIC_DESCOPE_PROJECT_ID` | Same value, exposed to the browser for the login component. |
+| — | `DESCOPE_MANAGEMENT_KEY` | Only needed if the app manages users, roles, or tenants server-side. |
+
+Follow with: "Net change: 5 variables removed, 1–3 added. No secrets need to be rotated
+on the Auth0 side — those credentials stop being used."
+
+---
+
+#### User Migration (only if existing users need to be migrated)
+
+Prose strategy first, then steps. Start with: "X existing users need to be in Descope before cutover." Describe:
+
+- **The plan**: whether this is big-bang (all users moved before cutover) or phased, and why
+- **What users will experience**: will they need to log in again? Will anything look different?
+- **The biggest dependency**: if password migration requires an Auth0 support ticket, say so
+  plainly and call out that this ticket should be opened immediately — it can take several days
+
+End with a brief checklist of the migration steps at the level a PM can track:
+- [ ] Open Auth0 support ticket to request password hash export (if applicable) — **start immediately**
+- [ ] Export user list from Auth0 (if > 1,000 users)
+- [ ] Do a dry run of the migration script against the Descope dev project
+- [ ] Review dry-run output for errors
+- [ ] Run live migration against staging, then production
+
+---
+
+#### Risks and Things to Decide
+
+Things that could affect timeline, user experience, or scope. Write each in plain English
+with three parts: **what it is**, **what breaks if it's ignored**, and **what to do**.
+Format each as a named callout:
+
+> **Risk: User profile data won't appear after login until a token template is configured**
+> Descope session tokens don't include name, email, or profile photo by default. Any part of
+> the app that displays user information — profile pages, nav bars, greeting text — will show
+> blank values after migration until the token template is set up in the Descope console. This
+> is a one-time configuration step, not a code change.
+> **Action:** Configure the token template in the Descope console before running any tests.
+> Estimated time: 10 minutes.
+
+> **Risk: Password migration requires an Auth0 support request**
+> If the app supports password-based login, users' hashed passwords must be exported from
+> Auth0 and imported into Descope. Auth0 only releases these via a support ticket, which can
+> take several days to fulfill.
+> **Action:** Open the support ticket now, in parallel with development work. Without it,
+> password users will need to reset their passwords after cutover.
+
+Include only applicable risks.
+
+---
+
+#### Execution Plan
+
+Open with one sentence: phases run in sequence; steps within a phase can run in parallel.
+Then labeled phases, each with a time estimate:
+
+---
+
+**Phase 1 — Console Setup** (~30–45 minutes, no code required)
+Can be done by any team member with Descope console access, in parallel with other work.
+
+- [ ] Create Descope project, copy Project ID
+- [ ] Create authentication flow (use the built-in `sign-up-or-in` to start)
+- [ ] Configure user profile token template
+- [ ] Create roles: (list actual roles found)
+- [ ] Configure social login providers: (list actual providers found)
+
+**Phase 2 — Code Changes** (~X–Y hours, 1 engineer)
+Work through files in the order listed. Run a compile check after each group.
+
+- [ ] Delete `pages/api/auth/[...auth0].ts` — no replacement needed (5 min)
+- [ ] Update environment variables in `.env.example` and CI config (15 min)
+- [ ] Rewrite `lib/auth.ts` session helper (30 min)
+- [ ] Update `_app.tsx` — swap `UserProvider` for Descope `AuthProvider` (15 min)
+- [ ] Update 8 protected route files to use new session check (45 min)
+- [ ] Update `lib/logout.ts` — two-step logout (15 min)
+- [ ] Compile check and fix any type errors before proceeding
+
+**Phase 3 — User Migration** (~1–2 hours, includes dry run)
+Run against dev/staging first. Do not run against production until Phase 4 passes.
+
+- [ ] (steps from user migration section above)
+
+**Phase 4 — Testing** (~30–45 minutes)
+- [ ] Compile passes with zero errors
+- [ ] Server starts, no crashes on startup
+- [ ] Unauthenticated routes redirect to login correctly
+- [ ] Login flow completes, user profile data appears (confirms token template is working)
+- [ ] Logout invalidates session
+
+**Phase 5 — Production Cutover**
+- [ ] (cutover-specific steps based on their strategy — maintenance window, phased rollout, etc.)
+
+---
+
+Total estimated engineering effort: **N–N hours** across N engineers.
+Blocking dependencies: (list anything on the critical path — support tickets, console access, etc.)
+
+---
+
+After writing `MIGRATION-PLAN.md`, **stop and tell the user:**
+
+> `MIGRATION-PLAN.md` has been written to your working directory. It maps every auth
+> touchpoint found, lists what needs Console setup before the first test, and calls out
+> risks that could affect the timeline.
+>
+> Take a look before we start making changes. When you're ready to proceed, say so.
+
+Do not proceed to Part 3 unless the user confirms.
+
+---
+
+## Part 3: Execution
+
+Execute the plan in `MIGRATION-PLAN.md` Section 8 order. Follow the detailed guidance below
+for each step.
+
+---
+
+### Context Continuity Protocol
+
+Context can be lost between turns. These rules keep the migration coherent.
+
+**Step 3.0 — Create `MIGRATION-STATE.md` before touching any code.**
+
+Write `MIGRATION-STATE.md` to the working directory from the template below. It's the
+source of truth for migration state — keep it current throughout execution.
+
+```markdown
+# Migration State
+
+_Last updated: [timestamp of last completed step]_
+
+## Project Context
+- Framework: [e.g., Next.js 14, Express + React]
+- Language: [TypeScript / Python / Go]
+- Package manager: [npm / yarn / pnpm / pip / etc.]
+- Migration path: [Path A: OIDC compat / Path B: Full native]
+- Migration goal: [Full cutover / Phased / Evaluating]
+
+## Triage Answers
+- Existing users: [Yes — N users / No — greenfield]
+- Password migration needed: [Yes / No]
+- Auth0 features in use: [comma-separated list]
+- Multiple environments: [Yes: dev/staging/prod / No]
+- Zero-downtime required: [Yes / No]
+
+## Files Inventory
+_All files that need to change. Update status after each step._
+
+| File | Change | Status |
+|---|---|---|
+| `pages/api/auth/[...auth0].ts` | Delete | ⬜ Pending |
+| `lib/auth.ts` | Rewrite session helper | ⬜ Pending |
+| `middleware.ts` | Update session check | ⬜ Pending |
+
+## Console Setup Checklist
+- [ ] Descope project created — Project ID: (fill in when done)
+- [ ] JWT template configured
+- [ ] Roles created: (list roles)
+- [ ] Social providers configured: (list providers)
+
+## Decisions Log
+_Non-obvious decisions made during migration — preserves rationale if context is lost._
+
+_(none yet)_
+
+## Current Phase
+Phase 1 — Console Setup (not started)
+
+## Next Action
+Complete console setup per MIGRATION-PLAN.md before making any code changes.
+
+## Blockers
+_(none)_
+```
+
+---
+
+**Rule 1 — Re-read before every turn.**
+
+At the start of every execution turn, re-read `MIGRATION-PLAN.md` and `MIGRATION-STATE.md`
+before writing any code or making any decision.
+
+**Rule 2 — Verify context before every code change.**
+
+If the framework, migration path, triage answers, or next step aren't clear from the
+conversation, re-read both files before proceeding. Then output a context line:
+
+> `Migration context: Next.js 14 · Path B · Phase 2, step 3/8 · Next: rewrite lib/auth.ts`
+
+If this line can't be filled in accurately, re-read the files first.
+
+**Rule 3 — Update `MIGRATION-STATE.md` immediately after each step.**
+
+Mark the file done in the Files Inventory, update "Current Phase" and "Next Action", and
+append any non-obvious decision to the Decisions Log. Do this before the next step.
+
+---
+
+## Pre-Generation Protocol (apply before writing any code)
+
+Run before generating any import, wrapper type, or helper. Skipping produces code that
+compiles but fails at runtime.
+
+**1. Verify SDK exports before writing any import.**
+When the Docs MCP is available, use `ask-question-about-descope` to confirm the exact method name, option shape, and return type before writing any SDK call. This is faster and more reliable than reading type declarations. Do not write a method name and add a hedge like "verify the exact name" — just verify it.
+
+When the Docs MCP is unavailable: resolve the package's type declarations (`node_modules/<pkg>/dist/types/` or its `package.json` `types` field) and confirm the exact exported name and signature. For Go, run `go doc`. For Python, check the SDK stubs.
+
+**Prefer local `node_modules/` over GitHub** when reading type declarations. Installed packages reflect the exact version in use. If the Descope package isn't installed yet, install it first, then read local type declarations. Only fall back to GitHub if the package can't be installed in the current environment.
+
+This applies to **every SDK call you write**, not just the first import. Field names on
+option objects (`sendMail` vs `sendEmail`), hook return shapes (`useDescope()` returns the
+SDK directly, not `{ sdk }`), and subpath exports (`/client` vs root) differ just as often.
+
+**1a. After rewriting any module, grep for remaining imports of the removed package.**
+```bash
+grep -r "from '@/lib/auth0'\|from '@auth0/" --include="*.ts" --include="*.tsx" .
+```
+Add remaining hits to the work list.
+
+**2. Derive wrapper types from the actual return type.**
+Read the function's declared return type and build the wrapper to match. Auth0's field
+names, nesting, and flags differ — don't infer from them.
+
+**3. Check dependency versions before generating framework-specific code.**
+For Next.js: `cookies()` and `headers()` from `next/headers` are synchronous in v14 and
+async in v15. Read `package.json` (or `go.mod`, `requirements.txt`) first.
+
+**4. When making a helper async, propagate to all callers immediately.**
+In TypeScript, `async` on a shared utility silently breaks callers that omit `await`. Grep
+for all call sites of the changed function and update them in the same pass. The cascade can
+span 10–20 files.
+
+**5. Verify published package versions before writing to `package.json` or running `npm install`.**
+Don't reuse Auth0's version number or rely on training data for versions. Before writing any
+install command:
+```bash
+npm view @descope/node-sdk version
+npm view @descope/nextjs-sdk version
+```
+If npm is unavailable, leave the version as `"latest"` and flag it.
 
 ---
 
 ## Step 1.5: Descope Project Setup & Console Configuration
 
-Many parts of a Descope migration require setup in the Descope Console that cannot be done
-through code or config files alone. The code will compile fine without these, but it won't
-work at runtime.
+Several steps require Descope Console setup that can't be done in code. The app compiles
+without them but won't work at runtime.
 
-**Use `AskUserQuestion` to check which of these the user has already done.** A good
-opening question: whether they already have a Descope project set up with a Project ID
-and working Flow — options: "Yes, already set up", "No, need to create one", "Not sure."
-If they already have a Project ID and a working Flow, move on — but still check items 5–7
-below via `AskUserQuestion`, since these are easy to miss even for existing projects.
+Use `AskUserQuestion` to ask whether they already have a Project ID and working Flow. If
+yes, skip to verifying items 5–7 — these are easy to miss even for existing projects.
 
 ### 1. Create a project and get your Project ID
 - Sign in at [console.descope.com](https://console.descope.com)
@@ -244,30 +606,23 @@ Required for: user management API, role/permission management, tenant operations
 management, they need this.
 - Console → **Company → Management Keys → Generate Key**
 - Store as `DESCOPE_MANAGEMENT_KEY`. Treat like a secret — never expose client-side.
-- Use `AskUserQuestion` to ask whether the app does any server-side user/role/admin
-  operations — if so, they need a Management Key.
 
 ### 3. Choose or create a Flow
-A Flow is the authentication UI and logic sequence users go through. You reference it by
-its Flow ID in the web component.
+A Flow is the auth UI sequence. Reference it by Flow ID in the web component.
 
 - Console → **Authentication → Flows**
-- The built-in **"sign-up-or-in"** flow handles email/password, OTP, and social login out
-  of the box. Use this for most migrations — it's the quickest path.
-- To customise: duplicate "sign-up-or-in", rename it, then edit steps in the visual builder.
-- The Flow ID is shown in the URL when editing a flow and in the flow list. Pass it as the
-  `flowId` prop to the Descope component (e.g. `flowId="sign-up-or-in"`).
-- If the Auth0 app uses MFA: the Flow needs an MFA step added. MFA enrollment in Descope
-  is managed through Flows, not the Management SDK — there's no equivalent to Auth0
-  Guardian enrollment tickets. Use `AskUserQuestion` to ask whether the app has a
-  self-service MFA settings page — if so, plan how to handle it with Descope Flows or
-  the UserProfile widget.
+- The built-in **"sign-up-or-in"** flow handles email/password, OTP, and social login.
+  Use it for most migrations.
+- To customise: duplicate "sign-up-or-in", rename it, then edit in the visual builder.
+- The Flow ID is in the URL when editing and in the flow list.
+- There are 100+ Flow templates in the library — check for an existing template before building a custom flow. See `references/flows-and-widgets.md` → Flows.
+- MFA: add an MFA step to the Flow or embed MFA as a subflow. Descope manages MFA enrollment through Flows, not the Management SDK — no equivalent to Auth0 Guardian enrollment tickets. For factor-deletion SDK support by type, see `references/implementation-nuances.md` → MFA section.
 
 ### 4. Configure authentication methods
 - Console → **Authentication** → select methods (Email OTP, Magic Link, Social, SSO, etc.)
 - For social providers (Google, GitHub, etc.): configure OAuth credentials here, then add
-  the provider step to your Flow. The web component renders configured providers automatically.
-- For enterprise SSO (SAML/OIDC): Console → **SSO** → configure per tenant.
+  the provider step to your Flow.
+- For enterprise SSO (SAML/OIDC): Console → **SSO** → configure per tenant. For correct SSO callback and ACS URLs (social OAuth, SAML ACS, what NOT to use), see `references/implementation-nuances.md` → Social login / SSO section.
 
 ### 5. Configure a JWT Template (almost always needed)
 Auth0 includes `email`, `name`, and `picture` in tokens by default. Descope does not.
@@ -275,27 +630,17 @@ Auth0 includes `email`, `name`, and `picture` in tokens by default. Descope does
 - Add claims: `{"email": "{{user.email}}", "name": "{{user.name}}", "picture": "{{user.picture}}"}`
 - Apply the template to your project. Without this step, any code reading `token.email`
   will get `undefined` after migration.
-- Use `AskUserQuestion` to ask whether the app displays user name, email, or avatar
-  anywhere — if so, a JWT Template must be configured before those will work.
 
 ### 6. Create roles in the Console (if using RBAC)
-Descope roles are referenced by **name**, not by ID. If the app expects roles like `admin`
-and `member` to exist, they must be created manually in the Console before the code that
-assigns them will work. Unlike Auth0 where role IDs come from env vars, Descope role names
-are hardcoded strings — `addTenantRoles()` will fail if the role doesn't exist.
+Descope roles are referenced by **name**, not by ID. They must be created manually in the
+Console before the code that assigns them will work.
 - Console → **Authorization → RBAC → + Role**
 - Create each role the app references (e.g. `admin`, `member`)
-- Use `AskUserQuestion` to ask what roles the app uses — they must be created in the
-  Descope Console under Authorization → RBAC before role assignment code will work.
 
 ### 7. Define custom attributes (if using tenant/user metadata)
-If the Auth0 app stores data in Organization `metadata` or User `app_metadata`, the Descope
-equivalent is `customAttributes` on tenants or users. These attributes must be pre-defined
-in the Console schema before they can be set via the SDK.
+Auth0 Organization `metadata` and User `app_metadata` map to Descope `customAttributes`.
+Pre-define them in the Console schema before setting them via the SDK.
 - Console → **Project → Custom Attributes**
-- Use `AskUserQuestion` to ask whether the app stores custom data on organizations or
-  users (verification tokens, feature flags, plan info, etc.) — these need to be declared
-  as custom attributes in the Console before they can be set via the SDK.
 
 ### 8. Env var summary
 | Variable | Where to get it | Used by |
@@ -304,12 +649,31 @@ in the Console schema before they can be set via the SDK.
 | `NEXT_PUBLIC_DESCOPE_PROJECT_ID` | Same value as above | Next.js `AuthProvider` (client-side) |
 | `DESCOPE_MANAGEMENT_KEY` | Console → Company → Management Keys | Management SDK, Outbound Apps API |
 
+### 9. Consider Widgets for management UI
+
+Before migrating custom profile pages, user management pages, or role assignment UI, ask
+whether a Descope Widget covers the use case. See `references/flows-and-widgets.md` → Widgets.
+
+**After completing console setup:** Update `MIGRATION-STATE.md` — check off each completed
+item in the Console Setup Checklist, record the Project ID in the file, and set Next Action
+to the first code change step.
+
 ---
 
 ## Step 2: Framework-Specific Migration
 
-Read the relevant section of `references/implementation-nuances.md` before answering framework-specific
-questions. The notes contain tested, verified patterns for each of these.
+Read `references/implementation-nuances.md` in two passes before writing any code:
+
+1. **General Insights** (always) — covers architecture, feature mapping, and common gotchas that apply to every migration regardless of framework.
+2. **Framework section** (use the file's ToC and `offset` to jump directly) — read only the section matching the user's stack:
+   - Express.js → `## Express.js`
+   - Flask / Python, FastAPI → `## Flask / Python` (FastAPI notes are in the "No drop-in middleware" subsection under General Insights)
+   - Next.js (App Router, standalone) → `## Next.js (standalone)` + `## Next.js (B2B): Migration Bug Catalog`
+   - Next.js + separate Express API server → `## Next.js (with separate Express API server)`
+   - Go → `## Go + Encore`
+   - LangChain / LangGraph / Vercel AI with FGA or Token Vault → `## Agentic AI Stacks`
+
+When a new framework is added to the file, add it to this list.
 
 ### Express.js
 - Remove `express-openid-connect`; add `@descope/node-sdk` + `cookie-parser`
@@ -335,17 +699,24 @@ questions. The notes contain tested, verified patterns for each of these.
 - `authlib` stored `access_token`, `id_token`, `userinfo` in Flask server-side session.
   Descope doesn't use Flask sessions. Drop `APP_SECRET_KEY` and `session` imports.
 - `validate_session()` returns a dict of JWT claims. Profile fields aren't there by
-  default — configure a JWT Template first (see Step 3 below).
+  default — configure a JWT Template first.
 
 ### Next.js
 - `@auth0/nextjs-auth0` → `@descope/nextjs-sdk` + `@descope/node-sdk`
 - `UserProvider` → `AuthProvider` (takes `projectId` prop; must use `NEXT_PUBLIC_` prefix)
 - `useUser()` → `useSession()` + `useUser()` (Descope separates session state from user data)
 - Remove `pages/api/auth/[...auth0].tsx` catch-all — no server-side OIDC handling
-- Add `/login` page with `<Descope>` component rendering `sign-up-or-in` flow
+- Add `/login` page with `<Descope>` component rendering `sign-up-or-in` flow; always wire `onSuccess` — the component does not auto-redirect (see `references/implementation-nuances.md` → Next.js section)
 - `withPageAuthRequired` → manual `useSession()` check + redirect
 - `withApiAuthRequired` → call `session()` at handler top, return 401 manually
 - Logout: `sdk.logout()` via `useDescope()` hook (not a link to `/api/auth/logout`)
+
+**Client vs. server session access — common source of errors:**
+- `session()` from `@descope/nextjs-sdk/server` — server components, server actions, API routes **only**
+- `useSession()` + `useUser()` from `@descope/nextjs-sdk/client` — React **client** components
+  - `useSession()` returns `{ isAuthenticated, sessionToken, ... }`
+  - `useUser()` returns the user object from the current session
+- Using `session()` in a client component compiles but throws at runtime (attempts to read cookies in a browser context). Scan for this pattern before finishing any Next.js migration.
 
 **Server-side session — exact SDK API (verify before generating):**
 
@@ -366,7 +737,7 @@ interface AuthenticationInfo {
   cookies?: string[]
 }
 ```
-There is no `isAuthenticated`, no `claims` field, and no `user` wrapper. Do not generate a wrapper type that adds these — write an adapter function instead:
+There is no `isAuthenticated`, no `claims` field, and no `user` wrapper. Write an adapter function instead:
 ```ts
 import { session as sdkSession } from "@descope/nextjs-sdk/server"
 
@@ -389,26 +760,67 @@ Then generate all server components using `getDescopeSession()` from this local 
   Descope JWKS, attaches claims as FastAPI `Security()` dependency
 - No auto-mounted routes; no session store
 
+### Path A: OIDC Compatibility (lower risk, incremental)
+
+Descope exposes standard OIDC endpoints. If the app uses an OIDC client library
+(`express-openid-connect`, `go-oidc`, `authlib`, `@auth0/nextjs-auth0` v4, etc.), it can
+point at Descope's OIDC issuer instead of Auth0's with minimal code changes:
+
+| Endpoint | Auth0 | Descope |
+|---|---|---|
+| Issuer | `https://YOUR_DOMAIN.auth0.com` | `https://api.descope.com` |
+| Authorization | `https://YOUR_DOMAIN.auth0.com/authorize` | `https://api.descope.com/oauth2/v1/authorize` |
+| Token | `https://YOUR_DOMAIN.auth0.com/oauth/token` | `https://api.descope.com/oauth2/v1/token` |
+| UserInfo | `https://YOUR_DOMAIN.auth0.com/userinfo` | `https://api.descope.com/oauth2/v1/userinfo` |
+| JWKS | `https://YOUR_DOMAIN.auth0.com/.well-known/jwks.json` | `https://api.descope.com/__ProjectID__/.well-known/jwks.json` |
+
+**`@auth0/nextjs-auth0` v4 (`Auth0Client`) config for Descope:**
+
+```typescript
+new Auth0Client({
+  domain: `https://api.descope.com/${DESCOPE_PROJECT_ID}`,
+  clientId: DESCOPE_OIDC_CLIENT_ID,       // from Descope Console → Applications → OIDC App
+  clientSecret: DESCOPE_OIDC_CLIENT_SECRET,
+  logoutStrategy: "oidc",                 // prevents calling Auth0's /v2/logout
+  secret: SESSION_ENCRYPTION_SECRET,      // still needed for server-side session encryption
+})
+```
+
+Auth0-specific params that **do not carry over** to Descope via OIDC:
+- `screen_hint: "signup"` — Auth0-specific, ignored by Descope
+- `organization: orgId` — Auth0 org-scoped login has no OIDC equivalent in Descope
+- `appClient.updateSession()` — no equivalent; session is read-only after login
+
+**Good for:** Teams that want to swap the IdP first, then refactor to Descope-native SDKs
+later. Preserves existing OIDC client code.
+
+**Caveats:** Claim shapes differ, token lifetimes may differ, and Auth0 Actions must be
+rebuilt in Descope Flows regardless of path.
+
+> **For B2B apps using Auth0 Organizations:** Path A preserves roughly 20% of the work
+> (middleware, `getSession()`, session routes); the remaining 80% (management SDK, org-scoped
+> login, signup flow, claim mapping) requires full migration regardless. **Path A savings are
+> minimal for B2B workloads** — account for this when estimating effort.
+
 ### Go
 - Remove `go-oidc` + `golang.org/x/oauth2`; add `descope/go-sdk`
 - Remove login/callback/logout backend endpoints (~150 lines) — only keep token validation
 - Session validation: `descopeClient.Auth.ValidateSessionWithToken(ctx, token)` returns
   `(bool, *descope.Token, error)`. `Token.Claims` is `map[string]interface{}`
-- `sub` claim maps directly to your auth handler's user ID (same claim name as Auth0, different issuer)
+- `sub` claim maps directly to your auth handler's user ID
 - Auth config: ClientID + ClientSecret + Domain + RedirectURL → ProjectID only
+
+**After completing framework code changes:** Update `MIGRATION-STATE.md` — mark each
+modified file as Done in the Files Inventory, update Current Phase and Next Action, and
+log any non-obvious decisions made (adapter types kept, async cascade scope, etc.).
 
 ---
 
 ## Step 2.5: Non-Code File Updates
 
-Code changes alone don't make a migrated app usable. After updating source files, scan
-for and update all non-code files that contain Auth0 references. These are the ones most
-likely to be stale and cause confusion for the next person running the app.
-
-**What to update — in order of priority:**
+Scan for Auth0 references in non-code files after updating source files.
 
 ### `.env.example` / `.env.template` / `.env.sample`
-These are the first place a new developer looks. Replace Auth0 variables with Descope equivalents:
 ```
 # REMOVE
 AUTH0_CLIENT_ID=
@@ -423,29 +835,30 @@ DESCOPE_PROJECT_ID=            # Console → Project Settings
 NEXT_PUBLIC_DESCOPE_PROJECT_ID= # Next.js only — same value as above
 DESCOPE_MANAGEMENT_KEY=        # Console → Company → Management Keys (only if using management SDK)
 ```
-Use `grep -r "AUTH0"` (or `grep -r "auth0"`) to find all env var references across the project,
-including `.env.example`, Docker configs, CI files, and any shell scripts.
+Run `grep -r "AUTH0"` to find all env var references — `.env.example`, Docker, CI, shell scripts.
 
 ### README / docs
-Search for Auth0 references in all `.md` files. At minimum, update:
+Search all `.md` files for Auth0 references. At minimum, update:
 - **Setup section** — replace "create an Auth0 app" instructions with Descope Console setup steps
-  (create project, get Project ID, configure a Flow, set up JWT Template)
 - **Environment variables section** — reflect the reduced env var set
-- **Run instructions** — if the README includes steps like "configure Auth0 tenant," replace them
-  with the equivalent Descope Console steps
-- **Auth flow diagrams or descriptions** — if the README describes the OIDC callback flow or
-  session handling, update to reflect Descope's cookie-based approach
+- **Run instructions** — replace Auth0 tenant steps with Descope Console steps
+- **Auth flow diagrams or descriptions** — update to reflect Descope's cookie-based approach
 
 ### Docker / CI files
 Check `Dockerfile`, `docker-compose.yml`, `.github/workflows/`, and any CI config for
-`AUTH0_*` env var declarations. Update them to `DESCOPE_*`. Missing these means the app
-will boot with empty auth config in CI and production even if local dev works.
+`AUTH0_*` env var declarations. Update them to `DESCOPE_*`.
 
-### `AskUserQuestion` before editing docs
-Before rewriting setup docs, ask: "Does this project have a README or other documentation
-with Auth0-specific setup instructions?" If yes, read those files first and update them
-in-place rather than rewriting from scratch — preserves project-specific context and keeps
-the diff minimal.
+### Setup / bootstrap scripts
+
+Auth0 CLI commands (`auth0 tenants patch`, `auth0 actions create/deploy`, `auth0 roles create`, etc.) have **no Descope CLI equivalent**. When the migration includes a setup or seed script (e.g., `scripts/bootstrap.mjs`, `scripts/seed.ts`), split it into two parts:
+
+1. **Console setup** (cannot be scripted): Flows, email templates, MFA configuration, branding/Styles — configure these in the Descope Console. Represent them as a Phase 1 checklist in `MIGRATION-PLAN.md`.
+2. **SDK automation** (can be scripted): role creation (`management.role.create()`), tenant creation, access key provisioning. Preserve these as a Node.js/Python script using the Descope Management SDK.
+
+Auth0 Actions deployed by the script need to be re-evaluated: each Action's logic maps to a Flow step, Scriptlet, or Connector in the Console — not a code deployment. Use `AskUserQuestion` if the intent of any Action is ambiguous.
+
+**After completing non-code file updates:** Update `MIGRATION-STATE.md` — mark env files,
+README, and CI config done in the Files Inventory, and advance Next Action.
 
 ---
 
@@ -455,25 +868,29 @@ the diff minimal.
 
 | Auth0 pattern | Descope equivalent |
 |---|---|
-| Custom claims in tokens | [JWT Templates](https://docs.descope.com/management/jwt-templates) (static/dynamic claims) |
-| Custom logic during auth | [Descope Flows](https://docs.descope.com/flows) — visual pipeline with conditional branching |
-| Post-login webhooks | Flows → [Connectors](https://docs.descope.com/customize/connectors) (HTTP calls to external endpoints) |
+| Custom claims in tokens | [JWT Templates](https://docs.descope.com/management/jwt-templates) |
+| Custom logic during auth | [Descope Flows](https://docs.descope.com/flows) |
+| Post-login webhooks | Flows → [Connectors](https://docs.descope.com/customize/connectors) |
 | Role assignment at login | Flow actions → RBAC role assignment steps |
-
-Auth0 Actions are imperative Node.js. Descope Flows are declarative and visual, with
-custom JS escape hatches. Business logic must be restructured around the visual pipeline.
 
 ### Social Login → Descope Social Auth
 - Configure providers in the Descope Console under Authentication → Social
 - Add them to a Flow (no code changes)
 - The Descope web component renders configured providers automatically
 
+### MFA Enrollment → Descope Flows
+
+**Before migrating MFA enrollment:** Many Auth0 apps have a separate MFA enrollment page because Auth0 Guardian works via a server-generated enrollment ticket URL. That pattern has no Descope equivalent — and a separate page is rarely the right approach in Descope.
+
+The Descope approach: add an MFA step directly to the sign-up/sign-in Flow — enrollment happens inline during the auth journey. Or embed MFA as a **subflow** (triggered by a condition: user is admin, risk score exceeds a threshold, etc.). Or use the `step-up` Flow template to gate sensitive operations.
+
+**Action:** Before writing any MFA enrollment code, use `AskUserQuestion` to confirm whether MFA can be integrated into the main sign-in Flow. See `references/flows-and-widgets.md` → MFA enrollment section.
+
 ### RBAC: Auth0 Roles/Permissions → Descope RBAC
-Auth0 embeds roles via Actions; Descope embeds them in the JWT by default (no action needed).
 
 | Auth0 | Descope |
 |---|---|
-| `req.auth.permissions.includes('read:messages')` | `token.permissions.includes('read:messages')` (same pattern, different source) |
+| `req.auth.permissions.includes('read:messages')` | `token.permissions.includes('read:messages')` |
 | Role claim via namespace in Actions | `roles` array in JWT (built-in) |
 | M2M token for Management API | `DESCOPE_MANAGEMENT_KEY` for management SDK |
 
@@ -482,8 +899,23 @@ SDK: `descopeClient.management.role.create(name, description, permissionNames, t
 ### Multi-Tenancy: Auth0 Organizations → Descope Tenants
 - Auth0 `org_id` (flat string) → Descope `tenants` (nested object: `{ tenantId: { roles, permissions } }`)
 - Auth0 org-scoped login → Descope routes by email domain or tenant-specific URLs
-- Tenant-level SSO enforcement available in Descope (SAML/OIDC required for all tenant users)
 - Users are project-level in Descope; associated with tenants, not created per-tenant
+
+### Enterprise SSO → Descope Tenant SSO
+
+**Preferred approach — SSO Setup Suite:** Before migrating management SDK SSO calls, ask whether the SSO Setup Suite removes the need for that code. The SSO Setup Suite is a no-code Console wizard that guides tenant admins through per-tenant SAML/OIDC configuration with step-by-step IdP-specific instructions (Okta, Azure AD, Google Workspace, etc.) — no engineering involvement needed for new tenant SSO onboarding.
+
+Use `AskUserQuestion` to ask: does this app need **programmatic** SSO configuration (CI/CD provisioning, API-driven tenant onboarding), or do tenant admins configure SSO themselves through a settings page? If the latter, the SSO Setup Suite + Tenant Profile Widget may eliminate the need for `sso.configureSAMLByTenant()` / `configureOIDCByTenant()` calls entirely.
+
+See `references/flows-and-widgets.md` → SSO Setup Suite.
+
+**SDK path (when programmatic SSO is needed):**
+
+| Auth0 | Descope |
+|---|---|
+| `connections.create({ strategy: "samlp" })` | `management.sso.configureSAMLByTenant(tenantId, settings)` |
+| `connections.create({ strategy: "oidc" })` | `management.sso.configureOIDCByTenant(tenantId, settings)` |
+| Per-org SAML connection | Per-tenant SSO (Console → SSO or Management SDK) |
 
 ### Auth0 FGA (OpenFGA) → Descope ReBAC
 
@@ -504,7 +936,7 @@ type doc
 ```
 
 API shape differences:
-- OpenFGA: `{ user, relation, object }` tuples (e.g., `user:alice`, `owner`, `doc:123`)
+- OpenFGA: `{ user, relation, object }` tuples
 - Descope: `{ target, targetType, relation, resource, resourceType }` — explicit typed fields
 
 | Operation | Auth0 FGA | Descope ReBAC |
@@ -532,29 +964,27 @@ Build a custom tool wrapper that calls the Outbound Apps API directly.
 
 ### CIBA / Async Authorization → Custom Implementation Required
 
-Descope has **no CIBA equivalent**. `withAsyncAuthorization()` from `@auth0/ai` requires
-a custom replacement. Recommended approach:
+Descope has **no CIBA equivalent**. Recommended approach:
 1. Agent creates a pending approval record in your database
 2. Frontend polls for it (or uses WebSocket)
 3. User approves via Descope Flow or custom UI
 4. Agent receives approval signal and continues
 
-Flag this explicitly — it's the highest-complexity migration item.
+This is the highest-complexity migration item.
 
 ### M2M / Client Credentials → Descope Access Keys
 Auth0 M2M apps use the client credentials grant. Descope's equivalent is
 [Access Keys](https://docs.descope.com/management/m2m-access-keys) — create one in
 Console → Access Keys, exchange it for a JWT via `descopeClient.auth.exchangeAccessKey()`,
-and validate the resulting token the same way as user tokens. Access keys support tenant
-and role scoping, IP restrictions, and configurable expiration.
+and validate the resulting token the same way as user tokens.
 
 ### User Migration → Descope Migration Script
 
 Descope provides a Python CLI tool — [`descope/descope-migration`](https://github.com/descope/descope-migration) — that handles bulk import of users, roles, permissions, and Auth0 organizations (→ Descope tenants) in one run.
 
-**Two import modes (based on user count):**
-- **Auth0 API** — use when fewer than 1,000 users (Auth0 API pagination limit)
-- **JSON export** — use when 1,000+ users; export via Auth0's User Import/Export extension, then pass the file to the script with `--from-json`
+**Two import modes:**
+- **Auth0 API** — use when fewer than 1,000 users
+- **JSON export** — use when 1,000+ users; export via Auth0's User Import/Export extension
 
 **Setup:**
 ```bash
@@ -562,87 +992,71 @@ git clone git@github.com:descope/descope-migration.git
 cd descope-migration
 python3 -m venv venv && source venv/bin/activate
 pip3 install -r requirements.txt
-cp .env.example .env  # populate with values below
+cp .env.example .env
 ```
 
 Required `.env` variables:
 | Variable | Where to get it |
 |---|---|
-| `AUTH0_TOKEN` | Auth0 Management API → [token explorer](https://manage.auth0.com/#/apis/management/explorer) (24h token) |
-| `AUTH0_TENANT_ID` | Your Auth0 dashboard URL, e.g. `dev-xyz` from `manage.auth0.com/dashboard/us/dev-xyz/` |
+| `AUTH0_TOKEN` | Auth0 Management API → token explorer (24h token) |
+| `AUTH0_TENANT_ID` | Your Auth0 dashboard URL |
 | `DESCOPE_PROJECT_ID` | Descope Console → Project Settings |
 | `DESCOPE_MANAGEMENT_KEY` | Descope Console → Company → Management Keys |
 
 **Always dry-run first:**
 ```bash
-# Via Auth0 API (< 1,000 users), without passwords
 python3 src/main.py auth0 --dry-run
-
-# Via JSON export, with passwords
 python3 src/main.py auth0 --dry-run --from-json ./export.json --with-passwords ./password_hashes.json
 ```
 
-Add `-v` / `--verbose` for detailed output. The dry run shows exactly what would be migrated: users, roles, permissions, organizations/tenants — without touching anything.
-
-**Password migration:** optional. Requires opening a support ticket with Auth0 to get a password hash export file, then passing it via `--with-passwords`. Without it, users will need to reset passwords or use passwordless methods after migration.
-
 **What gets migrated:** users, roles, permissions, Auth0 organizations → Descope tenants.
 
-**Auto-created custom attributes:** the script creates two custom attributes in Descope automatically:
+**Auto-created custom attributes:**
 - `connection` (text) — the Auth0 connection type for each user
-- `freshlyMigrated` (boolean) — set to `true` on import; use this in Flow conditionals to give newly migrated users a special first-login experience (e.g., prompt to verify email, set a password, or enroll in MFA), then flip it to `false` once done
+- `freshlyMigrated` (boolean) — set to `true` on import; use this in Flow conditionals to give newly migrated users a special first-login experience, then flip it to `false` once done
 
-**Live run (after dry-run passes):**
-```bash
-python3 src/main.py auth0 --from-json ./export.json --with-passwords ./password_hashes.json
-```
+**Session migration (beta):** for zero-disruption cutovers, active Auth0 sessions can be
+exchanged for Descope tokens without re-authenticating. Requires users to already exist in
+Descope (import first). See [session migration docs](https://docs.descope.com/migrate/session-migration).
 
-A log file is generated at `migration_log_auth0_<timestamp>.log`. Any failed items are listed with their error.
-
-**Session migration (beta):** for zero-disruption cutovers, Descope also supports [session migration](https://docs.descope.com/migrate/session-migration) — users with active Auth0 sessions can exchange their existing token for a Descope token without re-authenticating. Requires users to already exist in Descope (import first), and is currently in beta with no JIT user creation support.
-
-**Hybrid migration:** if a full cut-over isn't possible immediately, Descope can be configured as a federated IdP inside Auth0 — users authenticate via Descope Flows while Auth0 remains in place. Requires completing the import step first, then following the [Descope-as-IdP-for-Auth0 guide](https://docs.descope.com/identity-federation/applications/setup-guides/auth0).
-
-For phased migrations without the script, the [Batch Create User API](https://docs.descope.com/api/management/users/batch-create-users) also supports bcrypt hash import directly.
+**Large user bases (10,000+) — just-in-time migration via Auth0 Action:**
+For large populations where a bulk export/import would be disruptive, Auth0 supports creating an Action that forwards user data to Descope on each login during a cutover window — users migrate gradually, just-in-time, without a forced re-login. This approach requires coordination with the Descope Customer Success team. Flag this if the user wants zero-disruption cutover.
 
 ### Email Templates → Descope Messaging Templates
-Auth0 email templates (verification, password reset, invitation) map to Descope
-[Messaging Templates](https://docs.descope.com/management/messaging-templates), configured
-per authentication method in the Console. Templates support HTML and dynamic content.
+Auth0 email templates map to Descope [Messaging Templates](https://docs.descope.com/management/messaging-templates),
+configured per authentication method in the Console.
 
 ### Log Streams → Descope Audit Webhook
 Auth0 Log Streams map to Descope's
 [Audit Webhook Connector](https://docs.descope.com/connectors/connector-configuration-guides/network/audit-webhook).
-Configure it in Console → Connectors to stream auth events to your own HTTP endpoint. Set
-this up before cutover to avoid gaps in event logging.
+Set this up before cutover to avoid gaps in event logging.
 
 ### Custom Domains
-Auth0 custom domains map to Descope
-[custom domains](https://docs.descope.com/how-to-deploy-to-production/custom-domain).
 CNAME `auth.example.com` → `cname.descope.com`, verify in Console, then pass `baseUrl` to
-the Descope SDK. Plan this before cutover.
+the Descope SDK.
 
 ### Attack Protection → Descope Flow Security
-Auth0 Attack Protection (bot detection, brute force, breached passwords) maps to Descope
-Flow steps using security connectors: Arkose Bot Manager, Google reCAPTCHA, Fingerprint,
-Have I Been Pwned, AbuseIPDB. These are composable (add detection steps to Flows) rather
-than toggle-based. Not configured by default — flag this if the Auth0 app relies on Attack
-Protection.
+Auth0 Attack Protection maps to Descope Flow steps using security connectors: Arkose Bot Manager,
+Google reCAPTCHA, Fingerprint, Have I Been Pwned, AbuseIPDB. These are composable (add
+detection steps to Flows) rather than toggle-based — not configured by default.
+
+**After completing feature migration:** Update `MIGRATION-STATE.md` — record which features
+were migrated, mark any that were deferred or require follow-up, and advance Next Action to
+testing.
 
 ---
 
 ## Step 4: Critical Gotchas (Always Cover These)
 
-These are the most common migration mistakes. Surface them proactively.
-
 ### JWT Claims Are Not the Same
-Descope session JWTs contain `sub`, `amr`, `drn`, `tenants`, `roles`, `permissions` by
+Descope session JWTs contain `sub`, `amr`, `drn`, `tenants`, `roles`, `permissions`, and `dct` by
 default. They do **not** contain `email`, `name`, or `picture`. Auth0 ID tokens include
 these by default.
 
+`dct` (Descope Current Tenant) is a flat string holding the active tenant ID — the direct equivalent of Auth0's `org_id`. For apps where a user is always in a single tenant context, `token.dct` is simpler to read than iterating `token.tenants`. Use `token.tenants` when you need per-tenant roles or permissions (it is a keyed object: `{ [tenantId]: { roles, permissions } }`); use `token.dct` when you only need the tenant ID.
+
 **Action required:** Configure a JWT Template in the Descope Console to add `email`,
-`name`, and any other profile fields the app reads from the token. Without this, code
-reading `token.email` or `token.name` will get `undefined`.
+`name`, and any other profile fields the app reads from the token.
 
 ### Audience Validation Is Opt-In
 Descope session tokens have no `aud` claim by default. Apps using `AUTH0_AUDIENCE` for
@@ -650,13 +1064,22 @@ API access control must:
 1. Configure a custom `aud` claim in JWT Templates
 2. Pass `audience` to `validateSession()` on the backend
 
-Easy to miss; without it, any valid Descope token passes backend validation.
-
 ### Logout Is Two Steps
 1. Call `descopeClient.logout(refreshToken)` to invalidate server-side
 2. Clear `DS` and `DSR` cookies
 
-Skipping either step leaves a broken state. Both are required.
+Skipping either step leaves a broken state.
+
+### Server-Side Profile Updates Don't Immediately Reflect in the Session Token
+
+Auth0's `appClient.updateSession()` has no direct server-side equivalent in Descope. Profile changes via the Management SDK don't update the JWT already in the browser. Four options:
+
+1. **Wait for auto-refresh** (~5 min default) — no code required; tolerable for most apps.
+2. **`useDescope().refresh()` client-side** — triggers an immediate token refresh. Requires the profile form to be a client component with a `useDescope()` hook. Full code pattern in `references/implementation-nuances.md` → Session refresh section.
+3. **Update JWT endpoint** (`POST /v1/mgmt/user/jwt/update`) — server-side; updates stored JWT custom claims for a specific user. Verify current behavior against Descope docs before using — this updates stored claims, not the live session token.
+4. **User Profile Widget** — if the app is building a profile edit page, the Widget handles profile updates and session refresh automatically without custom code. See `references/flows-and-widgets.md` → Widgets.
+
+**Session change event listeners:** Instead of calling `refresh()` imperatively, the Descope client SDK exposes auth state change events — use these to react to session updates across components. See [docs.descope.com/client-sdk/auth-helpers#handling-authentication-state-changes](https://docs.descope.com/client-sdk/auth-helpers#handling-authentication-state-changes).
 
 ### Cookie Names Are Configurable (And May Conflict)
 Default: `DS` (session JWT), `DSR` (refresh JWT). Configure custom names in the Descope
@@ -664,199 +1087,107 @@ Console under the Flow's End action when running multiple Descope projects on th
 root domain.
 
 ### One Token, Not Two
-Auth0 issues separate ID tokens and access tokens (scoped to `audience`). Descope has
-one token: the session JWT (`DS` cookie). Forward it as `Authorization: Bearer <DS>` to
-API servers. No separate token endpoint.
+Auth0 issues separate ID tokens and access tokens. Descope has one token: the session JWT
+(`DS` cookie). Forward it as `Authorization: Bearer <DS>` to API servers.
 
 ### No Drop-In Middleware
 Descope has no `express-openid-connect` equivalent package. The middleware is ~20 lines
-of custom code. This is a feature (simpler, no hidden behavior) but users expecting
-a drop-in replacement need to know upfront.
+of custom code.
 
 ### `cookies()` and `headers()` Are Async in Next.js 15
-`cookies()` and `headers()` from `next/headers` return a `Promise` in Next.js 15+. Code
-generated against Next.js 14 assumptions (synchronous `cookies()`) will compile but throw
-at runtime. Before generating any server-side helper that reads cookies:
+`cookies()` and `headers()` from `next/headers` return a `Promise` in Next.js 15+. Before
+generating any server-side helper that reads cookies:
 
 1. Check the project's `package.json` for the Next.js version.
 2. If ≥ 15: write `await cookies()` and mark the containing function `async`.
 3. Trace upward — making a cookie-reading helper async cascades to every caller.
-   A single `getActiveTenantId` becoming async can require `await` additions across
-   10–20 files. Plan for this before starting edits.
 
 ### Async Cascade: Trace All Callers Before Finishing
-When a shared utility (e.g., `getActiveTenantId`, `getRole`) becomes async, TypeScript
-accepts `await` on non-Promises without error — so callers that forget `await` silently
-return a Promise object instead of the resolved value. Always grep for all call sites of
-any utility you make async and update them in the same pass.
+When a shared utility becomes async, TypeScript accepts `await` on non-Promises without
+error — so callers that forget `await` silently return a Promise object. Always grep for
+all call sites of any utility you make async and update them in the same pass.
 
 ### Env Var Reduction
 Auth0: `CLIENT_ID`, `CLIENT_SECRET`, `ISSUER_BASE_URL`, `SECRET`, `AUTH0_AUDIENCE` (5+).
-Descope: `DESCOPE_PROJECT_ID` only (+ `DESCOPE_MANAGEMENT_KEY` for management ops). No
-client secret for frontend flows.
+Descope: `DESCOPE_PROJECT_ID` only (+ `DESCOPE_MANAGEMENT_KEY` for management ops).
 
 ---
 
 ## Step 5: Automated Testing
 
-Do not hand the user a checklist and stop. Run the app and verify it actually works.
-A migration where "the code compiles" is not done — a migration where "the app starts,
-serves the login page, and protects routes correctly" is done.
-
-Work through the phases below in order. Stop and surface any failure immediately rather
-than continuing past a broken state.
+Run the app and verify it works — don't just hand over a checklist.
 
 ### Phase 0: Final stale-import sweep (BLOCKING)
 
-Before installing or starting anything, grep the entire project for remaining Auth0 references:
-
 ```bash
-# Adjust patterns to match the Auth0 packages used in this project
 grep -r "@auth0\|auth0\|express-openid-connect\|nextjs-auth0" \
   --include="*.ts" --include="*.tsx" --include="*.js" --include="*.py" --include="*.go" \
   --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=dist \
   .
 ```
 
-If this returns any results, **stop and fix them before proceeding**. Every hit is a guaranteed crash once the Auth0 package is removed. Common files missed in the rewrite:
-- Layout files (`layout.tsx`, `_app.tsx`) that still wrap with Auth0 Provider
-- API route files that import `withApiAuthRequired`
-- Utility/helper files not on the main auth path
-- Test files that import Auth0 fixtures or mock the Auth0 SDK
-
-Do not proceed to Phase 1 until this grep returns zero results.
+If this returns any results, **stop and fix them before proceeding**.
 
 ### Phase 1: Install, compile, and start
 
 ```bash
-# Install dependencies (use whatever package manager the project uses)
 npm install   # or: pip install -r requirements.txt / go mod tidy
 ```
 
-**Run the compile check immediately after making code changes — before setting up `.env` or
-starting the server.** Compilation does not require env vars to be populated. This catches
-stale Auth0 imports, wrong return-type destructuring, and async cascade gaps before they become
-runtime surprises. It takes seconds and saves far more.
-
 ```bash
-# TypeScript
-npx tsc --noEmit
-
-# Go
-go build ./...
-
-# Java / Kotlin (Maven)
-mvn compile -q
-
-# Java / Kotlin (Gradle)
-./gradlew compileJava compileKotlin
-
-# .NET / C#
-dotnet build
+npx tsc --noEmit    # TypeScript
+go build ./...      # Go
+mvn compile -q      # Java/Maven
+./gradlew compileJava compileKotlin  # Java/Gradle
+dotnet build        # .NET
 ```
 
-**Do not report the migration as complete, and do not move to Step 6, until this exits with
-zero errors.** A passing compile is the minimum bar — it catches stale imports, wrong
-return-type destructuring, and async cascade gaps that code review misses.
+**Do not proceed until compilation exits with zero errors.**
 
 **If compilation fails, diagnose by error message:**
-- `Cannot find module '@auth0/...'` → stale import missed by Phase 0 grep; expand the search pattern and re-run Phase 0
-- `Property 'X' does not exist on type 'AuthenticationInfo'` → wrapper type was built against the Auth0 shape; re-derive from the actual Descope SDK return type
-- `'await' expression is not allowed in synchronous contexts` → async cascade gap; trace the caller chain and add `async`/`await` up the tree
-- `Object is possibly 'undefined'` on session fields → `session()` returns `undefined` when unauthenticated; add a null check or early return guard
-
-**Do not proceed to Phase 2 if compilation fails.** Type errors are deterministic runtime crashes — fix all of them before starting the server.
+- `Cannot find module '@auth0/...'` → stale import; re-run Phase 0
+- `Property 'X' does not exist on type 'AuthenticationInfo'` → wrapper built against Auth0 shape; re-derive
+- `'await' expression is not allowed in synchronous contexts` → async cascade gap
+- `Object is possibly 'undefined'` on session fields → add null check or early return
 
 ```bash
-# Start the development server
 npm run dev   # or: python main.py / go run . / flask run / etc.
 ```
 
-Watch startup output for:
-- Missing env var errors (most common first-run failure — means `.env` wasn't populated with `DESCOPE_PROJECT_ID`)
-- `Cannot find module` at runtime → a dynamic `require()` or non-TS import was missed by the grep
-- Port conflicts or config errors
-
-**If the server starts but immediately exits:** check for `Missing env var` in logs and populate `.env`.
-
-**If the server starts but crashes on first request:** this is almost always an unresolved `Promise` — a function was made `async` but a caller was not updated with `await`. Add a `console.log` at the suspected call site and check whether it logs `Promise { <pending> }` instead of a value.
-
-If the server fails to start, fix it before proceeding. Do not move to Phase 2.
-
 ### Phase 2: Run existing tests
 
-If the project has a test suite, run it now:
 ```bash
-npm test          # or: pytest / go test ./... / etc.
+npm test   # or: pytest / go test ./... / etc.
 ```
 
-Auth-related test failures at this point usually mean:
-- A mock or fixture still uses Auth0 token shapes or env vars
-- A test directly imports an Auth0 SDK function that was removed
-- A test validates JWT claims that are now missing (e.g., `email` without a JWT Template)
-
-Fix failing tests before proceeding. If there are no existing tests, note this and continue.
+Auth-related test failures usually mean: a mock or fixture still uses Auth0 shapes, or a
+test validates JWT claims that are now missing (e.g., `email` without a JWT Template).
 
 ### Phase 3: Smoke test the running app
 
-With the server running, verify the core auth paths using `curl` or the browser automation
-tools available to you. At minimum, check:
-
-**Root path renders (app is alive):**
 ```bash
+# Root path
 curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/
-# Expect: 200 or 302 — any 5xx means a runtime crash in a root/layout component
-```
 
-If this returns 5xx, check server logs immediately. A 500 on the root path almost always
-means a runtime import error or an async crash in a layout or middleware that wraps all routes.
-Fix before continuing.
-
-**Unauthenticated access (should redirect or 401):**
-```bash
-# For a web app — expect redirect to /login
+# Unauthenticated protected route (expect 302 or 401)
 curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/dashboard
 
-# For an API — expect 401
-curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/api/protected
-```
-
-**Login page loads:**
-```bash
+# Login page loads Descope component
 curl -s http://localhost:<port>/login | grep -i "descope"
-# Should find the Descope web component or SDK reference
-# If it returns Auth0 references, something was missed in Step 2
-```
 
-**Protected routes without a session return 401 or redirect:**
-```bash
-curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/protected-route
-# Expect: 302 (redirect to login) or 401
-```
-
-**Session validation endpoint (if one exists):**
-```bash
-# Pass a deliberately invalid token — expect 401
+# Invalid token → 401
 curl -s -H "Cookie: DS=invalid_token" http://localhost:<port>/api/me
 ```
 
 ### Phase 4: Verify JWT claims (if JWT Template is configured)
 
-If the user confirmed a JWT Template was set up in the Console, verify claims are present.
-Obtain a valid `DS` cookie via the login flow (have the user log in and copy the cookie
-from DevTools, or use a test credential if available), then:
-
 ```bash
-# Decode the JWT payload (no verification needed for claim inspection)
 echo "<DS_cookie_value>" | cut -d'.' -f2 | base64 -d 2>/dev/null | python3 -m json.tool
 ```
 
-Check that `email`, `name`, and any other expected claims are present. If they're missing,
-the JWT Template wasn't applied — flag this explicitly.
+Check that `email`, `name`, and any other expected claims are present.
 
 ### Phase 5: Report results
-
-After running the phases above, produce a brief test summary:
 
 ```
 ## Test Results
@@ -872,10 +1203,6 @@ After running the phases above, produce a brief test summary:
 - [ ] (list anything that failed or needs manual action)
 ```
 
-If something can't be tested automatically (e.g., completing a full login flow requires
-a real browser and test credentials), say so explicitly and tell the user exactly what
-to do and what to look for. Do not silently skip it.
-
 **Do not proceed to Step 6 until ALL of the following are true:**
 - [ ] Phase 0 grep returns zero Auth0 references
 - [ ] Phase 1 compilation passes with zero errors
@@ -883,64 +1210,41 @@ to do and what to look for. Do not silently skip it.
 - [ ] Phase 3 root path returns 2xx or 3xx (not 5xx)
 - [ ] Phase 3 protected routes return 302 or 401 (not 500)
 
-A migration that produces a crashing app is not complete. Fix all blockers inline before
-writing the summary.
-
 ---
 
 ## Step 6: Post-Migration Summary (Required)
 
-Every migration must produce a `MIGRATION-SUMMARY.md` at the end. This captures what was
-done, what still needs manual setup, and what behavioral differences the user should
-be aware of before going to production. A migration isn't done when the code compiles —
-it's done when the user knows exactly what they need to set up, verify, and watch out
-for.
+Every migration produces a `MIGRATION-SUMMARY.md` covering what was done, manual setup
+remaining, and behavioral differences that matter before production.
 
 ### MIGRATION-SUMMARY.md
 
-Include the following sections:
-
 1. **What was migrated** — a table mapping each Auth0 concept to its Descope replacement
-   (SDK, session handling, middleware, login UI, organizations, roles, SSO, SCIM, MFA,
-   user management, invitations, env vars, etc.). Only include rows relevant to this
-   specific migration.
 
-2. **Behavioral differences and open questions** — a numbered list of the significant
-   differences between the Auth0 and Descope implementations that the user should
-   understand. For each item, briefly describe the Auth0 behavior, the Descope behavior,
-   and any action required or question to verify. Focus on things that could cause
-   confusion or bugs: features with no SDK equivalent (e.g. MFA enrollment tickets, SCIM
-   management), model differences (e.g. invitation objects vs. invited-status users,
-   org-scoped login vs. multi-tenant JWTs), session/token refresh gaps (e.g. stale JWTs
-   after tenant creation requiring re-login), and anything where the code compiles but
-   won't work without Console configuration.
+2. **Behavioral differences and open questions** — numbered list of significant differences
+   between the Auth0 and Descope implementations. For each item: Auth0 behavior, Descope
+   behavior, action required.
 
 3. **Pre-deploy checklist** — actionable checkbox items for everything that must happen
-   before the migrated app can run. This should prominently include all Console setup
-   tasks: creating the project, generating a Management Key, configuring a JWT Template,
-   creating roles, defining custom attributes, setting up Flows, etc. These are the
-   things easiest to forget because the code compiles without them.
+   before the migrated app can run. Prominently include all Console setup tasks — these
+   are the things easiest to forget because the code compiles without them.
 
 ---
 
 ## Step 7: Output Format
 
-Write a clear, numbered migration guide in Markdown, scoped to the user's specific
-stack. Prefer concrete code snippets and direct doc links over general descriptions.
-Always include the MIGRATION-SUMMARY.md deliverable (Step 6).
+Write a numbered migration guide in Markdown, scoped to the user's stack. Use code
+snippets and direct doc links. Always include the MIGRATION-SUMMARY.md deliverable (Step 6).
 
 For complex migrations (FGA, CIBA, AI tooling), flag the high-effort items explicitly
-with estimated complexity (Low/Medium/High) so the user can plan. Reference the
-migration difficulty table in `references/implementation-nuances.md` for the agentic AI scenario
-(LangChain/LangGraph + FGA + Token Vault + CIBA).
+with estimated complexity (Low/Medium/High) so the user can plan.
 
 ---
 
 ## Reference Files
 
 - `references/implementation-nuances.md` — Verified migration patterns, code-level diffs, and edge
-  cases for several frameworks. Use as a reference for the principles and patterns; apply
-  them to any language or framework the user is using.
+  cases for several frameworks.
 - Descope Docs: https://docs.descope.com
 - Auth0 Migration Guide: https://docs.descope.com/migrate/auth0
 - User Import (Custom): https://docs.descope.com/migrate/custom

--- a/skills/auth0-to-descope/references/flows-and-widgets.md
+++ b/skills/auth0-to-descope/references/flows-and-widgets.md
@@ -1,0 +1,227 @@
+# Descope Flows, Widgets, and Console-First Reference
+
+This file covers Descope's no-code/low-code layer — Flows, Widgets, the SSO Setup Suite, and
+the Console-vs-code decision guide. Read it when the migration touches auth UI, MFA enrollment,
+user management pages, or SSO configuration. In all those areas, a Console/Flow/Widget approach
+is usually faster and safer than writing code.
+
+---
+
+## Contents
+
+- [Terminology: Auth0 → Descope Lingo](#terminology-auth0--descope-lingo)
+- [Flows: Structure and What They Replace](#flows-structure-and-what-they-replace)
+- [Widgets: Post-Login Management UI](#widgets-post-login-management-ui)
+- [SSO Setup Suite](#sso-setup-suite)
+- [Console vs. Code: The Decision Guide](#console-vs-code-the-decision-guide)
+
+---
+
+## Terminology: Auth0 → Descope Lingo
+
+### Critical naming inversion
+
+The most common migration mistake: Auth0 and Descope use the word "tenant" to mean different things.
+
+| Auth0 term | Descope term | Notes |
+|---|---|---|
+| **Tenant** (your Auth0 account) | **Project** | Top-level unit. Has auth methods, Flows, users, and settings. Multiple environments → multiple Projects. |
+| **Organization** (your B2B customer) | **Tenant** | "For B2B apps, a tenant is your customer." Direct equivalent of Auth0 Organization. |
+| Application | **Federated Application** (OIDC/SAML clients) or just **Project** (direct SDK integration) | Use Federated Application when you need OIDC/SAML; use Project directly for SDK-based integration. |
+| Action / Rule / Hook | **Flow + Scriptlet + Connector** | Flows replace the entire Auth0 pipeline. Actions become Flow steps; custom code becomes Scriptlets; external calls become Connectors. |
+| M2M Client / Client Credentials | **Access Key** | Presented to exchange for a short-lived JWT. Supports expiration, permitted IPs, tenant/role scoping. |
+| Universal Login Page | **Auth Hosting** (hosted) or embedded **`<descope-wc>` / `<Descope>` component** | Flows define the auth experience in both cases. |
+| Social Connection (Google, GitHub…) | **OAuth Provider** | Configured under Authentication Methods in Console. |
+| Enterprise Connection (SAML/OIDC per-org) | **Tenant SSO** | Per-tenant configuration. Use the SSO Setup Suite for self-service. |
+| Branding | **Styles** | Logo, colors, fonts in Console → Styles. Inherited by all Flow Screens. |
+| Auth0 Marketplace integration | **Connector** | Added as a step inside a Flow. Response available in flow context as `connectors.<contextKey>`. |
+| Roles / Permissions | **Roles / Permissions** | Same concepts. Project-level and tenant-level. Stored as strings in JWT. |
+| Management API (M2M token) | **Management SDK + Management Key** | Same capabilities, different auth (Management Key vs. M2M token). |
+
+### Other Descope-specific terms
+
+- **Project** — the top-level unit. Think Auth0 tenant.
+- **Flow** — visual auth pipeline. Replaces Auth0 Actions/Rules/Hooks + Universal Login.
+- **Screen** — one UI page within a Flow. Designed in Screen Builder.
+- **Scriptlet** — inline JS step in a Flow (Lodash + CryptoJS included). Escape hatch for custom logic.
+- **Connector** — HTTP call step in a Flow. Response stored in flow context.
+- **Subflow** — one Flow embedded inside another. Context passes through; does not terminate the parent.
+- **Descoper** — a person with Console access. Managed in Company Settings → Descopers with custom roles.
+- **Auth Hosting Application** — the hosted login UI (equivalent to Auth0 Universal Login domain).
+
+---
+
+## Flows: Structure and What They Replace
+
+A Descope Flow is a visual, no-code authentication pipeline built in the Console. It IS the
+authentication process — not a hook on top of it. Flows can be changed without redeploying
+the application.
+
+### What Flows replace from Auth0
+
+| Auth0 | Descope Flow equivalent |
+|---|---|
+| Actions / Rules / Hooks (post-login logic, claims, role assignment) | Flow steps (Actions, Scriptlets, Custom Claims) |
+| Universal Login page UI | Flow Screens |
+| Email verification sequence | Email verification Flow step |
+| Password reset sequence | Password reset Flow (template available) |
+| MFA enrollment (Guardian ticket URL redirect) | MFA step in main sign-in Flow, or MFA subflow |
+| Invitation emails | Invitation Flow (template available) |
+| Step-up authentication | Step-up Flow (template: `step-up`; adds `su` claim to JWT) |
+| Progressive profiling | Progressive profiling Flow (template available) |
+| Attack protection (bot detection, brute force) | Connector steps (Arkose, reCAPTCHA, Fingerprint, HaveIBeenPwned, AbuseIPDB) |
+
+### Building blocks
+
+1. **Screens** — UI forms. Designed in Screen Builder. Support conditional show/hide of components based on context values (`user.*`, `form.*`, `tenant.*`).
+2. **Actions** — single-task steps: authenticate, send OTP, verify magic link, create user, assign role, set custom claims, end the flow.
+3. **Conditions** — branch routing based on context values (`user.*`, `tenant.*`, `form.*`, `connectors.<key>`, `jwtClaims.*`, `cookies.<name>`).
+4. **Connectors** — HTTP calls to external services during the flow. Response stored as `connectors.<contextKey>` for use in later Conditions, Actions, or Custom Claims.
+
+**Advanced:**
+- **Scriptlets** — inline JavaScript. Useful for string manipulation, hashing, date math, or calling Lodash/CryptoJS utilities. Has a test/debug mode.
+- **Subflows** — embed one Flow inside another. The subflow End continues back to the parent instead of generating a JWT. Pass inputs via `{{subflowInput.key}}`. Good for MFA as a step inside a larger sign-in journey.
+
+### Flow templates (100+ in library)
+
+Access via Console → Flows → "Start from template". Search by method, use case, or connector.
+
+**Common templates:**
+- `sign-up-or-in` — default; combines email OTP, magic link, social, passkeys
+- `step-up` — step-up auth; adds `su` JWT claim on success
+- OTP variants (email, SMS, WhatsApp)
+- Magic link variants
+- Passkey / WebAuthn
+- Social login
+- TOTP / authenticator app
+- SSO / SAML / OIDC federation
+- MFA combinations (password + TOTP, social + OTP, passkeys + magic link)
+- Invitation, user impersonation, progressive profiling, account recovery
+
+**Before writing any custom Flow configuration:** check whether a template already covers the
+use case. Most common patterns are available out of the box.
+
+### MFA enrollment specifically
+
+Many Auth0 apps have a separate MFA enrollment page because Auth0 Guardian works via a server-generated redirect URL. That pattern has no Descope equivalent.
+
+**The Descope approach:**
+- Add an MFA step to the main sign-up/sign-in Flow — enrollment happens inline during the auth journey
+- Or embed MFA as a **subflow** — triggered by a condition (e.g., user is admin, or risk score is high)
+- Or use the **step-up** flow template to gate sensitive operations
+
+Before migrating a standalone MFA enrollment page, ask whether MFA can be integrated into the main Flow instead. This is almost always the cleaner approach in Descope.
+
+---
+
+## Widgets: Post-Login Management UI
+
+Widgets are embeddable management UI components for post-login operations. Each widget
+action runs a Flow under the hood. Customizable via Console → Widgets without code changes.
+
+### When to recommend a Widget
+
+Whenever the migration plan calls for building or migrating a custom:
+- Profile edit page → **User Profile Widget**
+- User management page (admin view) → **User Management Widget**
+- Role assignment UI → **Role Management Widget**
+- Tenant SSO setup page → **Tenant Profile Widget** (+ SSO Setup Suite)
+- Audit log view → **Audit Widget**
+
+Ask before writing code: *"Does a Widget cover this use case?"*
+
+### Widget types
+
+**User-facing (for end users):**
+
+| Widget | What it does |
+|---|---|
+| User Profile Widget | Edit name, email, avatar; manage MFA enrollment; manage connected accounts |
+| Applications Portal Widget | List accessible applications |
+| Outbound Applications Widget | Manage third-party OAuth connections (Outbound Apps) |
+
+**Admin-facing (for tenant admins within your app):**
+
+| Widget | What it does |
+|---|---|
+| User Management Widget | Invite users, disable accounts, assign roles, view tenant members |
+| Role Management Widget | Create and assign roles within a tenant |
+| Access Key Management Widget | Create/revoke API access keys |
+| Audit Widget | View audit events per tenant |
+| Tenant Profile Widget | Edit tenant settings, configure SSO, manage SCIM |
+
+### Widget vs. Flow component
+
+| | Flow Component | Widget |
+|---|---|---|
+| **Purpose** | Authentication journey entry point | Post-login management UI |
+| **Use case** | Sign-up, sign-in, MFA, step-up, invitation | Profile editing, user/role/key management |
+| **When to use** | Login and auth flows | Any post-login management feature |
+
+---
+
+## SSO Setup Suite
+
+The SSO Setup Suite is a no-code Console wizard for SAML and OIDC SSO configuration.
+It guides tenant admins through per-tenant SSO setup with step-by-step instructions
+specific to common IdPs (Okta, Azure AD, Google Workspace, etc.).
+
+### When to recommend it
+
+Surface this before migrating any SSO-related Management SDK calls:
+
+- App uses `managementClient.connections.create({ strategy: "samlp" | "oidc" })`
+- Migration plan includes `management.sso.configureSAMLByTenant()` or `configureOIDCByTenant()`
+- App has a custom SSO settings page where tenant admins configure their IdP
+
+**The question to ask:**
+> "Does this app need programmatic SSO configuration (CI/CD provisioning, API-driven setup), or do tenant admins configure SSO themselves through a settings page? If the latter, the SSO Setup Suite + Tenant Profile Widget may remove the need for that SDK code entirely."
+
+### What it does
+
+- Generates per-tenant SAML metadata and ACS URL
+- Walks tenant admins through IdP-specific setup (Okta, Azure, Google, etc.)
+- Handles SCIM token generation for provisioning
+- Removes engineering involvement for SSO onboarding of new tenants
+
+---
+
+## Console vs. Code: The Decision Guide
+
+### Do in the Console
+
+| Task | Where in Console |
+|---|---|
+| Auth flow logic (sign-up, MFA, step-up, invitation, reset) | Flows |
+| Branding (logo, colors, fonts) | Styles |
+| RBAC model (create roles and permissions) | Authorization → RBAC |
+| Per-tenant SSO configuration | SSO (or SSO Setup Suite) |
+| Social OAuth providers | Authentication → Social |
+| Email/SMS templates | Authentication method settings → Templates |
+| Session token lifetime and refresh settings | Project → Session Management |
+| Custom JWT claims (profile fields, roles in token) | Authorization → JWT Templates |
+| Custom tenant/user attributes | Project → Custom Attributes |
+| Connectors (Slack, Salesforce, HTTP webhooks, etc.) | Connectors |
+| Access Keys (M2M) | Access Keys |
+| Descopers (Console access control) | Company Settings → Descopers |
+
+### Do in code
+
+| Task | Why it's code |
+|---|---|
+| Session validation on protected routes | Must run on every request; always backend code |
+| RBAC/ReBAC enforcement | Reads JWT claims; always in middleware |
+| Tenant/user automation at scale | Bulk provisioning, CI/CD, infrastructure-as-code |
+| Custom business logic during auth | Expose as a backend endpoint; call from Flow via Generic HTTP Connector |
+| SDK setup (one-time) | Install SDK, wrap app in `AuthProvider`, embed Flow component |
+
+### The mental model
+
+> **Console owns the user journey. Code owns business logic.**
+
+Engineers integrate once (SDK setup + session validation middleware). All subsequent auth
+evolution — new auth methods, MFA step changes, UI updates, connector integrations, new
+social providers — happens in the Console without code deployments.
+
+When a migration replaces Auth0 code with equivalent Descope SDK calls, that's correct.
+When it replaces Auth0 code with Console configuration, that's better.

--- a/skills/auth0-to-descope/references/implementation-nuances.md
+++ b/skills/auth0-to-descope/references/implementation-nuances.md
@@ -1,0 +1,731 @@
+# Descope Migration: Implementation Notes
+
+## General Insights
+
+### Auth0 owns the flow; Descope validates tokens
+
+Auth0's server-side SDKs ([express-openid-connect](https://github.com/auth0/express-openid-connect), [@auth0/nextjs-auth0](https://github.com/auth0/nextjs-auth0), [authlib](https://docs.authlib.org/en/latest/client/flask.html)) own the OIDC flow: they mount callback routes, handle code exchange, create server-managed sessions, and provide middleware that gates routes. Developers never touch tokens.
+
+Descope splits the work. The frontend ([Descope Flows](https://docs.descope.com/flows) via [web components](https://docs.descope.com/client-sdk/descope-components) or [client SDKs](https://docs.descope.com/client-sdk/initialize-sdk)) runs the authentication ceremony and stores JWTs in `DS` (session) and `DSR` (refresh) cookies. The backend [validates those JWTs](https://docs.descope.com/authorization/session-management/session-validation/backend). No server-side OAuth callback, no authorization code exchange, no server-managed session store.
+
+Every Auth0→Descope migration adds a dedicated login page (or embeds the [`<descope-wc>` component](https://docs.descope.com/client-sdk/descope-components#descope-component)) and removes callback/redirect plumbing.
+
+**Exception:** Descope can also act as a [standard OIDC provider](https://docs.descope.com/getting-started/oidc-endpoints). If you want to keep your existing OIDC client code (e.g., `express-openid-connect`, `go-oidc`, `authlib`), you can point it at Descope's OIDC endpoints instead of Auth0's. See the "OIDC compatibility path" section below.
+
+### OIDC compatibility path (alternative to full migration)
+
+Descope exposes standard [OIDC endpoints](https://docs.descope.com/getting-started/oidc-endpoints):
+
+| Endpoint | URL |
+|---|---|
+| Authorization | `https://api.descope.com/oauth2/v1/authorize` |
+| Token | `https://api.descope.com/oauth2/v1/token` |
+| UserInfo | `https://api.descope.com/oauth2/v1/userinfo` |
+| JWKS | `https://api.descope.com/__ProjectID__/.well-known/jwks.json` |
+| End Session | `https://api.descope.com/oauth2/v1/logout` |
+| Revocation | `https://api.descope.com/oauth2/v1/revoke` |
+
+An app using `express-openid-connect` could swap `ISSUER_BASE_URL` from `https://YOUR_AUTH0_DOMAIN` to `https://api.descope.com` and keep the existing OIDC client code intact. Differences in claim shapes (`nickname`, `email_verified` vs `verifiedEmail`), token lifetimes, and configuration semantics mean the OIDC swap still requires testing and adjustments. Still, it's a viable incremental path: swap the IdP first, then refactor to Descope-native SDKs later.
+
+### No drop-in middleware for Express or Flask
+
+Auth0 offers [`express-openid-connect`](https://github.com/auth0/express-openid-connect), a single `app.use(auth(config))` that [auto-mounts `/login`, `/logout`, `/callback`](https://github.com/auth0/express-openid-connect#readme) and attaches `req.oidc`. Descope has no Express middleware package. You:
+
+1. Add `cookie-parser` (Express doesn't parse cookies by default; Auth0's middleware handled it internally).
+2. Write custom middleware: read `DS` cookie → call [`descopeClient.validateSession()`](https://docs.descope.com/authorization/session-management/session-validation/backend#validate-session) → attach user claims to `req`.
+3. Write your own `requiresAuth()` guard (3 lines, but manual).
+
+The [Descope blog](https://www.descope.com/blog/post/authentication-middleware) shows an Express middleware pattern, but it's a tutorial example, not a published package.
+
+Flask is the same story. Auth0's [authlib Flask integration](https://docs.authlib.org/en/latest/client/flask.html) registers an OAuth client with `authorize_redirect` / `authorize_access_token` helpers. Descope's Flask backend [validates tokens](https://docs.descope.com/getting-started/python) only; auth UI is client-side.
+
+FastAPI follows the same pattern. Auth0 has [`auth0-fastapi`](https://github.com/auth0/auth0-fastapi), which provides `AuthConfig`, session middleware, auto-mounted `/auth/*` routes, a `require_session` dependency, and Token Vault / Connected Accounts support. Descope's equivalent is a [custom JWT authorizer using JWKS validation](https://docs.descope.com/authorization/session-management/session-validation/oidc-jwt-authorizers/python-fastapi-jwt-authorizer): a `TokenVerifier` class that reads the `Authorization` header, validates against Descope's JWKS, and attaches as a FastAPI `Security()` dependency. No auto-mounted routes, no session store.
+
+### Cookie names: `DS` and `DSR` (configurable)
+
+Descope web components and client SDKs default to `DS` for the session JWT and `DSR` for the refresh JWT. The [Node SDK README](https://github.com/descope/node-sdk#session-validation-using-middleware) references `DescopeClient.SessionTokenCookieName` and `DescopeClient.RefreshTokenCookieName` as constants.
+
+These names are configurable. The [End action in Descope Flows](https://docs.descope.com/flows/actions/end-action#session-cookie-name) has "Session Cookie Name" and "Refresh Cookie Name" fields that override the defaults. Use custom names when running multiple Descope projects on the same root domain to avoid cookie collisions. Backend code must then read the custom cookie name instead of `DS`/`DSR`.
+
+The `sessionTokenViaCookie` parameter in [`AuthProvider`](https://docs.descope.com/client-sdk/descope-components#cookie-configuration-options) controls whether the session token is set as a cookie at all (vs. managed in-memory by the SDK).
+
+### User claims differ
+
+The default Descope session JWT ([structure ref](https://docs.descope.com/authorization/session-management#descope-session-jwt-structure)) contains `sub`, `amr`, `drn`, `tenants`, `roles`, and `permissions`. It does **not** include `email`, `name`, or `picture` unless you add them via [JWT Templates](https://docs.descope.com/management/jwt-templates) or [Flow actions > Custom Claims](https://docs.descope.com/flows/actions/custom-claims). Auth0 ID tokens include these by default.
+
+| Field | Auth0 | Descope |
+|---|---|---|
+| User ID | `sub` (e.g., `auth0\|abc123`) | `sub` in JWT, `userId` in SDK user objects |
+| Display name | `name`, `nickname` | Not in JWT by default. Add via [JWT Templates](https://docs.descope.com/management/jwt-templates). No `nickname` equivalent. |
+| Email | `email` | Not in JWT by default. Add via JWT Templates. Available on user object via SDK management calls. |
+| Profile picture | `picture` | Not in JWT by default. Add via JWT Templates. |
+| Email verified | `email_verified` | Not in JWT by default. Available on user object as `verifiedEmail`. Add to JWT via Custom Claims if needed. |
+| Roles | Via `https://DOMAIN/roles` namespace claim (added by Auth0 Actions) | `roles` array in JWT (embedded by default with [RBAC](https://docs.descope.com/authorization/role-based-access-control)) |
+| Permissions | Via namespace claim or `permissions` array (added by Actions) | `permissions` array in JWT (embedded by default) |
+| Tenant | `org_id` (Auth0 Organizations) | `tenants` object with per-tenant roles ([ref](https://docs.descope.com/authorization/role-based-access-control#tenants-and-roles)) |
+
+`nickname` is Auth0-specific (derived from the email prefix). Descope lacks it. Fall back to `name`.
+
+**Migration action item:** Before migrating, configure a JWT Template that includes `email`, `name`, and any other profile claims your app reads from the token. Without this, code that reads `token.email` or `token.name` after `validateSession()` will get `undefined`.
+
+### Audience validation requires explicit setup
+
+Auth0 projects commonly set `AUTH0_AUDIENCE` to scope access tokens to a specific API. The access token's `aud` claim is validated by the API server (via `express-jwt`, `go-oidc`, etc.).
+
+Descope session tokens don't include an `aud` claim by default. To replicate Auth0's audience validation:
+1. Configure a custom `aud` claim in the Descope Console's [JWT Templates](https://docs.descope.com/management/jwt-templates).
+2. Pass the `audience` parameter to [`validateSession()`](https://docs.descope.com/getting-started/nodejs#implement-session-validation) on the backend.
+
+This is easy to miss during migration. Without it, any valid Descope session token from any project would pass validation. The audience check prevents cross-project token reuse.
+
+### Auth0 separate access tokens → Descope session token reuse
+
+Auth0's architecture issues separate access tokens (scoped to an `audience`) distinct from the ID token. The Next.js SDK's `getAccessToken()` returns this access token for API calls.
+
+Descope has one token: the session JWT (`DS` cookie). When calling a backend API, you forward the `DS` cookie value as `Authorization: Bearer <DS>`. The API server validates it with `descopeClient.validateSession(token)`. No separate token endpoint, no audience-scoped token issuance. If you need audience differentiation, use [JWT Templates](https://docs.descope.com/management/jwt-templates).
+
+### Logout requires two steps
+
+Auth0's `express-openid-connect` [redirects to Auth0's `/v2/logout`](https://github.com/auth0/express-openid-connect#readme) (clears the Auth0 session), then back to the app. `@auth0/nextjs-auth0` does the same via its API route.
+
+Descope logout ([backend](https://docs.descope.com/authorization/session-management/session-validation/backend#logout-current-session-using-backend-sdk) / [client](https://docs.descope.com/client-sdk/auth-helpers#logout)):
+1. Call `descopeClient.logout(refreshToken)` (server-side) or `sdk.logout()` (client-side) to invalidate the refresh token.
+2. Clear the `DS` and `DSR` cookies.
+
+Clear cookies without calling logout → the refresh token stays valid on Descope's servers. Call logout without clearing cookies → the client holds a dead session token that fails validation but confuses client-side state.
+
+### One env var instead of five
+
+Auth0 needs `CLIENT_ID`, `CLIENT_SECRET`, `ISSUER_BASE_URL`/`AUTH0_DOMAIN`, `SECRET`, and sometimes `AUTH0_AUDIENCE`. See the [express-openid-connect configuration](https://github.com/auth0/express-openid-connect#readme) for the full list.
+
+Descope needs `DESCOPE_PROJECT_ID` (or `NEXT_PUBLIC_DESCOPE_PROJECT_ID` for Next.js client-side). No client secret for frontend flows. The web component authenticates against Descope's API using the project ID. Backend SDKs [fetch the public key](https://docs.descope.com/authorization/session-management/session-validation/backend/offline-jwt-validation#finding-your-public-key) from Descope's JWKS endpoint (`https://api.descope.com/v2/keys/<project_id>`) using the same project ID. No secrets to rotate for the auth flow.
+
+For management operations (user CRUD, role management, FGA), add `DESCOPE_MANAGEMENT_KEY`.
+
+### Auth0 Actions/Rules → Descope Flows + JWT Templates
+
+Auth0 uses [Actions](https://auth0.com/docs/customize/actions) (and legacy Rules/Hooks) to run custom code at specific points in the authentication pipeline: post-login, pre-registration, and others. Common uses include enriching tokens with custom claims, blocking logins based on business logic, and assigning roles.
+
+Descope equivalent:
+- **Custom claims:** [JWT Templates](https://docs.descope.com/management/jwt-templates) to add static/dynamic claims to tokens, or [Flow actions > Custom Claims](https://docs.descope.com/flows/actions/custom-claims) for claims set during the auth flow.
+- **Custom logic during auth:** [Descope Flows](https://docs.descope.com/flows) are visual, drag-and-drop pipelines. Conditional branching, connectors to external services, and custom JS actions replace Auth0 Actions. Flows run on Descope's servers, not as arbitrary Node.js code.
+- **Post-login hooks:** Descope Flows can call external HTTP endpoints ([Connectors](https://docs.descope.com/customize/connectors)) for webhook-style behavior.
+
+Auth0 Actions are imperative Node.js code. Descope Flows are declarative and visual, with escape hatches to custom code via Connectors and JS actions. You'll need to restructure auth-time business logic around the visual pipeline model.
+
+### `authRequired: false` needs manual replication
+
+Auth0's `express-openid-connect` supports [`authRequired: false`](https://github.com/auth0/express-openid-connect#readme) globally: unauthenticated users browse freely, the middleware skips populating `req.oidc.user`. Descope equivalent: your session middleware catches validation errors and sets `req.isAuthenticated = false` instead of returning 401.
+
+### Social login / connection mapping
+
+Auth0 [Social Connections](https://auth0.com/docs/authenticate/identity-providers/social-identity-providers) (Google, GitHub, Facebook, etc.) are configured in the Auth0 dashboard and appear automatically on the Universal Login page.
+
+Descope equivalent: configure [social auth methods](https://docs.descope.com/authentication/social) in the Descope Console, then add them to a [Flow](https://docs.descope.com/flows). The Descope web component renders the configured providers. No code changes needed; configuration only.
+
+SAML/OIDC enterprise connections in Auth0 map to Descope's [SSO configuration](https://docs.descope.com/sso) (per-tenant SSO for B2B). Auth0 Organizations' per-org connections map to Descope's per-tenant SSO settings.
+
+### RBAC: Auth0 → Descope
+
+Auth0 RBAC: create permissions, create roles, assign roles to users. Roles/permissions can be added to access tokens via Auth0 Actions or the Authorization Extension.
+
+Descope RBAC ([docs](https://docs.descope.com/authorization/role-based-access-control)): same concept, but permissions are always grouped into roles, and roles can be project-level or tenant-level. Roles/permissions are embedded in the JWT by default (no Action required). Descope SDK methods:
+- `descopeClient.management.permission.create(name, description)` ([ref](https://docs.descope.com/authorization/role-based-access-control/with-sdks))
+- `descopeClient.management.role.create(name, description, permissionNames, tenantId)` ([ref](https://docs.descope.com/authorization/role-based-access-control/with-sdks))
+- Roles appear in the JWT `roles` array; permissions in `permissions` array.
+
+Backend code checking Auth0's `req.auth.permissions.includes('read:messages')` changes to reading the `permissions` array from Descope's validated JWT claims.
+
+### Multi-tenancy: Auth0 Organizations → Descope Tenants
+
+Auth0 [Organizations](https://auth0.com/docs/manage-users/organizations) group users by company. The `org_id` claim identifies the organization.
+
+Descope [Tenants](https://docs.descope.com/b2b#multi-tenancy) are the equivalent. Users can belong to multiple tenants with different roles per tenant. The JWT includes a `tenants` object with per-tenant role/permission data ([ref](https://docs.descope.com/authorization/role-based-access-control#tenants-and-roles)).
+
+Key differences:
+- Auth0: `org_id` is a flat string claim. Descope: `tenants` is a nested object (`{ "tenantId": { "roles": [...], "permissions": [...] } }`).
+- Auth0 requires organization-scoped login via `organization` parameter. Descope routes by email domain or tenant-specific login URLs ([ref](https://docs.descope.com/sso/multi-sso)).
+- Descope supports tenant-level SSO enforcement (require SAML/OIDC for all users in a tenant) ([ref](https://docs.descope.com/management/tenant-management/tenant)).
+- Users are project-level entities in Descope; they're associated with tenants, not created per-tenant.
+- Auth0's org-scoped login issues a JWT with one `org_id`. Descope's JWT contains **all** tenants the user belongs to at once. Switching tenants does not require re-authentication — implement it client-side (e.g. an `active_tenant` cookie) and read the active tenant from the `tenants` object in the JWT.
+- When a tenant is created and the user is added via the Management SDK, the existing JWT is stale — the `tenants` claim was set at login and doesn't include the new tenant. The user must re-authenticate (clear `DS`/`DSR` cookies and redirect to login) to get a JWT with the updated tenant list. Without this, the app sees an empty `tenants` claim and may loop back to onboarding.
+
+### Invitation model: Auth0 invitations → Descope user.invite()
+
+Auth0 Organizations have a dedicated invitation system with invitation objects, URLs, and CRUD operations. An invited user doesn't exist until they accept.
+
+Descope's `management.user.invite()` creates a user record immediately in `"invited"` status and sends an invitation email. There is no separate invitation object to list, update, or revoke independently. To list pending invitations for a tenant, filter users by `status === "invited"`. To revoke an invitation, delete the user.
+
+### SCIM: HTTP API only, not in SDK
+
+Auth0 exposes SCIM configuration via the Management SDK (`managementClient.connections.createScimConfiguration()`, etc.). Descope supports SCIM but only via the HTTP API (`https://api.descope.com/v1/mgmt/scim/*`), not the Node.js or Python SDKs. Implement with raw `fetch()` calls. Verify the request/response shapes against the current API — the endpoints are documented but not SDK-wrapped.
+
+### Session refresh after profile changes
+
+Auth0's `appClient.updateSession()` lets you immediately reflect profile changes (e.g. display name) in the cached session without re-authentication. Descope has no equivalent — profile changes via the Management SDK don't update the JWT. The user must wait for token refresh (if using DSR), sign out and back in, or call `refresh()` from the client SDK. Plan for this if the app has a profile editing flow that expects immediate UI updates.
+
+### Management API mapping
+
+Auth0's [Management API](https://auth0.com/docs/api/management/v2) is REST-based, accessed with an M2M token.
+
+Descope uses a Management SDK initialized with a `managementKey` ([Node SDK](https://github.com/descope/node-sdk), [Python SDK](https://github.com/descope/python-sdk), [Go SDK](https://github.com/descope/go-sdk)).
+
+| Operation | Auth0 | Descope (Node.js) |
+|---|---|---|
+| Create user | `POST /api/v2/users` | `descopeClient.management.user.create(...)` ([ref](https://docs.descope.com/management/user-management/sdks)) |
+| Update user | `PATCH /api/v2/users/{id}` | `descopeClient.management.user.update(...)` |
+| Search users | `POST /api/v2/users` (with q param) | `descopeClient.management.user.search(...)` |
+| Delete user | `DELETE /api/v2/users/{id}` | `descopeClient.management.user.delete(...)` |
+| Load user | `GET /api/v2/users/{id}` | `descopeClient.management.user.load(...)` / `.loadByUserId(...)` |
+| List permissions | `GET /api/v2/resource-servers/{id}` | `descopeClient.management.permission.loadAll()` |
+| Create role | `POST /api/v2/roles` | `descopeClient.management.role.create(name, description, permissions, tenantId)` |
+
+Auth0 M2M tokens expire and must be rotated. Descope management keys are long-lived (rotatable via the Console).
+
+### FGA: Auth0 FGA (OpenFGA) → Descope ReBAC
+
+Auth0 [Fine-Grained Authorization](https://fga.dev/) is built on [OpenFGA](https://openfga.dev/). Descope has its own [ReBAC](https://docs.descope.com/authorization/rebac) system with a similar model (types, relations, computed permissions) but a different API shape.
+
+**Schema definition:**
+
+OpenFGA uses a YAML/JSON model with `type_definitions`. Descope uses a [DSL](https://docs.descope.com/authorization/rebac/define-schema) saved via `descopeClient.management.fga.saveSchema(schema)` ([ref](https://docs.descope.com/authorization/rebac/implement-schema)).
+
+**Operation mapping:**
+
+| Operation | Auth0 FGA (OpenFGA SDK) | Descope ReBAC (Node SDK) |
+|---|---|---|
+| Write tuple | `fgaClient.write({ writes: [{ user, relation, object }] })` | `descopeClient.management.fga.createRelations([{ resource, resourceType, relation, target, targetType }])` ([ref](https://docs.descope.com/authorization/rebac/create-relations)) |
+| Delete tuple | `fgaClient.write({ deletes: [...] })` | `descopeClient.management.fga.deleteRelations([...])` |
+| Check | `fgaClient.check({ user, relation, object })` | `descopeClient.management.fga.check([{ resource, resourceType, relation, target, targetType }])` ([ref](https://docs.descope.com/authorization/rebac/check-relations)) |
+| List objects | `fgaClient.listObjects({ user, relation, type })` | `descopeClient.management.authz.whatCanTargetAccessWithRelation(target, relation, namespace)` ([ref](https://docs.descope.com/authorization/rebac/check-relations)) |
+| Who has access | `fgaClient.listUsers({ object, relation })` | `descopeClient.management.authz.whoCanAccess(resource, relation, namespace)` |
+
+**Key differences:**
+- OpenFGA tuples use `user`/`relation`/`object` (e.g., `user:alice`, `owner`, `doc:123`). Descope uses `target`/`targetType`/`relation`/`resource`/`resourceType`.
+- OpenFGA's `buildOpenFgaClient()` (from `@auth0/ai`) uses separate FGA credentials (`FGA_STORE_ID`, `FGA_CLIENT_ID`, `FGA_CLIENT_SECRET`, `FGA_API_URL`). Descope ReBAC uses the same `DESCOPE_PROJECT_ID` + `DESCOPE_MANAGEMENT_KEY`.
+- Auth0 FGA runs as a hosted OpenFGA instance. Descope ReBAC is integrated into the Descope platform.
+- The `@auth0/ai-langchain` package provides `FGARetriever` that wraps a LangChain retriever with FGA batch-check filtering. No Descope equivalent exists. Build a custom retriever that calls `descopeClient.management.fga.check()` for each candidate document.
+
+### Token Vault / Connected Accounts → Descope Outbound Apps
+
+Auth0's [Token Vault](https://auth0.com/docs/secure/tokens/token-vault) stores third-party OAuth tokens (Google, GitHub, Slack) and exchanges them on demand. The `@auth0/ai-langchain` package wraps this with `withTokenVault()` for LangGraph tools. The `@auth0/nextjs-auth0` SDK's `enableConnectAccountEndpoint` auto-mounts `/auth/connect` for linking accounts.
+
+Descope's equivalent: [Outbound Apps](https://docs.descope.com/identity-federation/outbound-apps). These store third-party OAuth tokens and static API keys. Tokens are retrieved via the Management API:
+
+```
+# Fetch token with specific scopes
+POST https://api.descope.com/v1/mgmt/outbound/app/user/token
+Authorization: Bearer {projectId}:{managementKey}
+Body: { "appId": "google-calendar", "userId": "U2abc...", "scopes": [...] }
+
+# Fetch latest token (no scope filter)
+POST https://api.descope.com/v1/mgmt/outbound/app/user/token/latest
+Body: { "appId": "google-calendar", "userId": "U2abc..." }
+```
+([ref](https://docs.descope.com/identity-federation/outbound-apps/using-outbound-apps#fetching-outbound-apps-tokens))
+
+Users connect accounts via `sdk.outbound.connect(appId, { redirectURL, scopes })` on the client side ([ref](https://docs.descope.com/identity-federation/outbound-apps/connect)).
+
+**Key differences:**
+- Auth0 wraps token exchange into LangGraph tools via `@auth0/ai-langchain` with interrupt-based consent UI. Descope has no AI-framework SDK. You call the Outbound Apps API directly from your tool function.
+- Auth0's Token Vault uses `subjectTokenType` for federated token exchange. Descope's API uses `appId` + `userId` lookup.
+- Auth0's connected account management is scoped to `https://DOMAIN/me/` audience. Descope's is part of the Management API.
+
+### CIBA / Rich Authorization Requests (no Descope equivalent)
+
+Auth0 supports [CIBA](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow) (Client-Initiated Backchannel Authentication) for async authorization. The agent sends a push notification to the user's device, waits for approval, then receives a scoped token. The `@auth0/ai` SDK wraps this via `withAsyncAuthorization()`.
+
+Descope does not offer CIBA or Rich Authorization Requests (RAR) as a product feature. Migrations that use `withAsyncAuthorization()` require a custom approval mechanism. One option: the agent creates a pending approval record, the frontend polls for it, and the user approves via a Descope Flow or custom UI.
+
+### @auth0/ai SDK (no Descope equivalent)
+
+Auth0 publishes [`@auth0/ai`](https://github.com/auth0/ai-sdks), [`@auth0/ai-langchain`](https://github.com/auth0/ai-sdks), and [`@auth0/ai-vercel`](https://github.com/auth0/ai-sdks). These SDKs wrap AI agent tools with:
+- Token Vault credential injection (`withTokenVault()`)
+- CIBA async authorization (`withAsyncAuthorization()`)
+- FGA-aware RAG retrieval (`FGARetriever`, `FGAFilter`)
+- Interrupt-based consent UI (`TokenVaultInterrupt`, `AccessDeniedInterrupt`)
+
+Descope has no AI-framework SDKs. Descope's agentic offerings focus on [MCP server authentication](https://www.descope.com/press-release/agentic-identity-hub) (OAuth 2.1, tool-level scopes, client registration) rather than LangChain/Vercel AI tool wrapping.
+
+For migration, each `@auth0/ai` wrapper must be reimplemented:
+- `withTokenVault()` → custom wrapper calling Descope Outbound Apps API
+- `withAsyncAuthorization()` → custom approval mechanism (see CIBA section above)
+- `FGARetriever` → custom retriever calling `descopeClient.management.fga.check()` per document
+- `TokenVaultInterrupt` → custom interrupt using LangGraph's `interrupt()` + frontend consent UI calling `sdk.outbound.connect()`
+
+### Fewer network round-trips at login
+
+Auth0's [authorization code flow](https://github.com/auth0/express-openid-connect#readme) (for server-rendered apps) requires at minimum 3 round-trips: browser to backend (get auth URL), browser to Auth0 (user signs in), Auth0 to backend callback (exchange code for tokens). The Encore sample added a fourth hop between the frontend and Go backend.
+
+Descope's [web component](https://docs.descope.com/client-sdk/descope-components#descope-component) handles sign-in in one step: the component loads in the browser, the user authenticates against Descope's API, and the component sets `DS`/`DSR` cookies. No backend round-trips for the auth ceremony. The backend is contacted only for subsequent API calls that need [token validation](https://docs.descope.com/authorization/session-management/session-validation/backend).
+
+### Auth0 vs Descope flow comparison
+
+```
+Auth0 (server-rendered):
+  Browser → /login → Auth0 hosted page → /callback → code exchange → session created → redirect
+
+Auth0 (Encore two-process):
+  Browser → Next.js /auth/login → Go backend Login → Auth0 URL
+  Browser → Auth0 hosted page → Next.js /callback → Go backend Callback → token exchange → cookie set
+
+Descope (all variants):
+  Browser → /login page → Descope web component renders → user authenticates → DS/DSR cookies set → redirect
+  (Backend participates only when validating tokens on subsequent requests)
+```
+
+### User migration: Auth0 export → Descope import
+
+Auth0 users don't automatically carry over. For production apps with existing users, this is a critical migration step.
+
+Descope has a dedicated [Auth0 migration guide](https://docs.descope.com/migrate/auth0) with two approaches:
+- **Full migration:** Export all users from Auth0 (via the Auth0 Management API or Dashboard export), then import them into Descope using the [Create User API](https://docs.descope.com/api/management/users/create-user) or [Batch Create User API](https://docs.descope.com/api/management/users/batch-create-users). Descope accepts bcrypt password hashes, so users can keep their existing passwords without a reset. Export as CSV or JSON; see the [user format JSON guide](https://docs.descope.com/migrate/custom/user-format-json) for the expected shape.
+- **Hybrid migration (just-in-time):** Keep Auth0 running alongside Descope during a transition period. New logins go through Descope; existing users are migrated on first login. This avoids a big-bang cutover but requires both systems running simultaneously.
+
+Key fields to map: Auth0 `user_id` → Descope `loginId` (or `userId`), `email`, `name`, `password` (as hash), `app_metadata` → `customAttributes`, `user_metadata` → `customAttributes`.
+
+If the Auth0 app uses Organizations, map each organization's member list to Descope tenant associations during import.
+
+### M2M authentication: Auth0 client credentials → Descope Access Keys
+
+Auth0's [Client Credentials Grant](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-credentials-flow) is used for machine-to-machine auth: a backend service authenticates with `CLIENT_ID` + `CLIENT_SECRET` and receives an access token scoped to an `audience`.
+
+Descope's equivalent is [Access Keys](https://docs.descope.com/management/m2m-access-keys). An access key is exchanged for a JWT, which is then validated by the receiving service the same way a user session token is validated. Access keys can be scoped to tenants and roles, and can have IP restrictions and expiration times.
+
+| Auth0 | Descope |
+|---|---|
+| Create M2M app in Dashboard | Create Access Key in Console → [Access Keys tab](https://app.descope.com/accessKeys) |
+| `CLIENT_ID` + `CLIENT_SECRET` | Access Key ID + Secret (returned once at creation) |
+| `POST /oauth/token` with `grant_type=client_credentials` | `descopeClient.auth.exchangeAccessKey(accessKey)` ([ref](https://docs.descope.com/management/m2m-access-keys)) |
+| Token scoped to `audience` | JWT with tenant/role claims (configure via Access Key settings) |
+| Token validated via `express-jwt` / JWKS | Token validated via `descopeClient.validateSession()` — same as user tokens |
+
+Access keys can also be created programmatically via `descopeClient.management.accessKey.create()`.
+
+### Email templates: Auth0 → Descope messaging templates
+
+Auth0 email templates (verification, password reset, invitation, blocked account) are configured in the Auth0 Dashboard under Branding → Email Templates.
+
+Descope uses [Messaging Templates](https://docs.descope.com/management/messaging-templates) configured per authentication method. Templates support HTML and dynamic content via `{{}}` placeholders.
+
+| Email type | Auth0 location | Descope location |
+|---|---|---|
+| Magic Link / OTP | Dashboard → Branding → Email Templates | Console → Settings → Authentication Methods → [Magic Link](https://docs.descope.com/auth-methods/magic-link/settings) or OTP → select connector → + New Template |
+| Password Reset | Dashboard → Branding → Email Templates | Console → Settings → Authentication Methods → [Passwords](https://docs.descope.com/auth-methods/passwords/settings) → Reset Password Email |
+| User Invitation | Dashboard → Branding → Email Templates | Console → [Project Settings → Sign Ups and User Invitations](https://docs.descope.com/management/project-settings#general-settings) → select connector → + New Template |
+| Verification | Dashboard → Branding → Email Templates | Handled within Flows (email verification is a Flow step, not a standalone email) |
+
+Descope also supports SMS and voice templates for OTP delivery, configured the same way via messaging connectors.
+
+### Webhooks / event streams: Auth0 Log Streams → Descope Audit Webhook
+
+Auth0 [Log Streams](https://auth0.com/docs/customize/log-streams) forward authentication events (login, failed login, signup, password change, etc.) to external services like Datadog, Splunk, or a custom webhook.
+
+Descope's equivalent is the [Audit Webhook Connector](https://docs.descope.com/connectors/connector-configuration-guides/network/audit-webhook). It streams audit events to your own HTTP endpoint. Configure it in the Console under Connectors → Audit Webhook with a base URL and authentication (Bearer, API Key, or Basic Auth).
+
+Descope also has a built-in [Audit Trail](https://docs.descope.com/audit) in the Console for viewing events, and supports streaming to third-party services via connectors.
+
+For Auth0 apps that rely on Log Streams for compliance or monitoring, set up the Audit Webhook Connector before cutover to avoid gaps in event logging.
+
+### Custom domains
+
+Auth0 supports [custom domains](https://auth0.com/docs/customize/custom-domains) so the login page appears on your own domain instead of `your-tenant.auth0.com`.
+
+Descope supports [custom domains](https://docs.descope.com/how-to-deploy-to-production/custom-domain) as well:
+1. Create a CNAME record (e.g. `auth.example.com`) pointing to `cname.descope.com` (US) or `CNAME.euc1.descope.com` (EU).
+2. Set the App URL in Console → Project Settings → General.
+3. Add and verify the custom domain in Console.
+4. Pass the custom domain as `baseUrl` to the Descope SDK/component: `<AuthProvider projectId="..." baseUrl="https://auth.example.com">`.
+
+If the Auth0 app uses a custom domain, plan this before cutover so cookies and redirects work correctly on the production domain.
+
+### Attack protection: Auth0 Attack Protection → Descope Flow-based security
+
+Auth0's [Attack Protection](https://auth0.com/docs/secure/attack-protection) includes bot detection, brute force protection, breached password detection, and suspicious IP throttling as built-in toggles.
+
+Descope handles these through [Flows](https://docs.descope.com/flows) and security connectors, giving more granular control but requiring explicit configuration:
+
+| Auth0 feature | Descope equivalent |
+|---|---|
+| Bot Detection | Flow step using [Arkose Bot Manager connector](https://www.descope.com/blog/post/arkose-labs-connector), [Google reCAPTCHA Enterprise](https://docs.descope.com/connectors), or [Fingerprint](https://docs.descope.com/connectors) |
+| Brute Force Protection | Flow conditional logic + connector-based risk signals; rate limiting on Descope's infrastructure |
+| Breached Password Detection | [Have I Been Pwned integration](https://docs.descope.com/connectors) — blocks credentials found in known breaches |
+| Suspicious IP Throttling | Flow step using [AbuseIPDB connector](https://docs.descope.com/connectors) or IP-based conditional logic |
+
+Auth0's attack protection is toggle-based (on/off in Dashboard). Descope's is composable — you add detection steps to your Flow and configure the response (block, challenge with MFA, allow with logging). More powerful but not configured by default.
+
+### Testing checklist (applies to all samples)
+
+**Compile first — no env vars needed.** Run `npx tsc --noEmit` (or `go build ./...`, `dotnet build`, etc.) immediately after code changes, before setting up `.env` or starting the server. Do not treat the migration as done until this exits clean.
+
+After migrating, verify:
+- DS and DSR cookies are set after login (check browser DevTools → Application → Cookies)
+- Protected routes redirect to /login when DS cookie is absent
+- Protected routes render when DS cookie is present and valid
+- Logout clears both DS and DSR cookies
+- Logout invalidates the refresh token (logging in again requires re-authentication)
+- User claims (name, email, picture) display correctly
+- API routes return 401 when no token is provided
+- Expired session tokens are rejected (test by waiting or manually expiring)
+- If using RBAC: roles/permissions appear in validated JWT claims
+- If using FGA/ReBAC: authorization checks pass for permitted resources and fail for unpermitted ones
+- If using Outbound Apps: third-party tokens are retrievable after user connects
+
+---
+
+## Express.js
+
+
+**Changes:**
+- Removed [`express-openid-connect`](https://github.com/auth0/express-openid-connect). Added [`@descope/node-sdk`](https://github.com/descope/node-sdk) and `cookie-parser`.
+- Replaced `app.use(auth(config))` with custom middleware (~20 lines) that validates the `DS` cookie via [`validateSession()`](https://docs.descope.com/getting-started/nodejs#implement-session-validation).
+- Added `/login` route rendering an EJS page with [`<descope-wc>`](https://docs.descope.com/client-sdk/descope-components#descope-component).
+- Logout changed from GET redirect to Auth0's `/v2/logout` to POST calling [`descopeClient.logout()`](https://docs.descope.com/authorization/session-management/session-validation/backend#logout-current-session-using-backend-sdk) + cookie clearing.
+- `requiresAuth()` is a custom 3-line function instead of an [Auth0 SDK import](https://github.com/auth0/express-openid-connect#readme).
+
+**Notes:**
+- `express-openid-connect` auto-configured `baseURL` from env vars and handled CSRF for the callback. Descope needs none of that since there's no server-side OAuth flow.
+- Auth0's `req.oidc.user` comes from ID token claims. Descope's `authInfo.token` after [`validateSession()`](https://docs.descope.com/authorization/session-management/session-validation/backend#validate-session) holds decoded JWT claims of the session token.
+
+**Limitation:**
+- The Descope web component requires JavaScript. Auth0's redirect flow worked without client-side JS. For JS-free auth, use [Descope as an OIDC provider](https://docs.descope.com/getting-started/oidc-endpoints) and implement the redirect flow manually.
+
+---
+
+## Flask / Python
+
+
+**Changes:**
+- Removed [`authlib`](https://docs.authlib.org/en/latest/client/flask.html); added [`descope`](https://github.com/descope/python-sdk).
+- Removed OAuth client registration (`oauth.register("auth0", ...)`) and redirect-based flow code.
+- Removed `/callback` route. No code exchange needed.
+- `/login` renders a template with the [Descope web component](https://docs.descope.com/client-sdk/descope-components#descope-component) instead of calling `oauth.auth0.authorize_redirect()`.
+- `/logout` changed from redirect to Auth0's `/v2/logout?returnTo=...&client_id=...` to [`descope_client.logout(refresh_token)`](https://docs.descope.com/authorization/session-management/session-validation/backend#logout-current-session-using-backend-sdk) + cookie deletion.
+- Home route reads `DS` cookie from `request.cookies`, validates with [`descope_client.validate_session()`](https://docs.descope.com/getting-started/python#implement-session-validation).
+
+**Notes:**
+- Auth0's authlib integration stores the full token response (`access_token`, `id_token`, `userinfo`) in Flask's server-side `session` ([authlib Flask OAuth docs](https://docs.authlib.org/en/latest/client/flask.html)). Descope doesn't use Flask sessions. State lives in client-side cookies. You can drop `session` from Flask imports; `APP_SECRET_KEY` becomes optional.
+- `validate_session` returns a dict-like object. JWT standard claims (`sub`, `name`, `email`) are present. Custom claims from [Descope's JWT Templates](https://docs.descope.com/management/jwt-templates) also appear here.
+- The `descope` Python SDK requires Python 3.7+. `authlib` supported older versions.
+
+**Limitation:**
+- Descope's Python SDK docs don't detail `validate_session()`'s return type beyond "jwt_response." It's a dict with JWT claims in practice, but official type annotations lag behind. Ref: [Descope Python SDK](https://github.com/descope/python-sdk), [Python quickstart](https://docs.descope.com/getting-started/python).
+
+---
+
+## Next.js (standalone)
+
+
+**Changes:**
+- [`@auth0/nextjs-auth0`](https://github.com/auth0/nextjs-auth0) → [`@descope/nextjs-sdk`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk).
+- `UserProvider` → [`AuthProvider`](https://docs.descope.com/client-sdk/descope-components#auth-provider) (takes `projectId` prop; Auth0's reads from env vars automatically).
+- `useUser()` → [`useSession()`](https://docs.descope.com/client-sdk/auth-helpers#booleans) + [`useUser()`](https://docs.descope.com/client-sdk/auth-helpers#core-sdk-functions) (Auth0 combines these; Descope separates session state from user data).
+- Removed `pages/api/auth/[...auth0].tsx` catch-all route. In [Auth0 v4 this became automatic middleware](https://github.com/auth0/nextjs-auth0/blob/main/V4_MIGRATION_GUIDE.md), but with Descope there's no server-side OIDC handling at all.
+- Added `pages/login.tsx` with [`<Descope>` component](https://docs.descope.com/client-sdk/descope-components#descope-component) rendering the `sign-up-or-in` flow.
+- `withPageAuthRequired` (client) replaced by manual `useSession()` check + redirect to `/login`. Auth0 v4 [deprecated `withPageAuthRequired`](https://github.com/auth0/nextjs-auth0/blob/main/V4_MIGRATION_GUIDE.md) in favor of `getSession()` anyway.
+- `withApiAuthRequired` replaced by server-side `session()` + manual 401 response. Descope's Next.js SDK exposes [`session()`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#server-side) for this.
+- Logout changed from `<a href="/api/auth/logout">` to a button calling [`sdk.logout()`](https://docs.descope.com/client-sdk/auth-helpers#logout) via [`useDescope()`](https://docs.descope.com/client-sdk/auth-helpers#core-sdk-functions).
+
+**Notes:**
+- Auth0 provides `withPageAuthRequired` as both a client-side HOC and a `getServerSideProps` wrapper. Descope's Next.js SDK has no equivalent HOC. You check `isAuthenticated` from `useSession()` and redirect yourself. More verbose, more explicit.
+- `NEXT_PUBLIC_` prefix is required on the project ID because [`AuthProvider`](https://docs.descope.com/client-sdk/descope-components#auth-provider) runs client-side.
+- Both CSR and SSR protected pages are preserved: client-side uses `useSession()`, server-side uses `session()` from the [Next.js SDK server helpers](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#server-side).
+- Auth0's `withApiAuthRequired` wraps the handler. Descope: call `session()` at handler top, return 401 yourself.
+- `User` interface: removed `nickname`, `email_verified`, `updated_at`; `sub` → `userId`.
+
+---
+
+## Next.js (B2B SaaS / Multi-tenant)
+
+
+This section documents bugs discovered during a migration review of a reference Next.js B2B SaaS
+app. Every error below traces to incorrect assumptions about the `@descope/nextjs-sdk` API surface.
+
+**Root cause:** The migration generated code against an assumed API that doesn't match what
+`@descope/nextjs-sdk` actually exports. Every error below stems from not verifying the SDK's
+`.d.ts` before generating imports and wrapper types.
+
+---
+
+### Bug 1: `getServerSession` doesn't exist — correct export is `session`
+
+The migration generated:
+```ts
+import { getServerSession } from "@descope/nextjs-sdk/server"
+const session = await getServerSession()
+```
+
+`getServerSession` does not exist in `@descope/nextjs-sdk`. The server entry exports two functions:
+- **`session(config?)`** — reads the session from request headers/cookies in a Next.js server component or server action. No arguments required. Returns `AuthenticationInfo | undefined`.
+- **`getSession(req, config?)`** — reads from an explicit `NextApiRequest` object. Intended for API routes only.
+
+The correct replacement for the Auth0 `getServerSideSession()` pattern (server component, no req argument) is `session`, not `getServerSession`. The name was invented by analogy, not verified.
+
+**Fix:** Verify exports before writing any import. For this SDK:
+```ts
+// Server component / server action (no req argument needed):
+import { session } from "@descope/nextjs-sdk/server"
+const authInfo = await session()
+
+// Or wrap it into the project's own session type:
+import { session as sdkSession } from "@descope/nextjs-sdk/server"
+```
+
+---
+
+### Bug 2: Return type is `AuthenticationInfo`, not an `{isAuthenticated, claims, token}` shape
+
+The migration generated a `DescopeSession` interface shaped like Auth0's session object:
+```ts
+interface DescopeSession {
+  isAuthenticated: boolean   // ← does not exist
+  token: string              // ← misleading: this was meant to be the raw JWT
+  claims: {                  // ← does not exist; decoded JWT lives under "token"
+    sub: string
+    email?: string
+    tenants?: Record<string, { roles: string[] }>
+    ...
+  }
+}
+```
+
+`session()` returns `AuthenticationInfo` from `@descope/node-sdk`, which is:
+```ts
+interface AuthenticationInfo {
+  jwt: string          // raw session JWT string
+  token: Token         // decoded JWT claims: { sub?, exp?, iss?, [claim: string]: unknown }
+  cookies?: string[]
+}
+```
+
+Key mismatches:
+- `isAuthenticated` — not present. `undefined` return means unauthenticated; a non-null object means authenticated.
+- `claims` — not present. Decoded claims are on `token`.
+- `token` (as JWT string) — not present as `token`; the raw JWT is `jwt`.
+
+Because the cast was `session as unknown as DescopeSession`, TypeScript didn't catch this. At runtime:
+- Every `!session?.isAuthenticated` check would always be `true` (property doesn't exist), making every auth guard fail.
+- Every `session.claims.sub` / `session.claims.email` would return `undefined`.
+
+**Fix:** Create a typed adapter that maps `AuthenticationInfo` to a stable internal type:
+```ts
+import { session as sdkSession } from "@descope/nextjs-sdk/server"
+import type { AuthenticationInfo } from "@descope/node-sdk"
+
+export interface DescopeSession {
+  isAuthenticated: boolean
+  jwt: string
+  token: {
+    sub: string
+    email?: string
+    name?: string
+    tenants?: Record<string, { roles: string[]; permissions: string[] }>
+    [key: string]: unknown
+  }
+}
+
+export async function getDescopeSession(): Promise<DescopeSession | null> {
+  const authInfo = await sdkSession()
+  if (!authInfo) return null
+  return {
+    isAuthenticated: true,
+    jwt: authInfo.jwt,
+    token: authInfo.token as DescopeSession["token"],
+  }
+}
+```
+
+---
+
+### Bug 3: `cookies()` from `next/headers` is async in Next.js 15
+
+The migration generated:
+```ts
+import { cookies } from "next/headers"
+
+export function getActiveTenantId(session: DescopeSession): string | null {
+  const cookieStore = cookies()   // ← synchronous call; wrong in Next.js 15
+  ...
+}
+```
+
+In Next.js 15, `cookies()` is async and returns `Promise<ReadonlyRequestCookies>`. The synchronous call compiles (TypeScript doesn't catch it because `cookies()` appears to return `ReadonlyRequestCookies` directly in older types) but throws at runtime.
+
+**Fix:** Check the target project's Next.js version before generating cookie/header reads. For Next.js 15+:
+```ts
+export async function getActiveTenantId(session: DescopeSession): Promise<string | null> {
+  const cookieStore = await cookies()
+  ...
+}
+```
+
+---
+
+### Bug 4: Making a helper async cascades to all callers — trace the dependency chain
+
+When `getActiveTenantId` became async, the following chain all needed `async`/`await`:
+1. `getActiveTenantId` → async
+2. `getActiveTenantRoles` (calls `getActiveTenantId`) → async
+3. `getRole` in `lib/roles.ts` (calls `getActiveTenantRoles`) → async
+4. All call sites in server components and server actions → add `await`
+
+This affected 20+ call sites across the project. The migration generated none of them as async, so adding `await cookies()` would have broken the entire tenant-aware authorization layer silently (TypeScript accepts `await` on non-Promise values without error).
+
+**Practice:** When making any shared helper async, immediately grep all call sites and propagate `async`/`await` before finishing the edit.
+
+---
+
+### Summary: what to verify before generating Next.js + `@descope/nextjs-sdk` code
+
+1. **Export names:** Resolve `node_modules/@descope/nextjs-sdk/dist/types/server/*.d.ts` and confirm the exact function names before writing any import.
+2. **Return type:** `session()` returns `AuthenticationInfo | undefined` from `@descope/node-sdk`, not a boolean-flagged Auth0-style session object.
+3. **isAuthenticated:** Does not exist on `AuthenticationInfo`. Unauthenticated = `undefined`; authenticated = non-null object.
+4. **claims vs token:** Decoded JWT claims are under `.token` (a `Token` object), not `.claims`. Raw JWT string is under `.jwt`.
+5. **Next.js version:** Check `package.json` for Next.js ≥ 15. If so, `cookies()` and `headers()` from `next/headers` are async — all consumers must be async.
+6. **Async cascade:** Tracing async upward from `cookies()` may require updating 10+ files. Plan for it.
+
+---
+
+## Next.js (with separate Express API server)
+
+
+**Changes:**
+- [`@auth0/nextjs-auth0`](https://github.com/auth0/nextjs-auth0) v4 → [`@descope/nextjs-sdk`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk) + [`@descope/node-sdk`](https://github.com/descope/node-sdk) (two packages: client SDK for Next.js, node SDK for the API server).
+- `Auth0Client` from `@auth0/nextjs-auth0/server` → singleton `getDescopeClient()` using `@descope/node-sdk`.
+- Removed Auth0's catch-all middleware that [auto-handled `/auth/*` routes in v4](https://github.com/auth0/nextjs-auth0/blob/main/V4_MIGRATION_GUIDE.md). Replaced with Next.js middleware using Descope's [`authMiddleware()`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#middleware) to check the `DS` cookie and redirect unauthenticated users.
+- Express API server (`api-server.js`): replaced [`express-jwt`](https://github.com/auth0/express-jwt) + [`jwks-rsa`](https://github.com/auth0/node-jwks-rsa) with `@descope/node-sdk` [`validateSession()`](https://docs.descope.com/authorization/session-management/session-validation/backend#validate-session).
+- Added `/login` page with [`<Descope>` React component](https://docs.descope.com/client-sdk/descope-components#descope-component).
+
+**Access token proxying changes:**
+Auth0's `auth0.getAccessToken()` returns a separate access token (scoped to `AUTH0_AUDIENCE`) passed to the external API as a Bearer token. The API server validates it against Auth0's JWKS endpoint via [`express-jwt`](https://github.com/auth0/express-jwt).
+
+Descope has no separate access token. The session token (DS cookie) is the token you pass to the API server. The Next.js API route reads `DS` from cookies and forwards it as `Authorization: Bearer <DS>`. The API server validates it with `descopeClient.validateSession(token)`.
+
+`AUTH0_AUDIENCE` and `AUTH0_SCOPE` env vars disappear. For audience validation with Descope, configure a custom `aud` claim in the Descope Console's [JWT Templates](https://docs.descope.com/management/jwt-templates) and pass the `audience` parameter to [`validateSession()`](https://docs.descope.com/getting-started/nodejs#implement-session-validation).
+
+**Notes:**
+- Auth0 v4's `Auth0Client` manages OIDC discovery, token caching, and session cookies. Descope's `DescopeClient` validates JWTs against [cached public keys](https://docs.descope.com/authorization/session-management/session-validation/backend/offline-jwt-validation). The frontend ([Descope Flows](https://docs.descope.com/flows)) handles what `Auth0Client` used to do.
+- [`jwks-rsa`](https://github.com/auth0/node-jwks-rsa) fetches and caches JWKS from Auth0's `/.well-known/jwks.json`. Descope's Node SDK does the same from `https://api.descope.com/v2/keys/<project_id>` ([ref](https://docs.descope.com/authorization/session-management/session-validation/backend/offline-jwt-validation#finding-your-public-key)). No configuration needed.
+- Removing `express-jwt` + `jwks-rsa` cuts 2 dependencies and ~15 lines of JWKS config. The Descope replacement is ~15 lines of middleware calling `validateSession()`.
+
+**Limitation:**
+- The original API server validated the `audience` claim (ensuring the token targeted this API). Descope's `validateSession()` checks signature and expiry but skips audience by default. To replicate: (1) configure `aud` in [Descope's JWT Templates](https://docs.descope.com/management/jwt-templates), (2) pass `audience` to `validateSession()` ([Node SDK docs](https://docs.descope.com/getting-started/nodejs#implement-session-validation)). Easy to miss during migration.
+
+---
+
+## Go + Encore
+
+
+**Changes:**
+- Backend gutted: 4 auth endpoints (Login, Callback, Logout, AuthHandler) at ~150 lines of Go → 1 endpoint (AuthHandler, ~25 lines) validating DS session tokens with the [Descope Go SDK](https://github.com/descope/go-sdk).
+- Removed `backend/auth/authenticator.go` (OIDC provider setup via [`go-oidc`](https://github.com/coreos/go-oidc), OAuth2 config, code exchange). Not needed.
+- Frontend removed 3 API routes (`/auth/login`, `/auth/logout`, `/callback`). Replaced with `/login` page containing [`<Descope>` component](https://docs.descope.com/client-sdk/descope-components#descope-component) and client-side `LogoutButton` using [`useDescope().logout()`](https://docs.descope.com/client-sdk/auth-helpers#logout).
+- `getRequestClient.ts` reads `DS` cookie instead of custom `auth-token` cookie.
+- Generated Encore client (`client.ts`) simplified: auth service methods (Login, Logout, Callback) removed since those backend endpoints are gone.
+
+**Two-process architecture:**
+The original split auth between Go backend (OIDC/code exchange/token verification) and Next.js frontend (redirect orchestration). With Descope, auth is client-side. The Go backend validates tokens only. The split is cleaner: backend is a pure API, frontend owns auth UX.
+
+Cookie name changed from `auth-token` (custom, set by callback route) to `DS` (Descope standard). `getRequestClient.ts` extracts this and passes it as Bearer token in the `Authorization` header. Encore's [`//encore:authhandler`](https://encore.dev/docs/go/primitives/defining-apis#access-controls) intercepts it.
+
+**Notes:**
+- Go SDK constructor: `client.NewWithConfig(&client.Config{ProjectID: "..."})`. Session validation: [`descopeClient.Auth.ValidateSessionWithToken(ctx, token)`](https://docs.descope.com/getting-started/go#implement-session-validation) returns `(bool, *descope.Token, error)`. `Token.Claims` is `map[string]interface{}`. Ref: [Descope Go SDK](https://github.com/descope/go-sdk).
+- Encore's `//encore:authhandler` expects `(auth.UID, error)`. Descope's JWT `sub` claim maps to `auth.UID`. Same claim name as Auth0, different issuer.
+- `encore.cue` config: ClientID + ClientSecret + Domain + RedirectURL → ProjectID only.
+- `go.mod`: [`coreos/go-oidc/v3`](https://github.com/coreos/go-oidc) + `golang.org/x/oauth2` → [`descope/go-sdk`](https://github.com/descope/go-sdk). Fewer dependencies.
+
+**Limitation:**
+- The Go SDK's exported type names (`client.DescopeClient`, `descope.Token`) aren't documented in Descope's official docs. The [Go quickstart](https://docs.descope.com/getting-started/go) shows usage patterns, not Go type signatures. Types in this migration are inferred from [Go SDK README](https://github.com/descope/go-sdk#readme) examples; verify against `go doc` output.
+- Encore's `//encore:service` init pattern (`initService()`) creates the Descope client at service startup. If Encore's lifecycle skips `initService`, the client won't exist. Same risk the original had with the OIDC authenticator.
+
+---
+
+## Agentic AI Stacks (LangChain / LangGraph + FGA + Token Vault)
+
+
+Three sub-projects (`py-langchain`, `ts-langchain`, `ts-vercel-ai`) sharing the same architecture: a document RAG app with an AI agent that accesses third-party services (Google Calendar, Gmail, GitHub, Slack) and processes purchases.
+
+### Architecture overview
+
+| Layer | Auth0 component | Descope equivalent | Migration difficulty |
+|---|---|---|---|
+| Authentication (login/session) | `@auth0/nextjs-auth0` v4, `auth0-fastapi` | `@descope/nextjs-sdk`, Descope Python SDK + custom FastAPI JWT authorizer | Low: same patterns as the framework sections above |
+| Fine-grained authorization | Auth0 FGA (OpenFGA) via `@openfga/sdk` + `@auth0/ai` `FGARetriever` | Descope ReBAC via `management.fga.*` + custom retriever | Medium: API shape differs, no `FGARetriever` |
+| Third-party token storage | Auth0 Token Vault / Connected Accounts | Descope Outbound Apps | Medium: API differs, no AI-framework wrapper |
+| Async user approval | Auth0 CIBA via `@auth0/ai` `withAsyncAuthorization()` | No equivalent; custom implementation needed | High |
+| AI tool authorization wrappers | `@auth0/ai-langchain`, `@auth0/ai-vercel` | No equivalent; custom wrappers needed | High |
+
+### Auth0 integration points across sub-projects
+
+**py-langchain** (FastAPI + LangGraph Python):
+- `auth0-fastapi` provides `AuthConfig`, `AuthClient`, session middleware, `/api/auth/*` routes, `require_session` dependency
+- `auth0-ai` Python SDK provides `Auth0AI`, `with_token_vault()`, `with_async_authorization()`
+- `auth0-ai-langchain` provides `FGARetriever`, `get_access_token_from_token_vault()`
+- `openfga-sdk` for direct FGA tuple writes/deletes in document management
+- LangGraph receives credentials via `config["configurable"]["_credentials"]` (injected by FastAPI proxy route)
+- Frontend is a Vite React SPA; auth is cookie-based via `withCredentials: true` on axios
+
+**ts-langchain** (Next.js + LangGraph TS):
+- `@auth0/nextjs-auth0` v4 with `Auth0Client`, `enableConnectAccountEndpoint`, `getAccessToken()`, `getSession()`
+- `@auth0/ai-langchain` provides `Auth0AI`, `withTokenVault()`, `withAsyncAuthorization()`, `FGARetriever`, `getAccessTokenFromTokenVault()`
+- LangGraph custom auth handler (`auth.ts`) validates JWTs against Auth0 JWKS, attaches `getRawAccessToken()` to context
+- `langgraph-nextjs-api-passthrough` proxies requests with Auth0 access token + user object injected
+- Connected Accounts API uses `https://DOMAIN/me/v1/connected-accounts/accounts` with scoped tokens
+- Uses `AUTH0_CUSTOM_API_CLIENT_ID`/`SECRET` for Token Vault federated token exchange
+
+**ts-vercel-ai** (Next.js + Vercel AI SDK):
+- Same auth setup as ts-langchain but uses Vercel AI SDK instead of LangGraph
+- `@auth0/ai-vercel` replaces `@auth0/ai-langchain` for tool wrapping
+- Tool authorization patterns are identical; the runtime difference is Vercel AI SDK vs LangGraph
+
+### FGA schema (shared across all three)
+
+```
+type user
+type doc
+  relations
+    define owner: [user]
+    define viewer: [user, user:*]
+    define can_view: owner or viewer
+```
+
+Documents are created with `owner` relation. Sharing adds `viewer` relations. RAG retrieval filters via `can_view` check. Delete removes all relations.
+
+Descope ReBAC equivalent schema ([DSL format](https://docs.descope.com/authorization/rebac/define-schema)):
+```
+model AuthZ 1.0
+
+type user
+
+type doc
+  relation owner: user
+  relation viewer: user
+  permission can_view: owner or viewer
+```
+
+### Credential flow (all three sub-projects)
+
+```
+Frontend (browser)
+  → cookies sent with request
+    → Next.js/FastAPI middleware validates session
+      → extracts access_token + user from session
+        → injects into LangGraph config as _credentials
+          → tool reads _credentials to:
+            a) call Auth0 /userinfo (user_info tool)
+            b) exchange via Token Vault (google_calendar, gmail, github, slack tools)
+            c) get CIBA approval token (shop_online tool)
+            d) build FGA check query with user email (context_docs tool)
+```
+
+With Descope, step (a) changes to reading claims from the validated session token (no `/userinfo` call needed since claims are in the JWT). Steps (b-d) require custom implementations using Descope Outbound Apps API, a custom approval mechanism, and Descope ReBAC API respectively.
+
+### Migration strategy notes
+
+The authentication layer (login, session, middleware) follows the same patterns as the framework sections above. The complexity is in the four Auth0 product integrations layered on top.
+
+Recommended migration order:
+1. Swap auth layer first (auth0-fastapi/nextjs-auth0 to Descope SDKs). Low risk, proven patterns.
+2. Migrate FGA to Descope ReBAC. Moderate lift; the API shape changes but the capability is equivalent.
+3. Migrate Token Vault to Outbound Apps. Moderate lift; needs custom tool wrappers.
+4. Build custom CIBA replacement. Highest risk; no direct equivalent.

--- a/skills/auth0-to-descope/references/implementation-nuances.md
+++ b/skills/auth0-to-descope/references/implementation-nuances.md
@@ -1,6 +1,61 @@
 # Descope Migration: Implementation Notes
 
+## Contents
+
+**General Insights — Architecture & Flow**
+- [Auth0 owns the flow; Descope validates tokens](#auth0-owns-the-flow-descope-validates-tokens)
+- [OIDC compatibility path](#oidc-compatibility-path-alternative-to-full-migration)
+- [No drop-in middleware for Express or Flask](#no-drop-in-middleware-for-express-or-flask)
+- [Fewer network round-trips at login](#fewer-network-round-trips-at-login)
+- [Auth0 vs Descope flow comparison](#auth0-vs-descope-flow-comparison)
+
+**General Insights — Feature Mapping: Auth0 → Descope**
+- [Social login / connection mapping + SSO URLs](#social-login--connection-mapping)
+- [RBAC: Auth0 → Descope](#rbac-auth0--descope)
+- [Multi-tenancy: Auth0 Organizations → Descope Tenants](#multi-tenancy-auth0-organizations--descope-tenants)
+- [Invitation model](#invitation-model-auth0-invitations--descope-userinvite)
+- [MFA enrollment and factor management](#mfa-enrollment-and-factor-management)
+- [SCIM: HTTP API only, not in SDK](#scim-http-api-only-not-in-sdk)
+- [Session refresh after profile changes + sdk.refresh()](#session-refresh-after-profile-changes)
+- [Management API mapping](#management-api-mapping)
+- [FGA: Auth0 FGA (OpenFGA) → Descope ReBAC](#fga-auth0-fga-openfga--descope-rebac)
+- [Token Vault / Connected Accounts → Descope Outbound Apps](#token-vault--connected-accounts--descope-outbound-apps)
+- [CIBA / Rich Authorization Requests (no equivalent)](#ciba--rich-authorization-requests-no-descope-equivalent)
+- [@auth0/ai SDK (no equivalent)](#auth0ai-sdk-no-descope-equivalent)
+- [User migration: Auth0 export → Descope import](#user-migration-auth0-export--descope-import)
+- [M2M: Auth0 client credentials → Descope Access Keys](#m2m-authentication-auth0-client-credentials--descope-access-keys)
+- [Email templates](#email-templates-auth0--descope-messaging-templates)
+- [Webhooks / Log Streams → Descope Audit Webhook](#webhooks--event-streams-auth0-log-streams--descope-audit-webhook)
+- [Custom domains](#custom-domains)
+- [Attack protection](#attack-protection-auth0-attack-protection--descope-flow-based-security)
+- [Testing checklist](#testing-checklist-applies-to-all-samples)
+
+**General Insights — Common Gotchas**
+- [Cookie names: DS and DSR](#cookie-names-ds-and-dsr-configurable)
+- [User claims differ (dct, tenants, email not default)](#user-claims-differ)
+- [Audience validation requires explicit setup](#audience-validation-requires-explicit-setup)
+- [One session token, not two](#auth0-separate-access-tokens--descope-session-token-reuse)
+- [Logout requires two steps](#logout-requires-two-steps)
+- [One env var instead of five](#one-env-var-instead-of-five)
+- [Auth0 Actions/Rules → Flows + JWT Templates](#auth0-actionsrules--descope-flows--jwt-templates)
+- [authRequired: false needs manual replication](#authrequired-false-needs-manual-replication)
+
+**Framework Sections**
+- [Express.js](#expressjs)
+- [Flask / Python](#flask--python)
+- [Next.js (standalone)](#nextjs-standalone)
+- [Next.js (B2B): Migration Bug Catalog](#nextjs-b2b-migration-bug-catalog)
+- [Next.js (with separate Express API server)](#nextjs-with-separate-express-api-server)
+- [Go + Encore](#go--encore)
+- [Agentic AI Stacks (LangChain / LangGraph + FGA + Token Vault)](#agentic-ai-stacks-langchain--langgraph--fga--token-vault)
+
+> **See also:** `flows-and-widgets.md` in this directory — Auth0→Descope lingo map, Flow structure and templates, Widget types, SSO Setup Suite, and the Console-vs-code decision guide. Read it before migrating any auth UI, MFA enrollment, user management pages, or SSO configuration.
+
+---
+
 ## General Insights
+
+**— Architecture & Flow —**
 
 ### Auth0 owns the flow; Descope validates tokens
 
@@ -26,6 +81,8 @@ Descope exposes standard [OIDC endpoints](https://docs.descope.com/getting-start
 | Revocation | `https://api.descope.com/oauth2/v1/revoke` |
 
 An app using `express-openid-connect` could swap `ISSUER_BASE_URL` from `https://YOUR_AUTH0_DOMAIN` to `https://api.descope.com` and keep the existing OIDC client code intact. Differences in claim shapes (`nickname`, `email_verified` vs `verifiedEmail`), token lifetimes, and configuration semantics mean the OIDC swap still requires testing and adjustments. Still, it's a viable incremental path: swap the IdP first, then refactor to Descope-native SDKs later.
+
+**— Common Gotchas —**
 
 ### No drop-in middleware for Express or Flask
 
@@ -62,7 +119,7 @@ The default Descope session JWT ([structure ref](https://docs.descope.com/author
 | Email verified | `email_verified` | Not in JWT by default. Available on user object as `verifiedEmail`. Add to JWT via Custom Claims if needed. |
 | Roles | Via `https://DOMAIN/roles` namespace claim (added by Auth0 Actions) | `roles` array in JWT (embedded by default with [RBAC](https://docs.descope.com/authorization/role-based-access-control)) |
 | Permissions | Via namespace claim or `permissions` array (added by Actions) | `permissions` array in JWT (embedded by default) |
-| Tenant | `org_id` (Auth0 Organizations) | `tenants` object with per-tenant roles ([ref](https://docs.descope.com/authorization/role-based-access-control#tenants-and-roles)) |
+| Tenant ID | `org_id` (flat string) | `dct` — flat string with active tenant ID, direct `org_id` equivalent; `tenants` — object keyed by tenant ID containing per-tenant `roles` and `permissions`. Use `dct` when you only need the ID; use `tenants` when you need per-tenant roles ([ref](https://docs.descope.com/authorization/role-based-access-control#tenants-and-roles)) |
 
 `nickname` is Auth0-specific (derived from the email prefix). Descope lacks it. Fall back to `name`.
 
@@ -117,6 +174,8 @@ Auth0 Actions are imperative Node.js code. Descope Flows are declarative and vis
 
 Auth0's `express-openid-connect` supports [`authRequired: false`](https://github.com/auth0/express-openid-connect#readme) globally: unauthenticated users browse freely, the middleware skips populating `req.oidc.user`. Descope equivalent: your session middleware catches validation errors and sets `req.isAuthenticated = false` instead of returning 401.
 
+**— Feature Mapping: Auth0 → Descope —**
+
 ### Social login / connection mapping
 
 Auth0 [Social Connections](https://auth0.com/docs/authenticate/identity-providers/social-identity-providers) (Google, GitHub, Facebook, etc.) are configured in the Auth0 dashboard and appear automatically on the Universal Login page.
@@ -124,6 +183,15 @@ Auth0 [Social Connections](https://auth0.com/docs/authenticate/identity-provider
 Descope equivalent: configure [social auth methods](https://docs.descope.com/authentication/social) in the Descope Console, then add them to a [Flow](https://docs.descope.com/flows). The Descope web component renders the configured providers. No code changes needed; configuration only.
 
 SAML/OIDC enterprise connections in Auth0 map to Descope's [SSO configuration](https://docs.descope.com/sso) (per-tenant SSO for B2B). Auth0 Organizations' per-org connections map to Descope's per-tenant SSO settings.
+
+**SSO Setup Suite:** For apps that expose a self-service SSO settings page where tenant admins configure their IdP, the SSO Setup Suite (Console wizard) can replace `sso.configureSAMLByTenant()` / `configureOIDCByTenant()` calls entirely — tenant admins configure their own IdP through a guided wizard with no engineering involvement. Surface this before migrating any Management SDK SSO code. See `flows-and-widgets.md` → SSO Setup Suite.
+
+**SSO callback and ACS URLs:**
+- Social OAuth callback (Google, GitHub, etc.): `https://api.descope.com/v1/oauth/callback`
+- SAML ACS URL (per-tenant enterprise SSO): found in Console → SSO → [tenant] → SP Settings — tenant-specific, not a global hardcoded URL
+- OIDC authorization server endpoints (Descope acting as IdP): `/oauth2/v1/authorize`, `/oauth2/v1/token` — already in the OIDC compatibility table above
+
+`https://api.descope.com/oauth2/v1/callback` does not exist — do not use it as a callback URL when configuring an IdP.
 
 ### RBAC: Auth0 → Descope
 
@@ -147,6 +215,7 @@ Key differences:
 - Auth0 requires organization-scoped login via `organization` parameter. Descope routes by email domain or tenant-specific login URLs ([ref](https://docs.descope.com/sso/multi-sso)).
 - Descope supports tenant-level SSO enforcement (require SAML/OIDC for all users in a tenant) ([ref](https://docs.descope.com/management/tenant-management/tenant)).
 - Users are project-level entities in Descope; they're associated with tenants, not created per-tenant.
+- **Finding a user's tenants**: use `management.user.load(loginId)` and read `.userTenants` — it lists only that user's tenants. Avoid `management.tenant.loadAll()` + client-side filter; it scans every tenant in the project (O(n)).
 - Auth0's org-scoped login issues a JWT with one `org_id`. Descope's JWT contains **all** tenants the user belongs to at once. Switching tenants does not require re-authentication — implement it client-side (e.g. an `active_tenant` cookie) and read the active tenant from the `tenants` object in the JWT.
 - When a tenant is created and the user is added via the Management SDK, the existing JWT is stale — the `tenants` claim was set at login and doesn't include the new tenant. The user must re-authenticate (clear `DS`/`DSR` cookies and redirect to login) to get a JWT with the updated tenant list. Without this, the app sees an empty `tenants` claim and may loop back to onboarding.
 
@@ -156,13 +225,37 @@ Auth0 Organizations have a dedicated invitation system with invitation objects, 
 
 Descope's `management.user.invite()` creates a user record immediately in `"invited"` status and sends an invitation email. There is no separate invitation object to list, update, or revoke independently. To list pending invitations for a tenant, filter users by `status === "invited"`. To revoke an invitation, delete the user.
 
+### MFA enrollment and factor management
+
+MFA enrollment is managed through Flows, not the Management SDK — there is no equivalent to Auth0 Guardian's `createEnrollmentTicket()`. Add an MFA step to a Flow in the Console; users enroll in-browser through the Flow component.
+
+**Factor deletion SDK support varies by type:**
+- **Passkeys**: `descopeClient.management.user.removeAllPasskeys(loginId)` — SDK-supported
+- **TOTP (authenticator apps)**: no SDK method; deletion is Console-only (User Management → [user] → Delete TOTP Seed)
+- **SMS/OTP factors**: no documented SDK method — may require REST API calls
+
 ### SCIM: HTTP API only, not in SDK
 
 Auth0 exposes SCIM configuration via the Management SDK (`managementClient.connections.createScimConfiguration()`, etc.). Descope supports SCIM but only via the HTTP API (`https://api.descope.com/v1/mgmt/scim/*`), not the Node.js or Python SDKs. Implement with raw `fetch()` calls. Verify the request/response shapes against the current API — the endpoints are documented but not SDK-wrapped.
 
 ### Session refresh after profile changes
 
-Auth0's `appClient.updateSession()` lets you immediately reflect profile changes (e.g. display name) in the cached session without re-authentication. Descope has no equivalent — profile changes via the Management SDK don't update the JWT. The user must wait for token refresh (if using DSR), sign out and back in, or call `refresh()` from the client SDK. Plan for this if the app has a profile editing flow that expects immediate UI updates.
+Auth0's `appClient.updateSession()` lets you immediately reflect profile changes in the cached session without re-authentication. Descope has no equivalent — profile changes via the Management SDK don't update the JWT already in the browser.
+
+To trigger an immediate client-side token refresh after a profile update:
+```ts
+// @descope/react-sdk, @descope/nextjs-sdk/client, or WebJS SDK
+const { refresh } = useDescope()
+await refresh()
+```
+
+The user can also wait for the next auto-refresh (default: ~5 min, driven by the DSR refresh token) or sign out and back in. Use the explicit `refresh()` call if the app has a profile editing page that expects immediate UI updates.
+
+**Session change event listeners** — instead of calling `refresh()` imperatively, subscribe to auth state changes via [docs.descope.com/client-sdk/auth-helpers#handling-authentication-state-changes](https://docs.descope.com/client-sdk/auth-helpers#handling-authentication-state-changes). Use event listeners when the session can change from multiple places (profile update, admin role grant, tenant assignment) and the UI needs to react consistently.
+
+**Update JWT endpoint** — for server-side custom claim updates without waiting for a client refresh: `POST /v1/mgmt/user/jwt/update`. This updates stored JWT custom claims for a specific user; it is not a session mutation and does not push an update to the browser. The user's next token refresh picks up the new claims. Verify the current endpoint behavior against Descope docs — this endpoint is less documented than the Management SDK methods.
+
+**User Profile Widget** — if the app is building a profile edit page, the Widget handles profile updates and session refresh automatically with no custom SDK calls. See `flows-and-widgets.md` → Widgets.
 
 ### Management API mapping
 
@@ -422,6 +515,15 @@ After migrating, verify:
 - `useUser()` → [`useSession()`](https://docs.descope.com/client-sdk/auth-helpers#booleans) + [`useUser()`](https://docs.descope.com/client-sdk/auth-helpers#core-sdk-functions) (Auth0 combines these; Descope separates session state from user data).
 - Removed `pages/api/auth/[...auth0].tsx` catch-all route. In [Auth0 v4 this became automatic middleware](https://github.com/auth0/nextjs-auth0/blob/main/V4_MIGRATION_GUIDE.md), but with Descope there's no server-side OIDC handling at all.
 - Added `pages/login.tsx` with [`<Descope>` component](https://docs.descope.com/client-sdk/descope-components#descope-component) rendering the `sign-up-or-in` flow.
+  - **`onSuccess` is required for redirect** — the component does not auto-navigate after login. Without it, the user finishes auth and stays on the login page:
+    ```tsx
+    const router = useRouter()
+    <Descope
+      flowId="sign-up-or-in"
+      onSuccess={() => router.push('/dashboard')}
+      onError={(e) => console.error(e)}
+    />
+    ```
 - `withPageAuthRequired` (client) replaced by manual `useSession()` check + redirect to `/login`. Auth0 v4 [deprecated `withPageAuthRequired`](https://github.com/auth0/nextjs-auth0/blob/main/V4_MIGRATION_GUIDE.md) in favor of `getSession()` anyway.
 - `withApiAuthRequired` replaced by server-side `session()` + manual 401 response. Descope's Next.js SDK exposes [`session()`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#server-side) for this.
 - Logout changed from `<a href="/api/auth/logout">` to a button calling [`sdk.logout()`](https://docs.descope.com/client-sdk/auth-helpers#logout) via [`useDescope()`](https://docs.descope.com/client-sdk/auth-helpers#core-sdk-functions).
@@ -429,13 +531,14 @@ After migrating, verify:
 **Notes:**
 - Auth0 provides `withPageAuthRequired` as both a client-side HOC and a `getServerSideProps` wrapper. Descope's Next.js SDK has no equivalent HOC. You check `isAuthenticated` from `useSession()` and redirect yourself. More verbose, more explicit.
 - `NEXT_PUBLIC_` prefix is required on the project ID because [`AuthProvider`](https://docs.descope.com/client-sdk/descope-components#auth-provider) runs client-side.
+- **Client vs. server session access:** `session()` from `@descope/nextjs-sdk/server` is for server components, server actions, and API routes **only**. In React client components, use `useSession()` + `useUser()` from `@descope/nextjs-sdk/client`. Using `session()` in a client component compiles but throws at runtime (attempts to read cookies in a browser context). Scan for this pattern before finishing any Next.js migration.
 - Both CSR and SSR protected pages are preserved: client-side uses `useSession()`, server-side uses `session()` from the [Next.js SDK server helpers](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#server-side).
 - Auth0's `withApiAuthRequired` wraps the handler. Descope: call `session()` at handler top, return 401 yourself.
 - `User` interface: removed `nickname`, `email_verified`, `updated_at`; `sub` → `userId`.
 
 ---
 
-## Next.js (B2B SaaS / Multi-tenant)
+## Next.js (B2B): Migration Bug Catalog
 
 
 This section documents bugs discovered during a migration review of a reference Next.js B2B SaaS


### PR DESCRIPTION
## Description

Provides new and potential customers with the ability to migrate their entire codebase from using Auth0 to Descope with any agent of their choice. 

Includes options for full or hybrid migrations, as well as migration evaluation, and user migration planning. These goals and preference are ascertained via built-in question; functionality may vary based on the harness/choice of AI coding tool.

## Must

- [x] Tests

This skill was tested on several auth0 sample codebases to gauge effectiveness; future iterations will have wider platform and language/framework support.
