### PR TITLE
feat: add auth-review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,40 @@ Integrate Descope authentication into applications with support for passwordless
 </details>
 
 <details>
+<summary><b>auth-review</b> — Static security review for authentication and authorization vulnerabilities</summary>
+
+Framework- and vendor-agnostic static review that enumerates every route/endpoint in a codebase, builds an authorization matrix, applies a vulnerability catalog (OWASP Web + API Top 10 identity categories), and writes a triage report ready to slice into GitHub issues or PRs.
+
+**Use when:**
+- "/auth-review"
+- "Audit authentication in my app"
+- "Find authorization bugs / IDOR / BOLA"
+- "Review access control"
+- "Identity security review before release"
+
+**Covers:**
+- Broken authentication (missing auth, weak password handling, SQLi-in-login, enumeration)
+- JWT / token flaws (`alg:none`, algorithm confusion, unverified decode, missing claim validation)
+- Session management (cookie flags, fixation, logout invalidation, predictable IDs)
+- Broken access control (IDOR / BOLA, BFLA, tenant crossing, client-trusted input)
+- Privilege escalation & mass assignment
+- OAuth / OIDC / SAML (state/PKCE, open redirect, ID-token validation, SAML XSW)
+- Password reset & account recovery (predictable/non-expiring tokens, host poisoning, MFA bypass)
+- MFA bypass and step-up gaps
+- Rate limiting & enumeration on auth surfaces
+- CSRF, CORS, identity-adjacent SSRF
+
+**Output:**
+- Triage report in `./auth-review/report-YYYY-MM-DD.md`
+- Endpoint inventory and authorization matrix
+- Findings with severity (High/Medium/Low), CWE, `file:line`, evidence, remediation
+- Pre-formatted issue bodies ready to paste into GitHub
+
+**Scope:** static and read-only. Does not run the target application, make network probes, modify code, or file issues directly.
+
+</details>
+
+<details>
 <summary><b>descope-terraform</b> — Manage Descope projects as infrastructure-as-code</summary>
 
 Manage Descope projects as infrastructure-as-code using the official [Terraform provider](https://registry.terraform.io/providers/descope/descope/latest/docs). Generates valid HCL configurations for authentication methods, RBAC, connectors, and project settings.
@@ -135,6 +169,27 @@ Add an HTTP connector and S3 audit logging to my Descope Terraform config
 
 </details>
 
+<details>
+<summary><b>auth-review examples</b></summary>
+
+```
+/auth-review
+```
+
+```
+Audit my app for authentication and authorization vulnerabilities
+```
+
+```
+Find IDOR and broken access control bugs in this repo
+```
+
+```
+Run an identity security review before I ship
+```
+
+</details>
+
 ## Compatible Agents
 
 Works with any agent supporting the Agent Skills format:
@@ -158,12 +213,19 @@ skills/
 │       ├── nextjs.md - Next.js App Router patterns
 │       ├── react.md - React SPA patterns
 │       └── backend.md - Node.js/Python validation
-└── descope-terraform/
-    ├── SKILL.md - Provider setup, common configurations, and guardrails
+├── descope-terraform/
+│   ├── SKILL.md - Provider setup, common configurations, and guardrails
+│   └── references/
+│       ├── project-resource.md - Full descope_project schema
+│       ├── other-resources.md - descope_management_key and descope_descoper schemas
+│       └── connectors.md - All 60+ supported connector types
+└── auth-review/
+    ├── SKILL.md - Four-phase workflow, severity scale, guardrails
     └── references/
-        ├── project-resource.md - Full descope_project schema
-        ├── other-resources.md - descope_management_key and descope_descoper schemas
-        └── connectors.md - All 60+ supported connector types
+        ├── enumeration.md - Entrypoint patterns across HTTP/GraphQL/WebSocket/RPC/serverless/queues
+        ├── vulnerability-catalog.md - AuthN, tokens, sessions, IDOR/BOLA, OAuth, recovery, MFA, CSRF/CORS
+        ├── authz-matrix.md - Matrix schema and expected-principal inference rules
+        └── report-template.md - Exact report structure and issue-ready finding format
 ```
 
 </details>

--- a/skills/auth-review/SKILL.md
+++ b/skills/auth-review/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: auth-review
+description: Static security review for authentication and authorization vulnerabilities. Use when the user invokes /auth-review, asks to audit auth, find identity breaches, review access control, hunt for IDOR/BOLA, or check authorization. Framework- and vendor-agnostic. Enumerates every route/endpoint, builds an authorization matrix, applies a vulnerability catalog, and writes a triage report ready to turn into issues or PRs.
+---
+
+# Auth Review
+
+Perform a **static, read-only** security review of authentication and authorization in the current codebase. Framework- and vendor-agnostic. Output: a triage report in `./auth-review/` with findings ready to file as issues or PRs.
+
+## When to Use
+
+- User invokes `/auth-review`.
+- Requests like "audit auth", "find authz bugs", "review access control", "check for IDOR", "identity security review".
+- Pre-release hardening or post-incident forensic code review focused on identity.
+
+## Workflow
+
+Run these phases **in order**. Do not skip ahead.
+
+### Phase 1 — Enumerate every entrypoint
+
+Identify every code path reachable by an external or semi-trusted caller. See `references/enumeration.md` for exhaustive patterns. A single repo often mixes HTTP, GraphQL, WebSocket, queue consumers, serverless handlers, and admin CLIs — list them all.
+
+**Deliverable:** an **Endpoint Inventory** table: `method`, `path / trigger`, `handler (file:line)`, `auth required? (y/n/unknown)`, `roles or scopes`, `notes`.
+
+Reconcile against router files, OpenAPI specs, and GraphQL schemas before moving on.
+
+### Phase 2 — Build the authorization matrix
+
+For each endpoint answer: *who should reach this, and what does the code actually enforce?* Use `references/authz-matrix.md` to infer the expected principal from conventions and classify gaps.
+
+**Deliverable:** an **Authorization Matrix** table: `endpoint`, `expected principal`, `enforced check (file:line)`, `gap`.
+
+### Phase 3 — Apply the vulnerability catalog
+
+Walk `references/vulnerability-catalog.md` category by category. For each, run the detection heuristics, then **read** the matched files to confirm. Never flag from a grep hit alone.
+
+Before calling a check missing, confirm no upstream middleware, decorator, guard, filter, interceptor, framework default, or reverse proxy enforces it. Trace at least one concrete caller path end-to-end for each finding. If a check is conditional, record the condition and whether an attacker controls it.
+
+### Phase 4 — Write the report
+
+Create `./auth-review/` if absent. Write to `./auth-review/report-YYYY-MM-DD.md` (append `-HHMM` if one already exists for today). Use the structure in `references/report-template.md`.
+
+The report must include:
+
+1. Executive summary with counts by severity.
+2. Endpoint inventory (Phase 1).
+3. Authorization matrix (Phase 2).
+4. Findings — each with title, severity, CWE, `file:line`, evidence, exploit reasoning, remediation.
+5. "Issues to file" — findings pre-formatted as ready-to-paste issue bodies.
+6. Open questions the maintainer must answer.
+
+After writing, summarize severity counts to the user and point at the file path. Do not create issues or PRs.
+
+## Severity Scale
+
+| Level  | Meaning |
+|--------|---------|
+| High   | Exploitable by unauthenticated or low-privilege attacker; leads to account takeover, data breach, privilege escalation, or tenant crossing. |
+| Medium | Requires specific conditions, partial impact, or defense-in-depth failure. |
+| Low    | Hardening recommendation; minor information disclosure; missing best practice. |
+
+Always include a CWE ID (e.g., CWE-287, CWE-639, CWE-862, CWE-863). Use identifiers from `references/vulnerability-catalog.md` — do not invent IDs.
+
+## DO NOT
+
+- DO NOT modify source code. This skill is read-only.
+- DO NOT execute the application, run network probes, or make outbound requests.
+- DO NOT report a finding without a `file.ext:line` reference and evidence snippet.
+- DO NOT flag a missing check before confirming no upstream middleware, guard, decorator, or proxy enforces it.
+- DO NOT invent CWE IDs, CVSS scores, or framework behaviors — if unsure, mark the finding "unconfirmed" and move it to Open Questions.
+- DO NOT include secrets, tokens, private keys, or real user data in the report. Redact as `[REDACTED]`.
+- DO NOT commit the report to git unless the user asks.
+- DO NOT create GitHub issues or PRs directly. Output issue-ready text and let the user file them.
+- DO NOT stop after finding one bug. Enumerate everything, then report.
+- DO NOT trust code comments or documentation over the code itself. A comment saying "admin only" is not a security control.
+
+## References
+
+- `references/enumeration.md` — entrypoint patterns across HTTP, GraphQL, WebSocket, RPC, serverless, and background stacks.
+- `references/vulnerability-catalog.md` — full taxonomy with detection heuristics, CWE IDs, and fixes.
+- `references/authz-matrix.md` — matrix schema and expected-principal inference rules.
+- `references/report-template.md` — exact report structure and issue-body format.

--- a/skills/auth-review/references/authz-matrix.md
+++ b/skills/auth-review/references/authz-matrix.md
@@ -1,0 +1,86 @@
+# Authorization Matrix
+
+For each endpoint from Phase 1, decide what *should* happen and compare to what the code *actually* enforces. The gap is where the bugs live.
+
+## Table schema
+
+| Column | Meaning |
+|--------|---------|
+| `endpoint` | `METHOD /path` or equivalent (GraphQL field, queue topic, RPC method). |
+| `expected principal` | Who should be allowed: `public`, `authenticated`, `owner`, `same-tenant`, `role:admin`, `scope:x`, or a combination. Derived from conventions (see below). |
+| `enforced check` | The exact check in code, with `file:line`. `none` if nothing. |
+| `upstream` | Middleware/guard/filter/proxy rule that applies before the handler, with `file:line`. |
+| `gap` | One of: `none`, `no-auth`, `no-authz`, `weak-authz`, `client-trusted-input`, `inconsistent`, `unknown`. |
+
+## Inferring the expected principal
+
+Most codebases do not document who should access what. Use these heuristics — all are rebuttable by reading the code.
+
+### By path
+
+| Pattern | Default expected principal |
+|---------|----------------------------|
+| `/admin/*`, `/internal/*`, `/ops/*`, `/_*` | `role:admin` (or higher) |
+| `/api/public/*`, `/health`, `/metrics` (if unauth'd by design) | `public` |
+| `/api/me/*`, `/account/*`, `/profile/*` | `authenticated`, scoped to self |
+| `/users/:id/*`, `/orders/:id/*`, `/tenants/:tid/*` | `owner` or `same-tenant` |
+| `/webhooks/*` | `signed-request` (HMAC verified) |
+| `/auth/*`, `/login`, `/signup`, `/reset` | `public` but rate-limited |
+
+### By verb × resource
+
+| Shape | Expected |
+|-------|----------|
+| `GET /resource/:id` | owner or tenant-scoped read |
+| `PUT/PATCH /resource/:id` | owner or admin |
+| `DELETE /resource/:id` | owner or admin (often admin-only in real systems) |
+| `POST /resource` (create) | authenticated; creator becomes owner |
+| `GET /resource` (list) | authenticated; results scoped to owner/tenant |
+| Any handler named `impersonate`, `promote`, `grant`, `refund`, `disable`, `delete_user` | `role:admin` minimum, usually with step-up MFA |
+
+### By data returned
+
+If the handler returns PII, financial data, or credentials — the expected principal is at minimum `owner`. If it returns aggregated data across users, it is `role:admin` or `internal`.
+
+### Corroborating sources (check, don't trust blindly)
+
+- OpenAPI / Swagger `security` blocks.
+- GraphQL schema directives (`@auth`, `@hasRole`).
+- Tests — `it('rejects non-admin users')` reveals intent even when the code drifts.
+- Comments and docstrings — informative but not authoritative.
+- Product docs or admin UI screenshots in the repo.
+
+When expected and enforced disagree, and the tests assert the *enforced* behavior, the test may itself be wrong — note this in Open Questions.
+
+## Classifying the gap
+
+| Gap | Definition |
+|-----|------------|
+| `none` | Enforced check matches expected principal, including ownership/tenant scoping. |
+| `no-auth` | Endpoint requires authentication but does not check it. |
+| `no-authz` | Endpoint is authenticated but does not check role/ownership/tenant when it should. |
+| `weak-authz` | A check exists but can be bypassed: uses request-supplied `userId`/`role`, checks only presence of a token, or compares against easily-forged values. |
+| `client-trusted-input` | Authorization decision reads from `req.body`/`req.query`/`req.headers` beyond standard auth headers. |
+| `inconsistent` | Some code paths enforce, others skip (e.g., middleware applied to one router group but not another covering the same resource). |
+| `unknown` | Cannot determine statically — escalate to Open Questions. |
+
+## Verifying the enforced check
+
+A `file:line` reference is required. For each enforced check, confirm:
+
+1. **It runs on every path into the handler.** Middleware registration order matters. A `router.use(auth)` after a `router.get(...)` does not protect that route. Guards applied at the controller level do not protect sibling controllers.
+2. **It checks the right thing.** `authenticate()` proves identity but does not prove authorization. `@login_required` is not `@admin_required`.
+3. **It scopes the query.** Ownership checks after the fetch (`if (record.owner !== user.id) throw`) are correct but fragile; scoped queries (`findOne({ id, ownerId })`) are sturdier.
+4. **It is not bypassable via a sibling route.** If `GET /users/:id` is protected but `GET /users/:id/profile` is not, the profile route leaks.
+5. **It survives the framework's quirks.** NestJS `@UseGuards` on a class does not cover handlers decorated with `@Public`. Spring `@PreAuthorize` requires `@EnableGlobalMethodSecurity`. Express middleware order matters.
+
+## Example matrix row
+
+| endpoint | expected | enforced check | upstream | gap |
+|----------|----------|---------------|----------|-----|
+| `GET /api/orders/:id` | owner or admin | `if (order.userId !== req.user.id) 403` at `routes/orders.ts:42` | `requireAuth` at `app.ts:15` applies | none |
+| `PATCH /api/users/:id` | owner or admin | `User.update(req.params.id, req.body)` at `routes/users.ts:88` — no ownership check | `requireAuth` at `app.ts:15` | `no-authz` (IDOR, body also mass-assigned) |
+| `POST /admin/refund` | role:admin | `requireAuth` only; no role check | `requireAuth` at `app.ts:15` | `no-authz` (BFLA) |
+| `GET /webhooks/stripe` | signed-request | no signature check at `routes/webhook.ts:10` | none | `no-auth` |
+
+A clean matrix is the backbone of the report. Every `gap != none` row becomes a candidate finding; cross-reference with the vulnerability catalog to assign CWE and severity.

--- a/skills/auth-review/references/enumeration.md
+++ b/skills/auth-review/references/enumeration.md
@@ -1,0 +1,106 @@
+# Entrypoint Enumeration
+
+Find **every** externally- or semi-externally-reachable handler. Miss one and the review is incomplete. Most real repos mix several frameworks — check them all.
+
+## Process
+
+1. Read root manifests (`package.json`, `pyproject.toml`, `go.mod`, `Gemfile`, `pom.xml`, `*.csproj`, etc.) to identify all frameworks in use.
+2. Apply every relevant pattern below. Grep then read each match to confirm it is a handler.
+3. Reconcile against central router files, OpenAPI/Swagger specs, GraphQL schemas, and tests. Divergences from the spec are themselves findings.
+4. Record each entrypoint in the Endpoint Inventory.
+
+## HTTP / REST by stack
+
+### JavaScript / TypeScript
+
+| Stack | Detection |
+|-------|-----------|
+| Express / Koa / Connect | `app\.(get\|post\|put\|patch\|delete\|all\|use)\(`, `router\.(get\|post\|...)\(` |
+| Fastify | `fastify\.(get\|post\|route)\(`, `\.register\(` |
+| Hapi | `server\.route\(`, `{ method:` |
+| NestJS | `@(Get\|Post\|Put\|Patch\|Delete\|All)\(`, `@Controller\(` |
+| Next.js pages | files under `pages/api/**`, default export |
+| Next.js app | `route.(ts\|js)` files, exported `GET`/`POST`/etc. |
+| Server Actions | `'use server'` directive, exported async functions |
+| tRPC | `\.(query\|mutation)\(`, `publicProcedure`, `protectedProcedure` |
+| Remix / SvelteKit | `loader`/`action` exports, `+server.ts` files |
+| Hono | `app\.(get\|post\|...)\(` |
+
+### Python
+
+| Stack | Detection |
+|-------|-----------|
+| Flask | `@app\.route\(`, `@blueprint\.route\(`, `add_url_rule\(` |
+| FastAPI | `@app\.(get\|post\|...)\(`, `@router\.(get\|...)\(`, `APIRouter` |
+| Django | `urls.py` — `path\(`, `re_path\(`; class-based views |
+| DRF | `@api_view\(`, `ViewSet`, `permission_classes =` |
+| Starlette / Tornado | `Route\(`, `Mount\(`, `Application([(r"..."` |
+
+### Go
+
+| Stack | Detection |
+|-------|-----------|
+| net/http / gorilla | `http\.HandleFunc\(`, `mux\.Handle(Func)?\(`, `r\.HandleFunc\(` |
+| chi | `r\.(Get\|Post\|Put\|Patch\|Delete\|Handle)\(`, `r\.Mount\(` |
+| gin / echo / fiber | `router\.(GET\|POST\|...)\(`, `e\.(GET\|POST\|...)\(`, `app\.(Get\|Post\|...)\(` |
+
+### Ruby / Java / .NET / PHP / Elixir / Rust
+
+| Stack | Detection |
+|-------|-----------|
+| Rails | `config/routes.rb` — `resources`, `resource`, `get`, `match`, `namespace`, `mount` |
+| Sinatra / Grape | `(get\|post\|...)\s+['"]`, `class \w+ < Grape::API` |
+| Spring | `@(Get\|Post\|Put\|Patch\|Delete\|Request)Mapping\(`, `@RestController` |
+| JAX-RS / Ktor / Micronaut | `@(GET\|POST\|...)`, `routing { ... }`, `@Controller\(` |
+| ASP.NET | `\[Http(Get\|Post\|...)\]`, `\[Route\(`, `app\.Map(Get\|Post\|...)\(` |
+| Laravel / Symfony | `Route::(get\|post\|...)\(`, `#\[Route\(` |
+| Phoenix | `router.ex` — `get`, `post`, `scope`, `pipe_through` |
+| Axum / Actix | `Router::new\(\)\.route\(`, `web::(get\|post\|...)\(` |
+
+## Non-HTTP entrypoints (often missed)
+
+### GraphQL
+
+Extract every field under `Query`, `Mutation`, `Subscription` from `*.graphql`/`*.gql`/schema TS. Find resolver registrations: `resolvers = { Query: { ... } }`, `@Resolver`, `@Query`, `@Mutation`, `field :name, resolve:` (graphql-ruby), `Field(...)` (Hot Chocolate). **Treat each resolver as an endpoint** — teams often protect the `/graphql` route but forget per-resolver authz.
+
+### WebSocket / real-time
+
+`new WebSocketServer`, `ws.on('connection'`, `@SubscribeMessage\(` (Nest gateways), Socket.IO `io.on('connection', socket.on(`, ActionCable channels, Phoenix Channels. Connection auth is often present; per-message authz often is not.
+
+### RPC / gRPC / tRPC
+
+`.proto` service definitions (each `rpc` is an endpoint), `@GrpcMethod\(`, `server.addService\(`. tRPC procedures as above.
+
+### Serverless
+
+AWS Lambda: `exports.handler`, `def lambda_handler`, `serverless.yml` functions, SAM/CDK function definitions. Vercel/Netlify: `api/**`, `netlify/functions/**`. Cloudflare Workers: `export default { fetch(`.
+
+### Background jobs / webhooks
+
+Often process attacker-controlled data (uploads, webhook payloads) without authz. Enumerate:
+
+- Queues: BullMQ `new Worker\(`, Sidekiq `include Sidekiq::Job`, Celery `@task`, AWS SQS consumers, `@KafkaListener`.
+- Scheduled: cron, `@Scheduled`, APScheduler, Rails `ActiveJob`, Quartz.
+- Webhooks: check for signature verification — or its absence.
+
+### Admin / debug surfaces
+
+Django `management/commands/`, Rails `lib/tasks/*.rake`, internal HTTP wrappers, `/debug`, `/admin`, `/internal`, `/actuator`, `/metrics` — sometimes exposed unintentionally.
+
+## Middleware / guard inventory
+
+Record auth plumbing separately; Phase 2 needs it.
+
+- Global chains: Express `app.use\(`, Django `MIDDLEWARE =`, Rails `config.middleware`, Spring `SecurityFilterChain`, ASP.NET `app.Use*`.
+- Per-route: `@UseGuards\(`, `@PreAuthorize\(`, `@Secured\(`, `before_action :authenticate`, `[Authorize]`, `permission_classes = [...]`, `authorize!`, `can?`.
+- Gateway / proxy: `nginx.conf`, `Caddyfile`, API Gateway, Envoy, Traefik, Kong plugins — may enforce or bypass auth outside the app.
+
+## Completeness check
+
+Before ending Phase 1:
+
+- [ ] Every framework from manifests has been searched with its patterns.
+- [ ] Every route in a central router file is in the inventory.
+- [ ] Every OpenAPI/Swagger path maps to a handler (and vice versa — undocumented handlers are notable).
+- [ ] GraphQL, WebSocket, gRPC, serverless, and queue handlers each have rows.
+- [ ] `auth required? = unknown` is used when unclear — do not guess.

--- a/skills/auth-review/references/report-template.md
+++ b/skills/auth-review/references/report-template.md
@@ -1,0 +1,165 @@
+# Report Template
+
+Write the report to `./auth-review/report-YYYY-MM-DD.md` (append `-HHMM` if one already exists today). Use the structure below verbatim — downstream tooling and reviewers expect it.
+
+## Structure
+
+````markdown
+# Auth Review Report
+
+- **Repository:** <repo name or path>
+- **Commit:** <git HEAD short SHA, if available>
+- **Date:** <YYYY-MM-DD>
+- **Reviewer:** auth-review skill (static, read-only)
+
+## Executive Summary
+
+<2–4 sentences: what was reviewed, the highest-impact findings, and overall posture.>
+
+**Findings by severity**
+
+| Severity | Count |
+|----------|-------|
+| High     | <n>   |
+| Medium   | <n>   |
+| Low      | <n>   |
+
+**Top risks** (one line each, highest severity first):
+
+1. <title> — <file:line>
+2. ...
+
+## Scope
+
+- **In scope:** <directories / services / packages reviewed>
+- **Out of scope:** <anything skipped and why>
+- **Frameworks detected:** <list>
+- **Not covered by static review:** runtime configuration, infrastructure, deployed middleware that does not live in this repo, production secrets.
+
+## Endpoint Inventory
+
+| Method / Trigger | Path / Name | Handler | Auth required? | Roles / Scopes | Notes |
+|------------------|-------------|---------|----------------|----------------|-------|
+| GET              | /api/orders/:id | `routes/orders.ts:40` | yes | owner | |
+| POST             | /admin/refund   | `routes/admin.ts:12` | yes | **missing** | flagged F-003 |
+| GraphQL Mutation | `promoteUser`   | `graphql/user.ts:88` | yes | admin | |
+| Queue            | `user.signup`   | `workers/signup.ts:10` | n/a | internal | verifies HMAC |
+| ...              | ...             | ...     | ...             | ...             | ... |
+
+## Authorization Matrix
+
+| Endpoint | Expected | Enforced | Upstream | Gap |
+|----------|----------|----------|----------|-----|
+| `GET /api/orders/:id` | owner or admin | ownership check at `routes/orders.ts:42` | `requireAuth` `app.ts:15` | none |
+| `PATCH /api/users/:id` | owner or admin | none | `requireAuth` `app.ts:15` | no-authz |
+| ... | ... | ... | ... | ... |
+
+## Findings
+
+Each finding uses this block. Number them `F-001`, `F-002`, ... in order of severity then discovery.
+
+---
+
+### F-001 — <short title>
+
+- **Severity:** High | Medium | Low
+- **CWE:** CWE-XXX (<name>)
+- **Category:** <from vulnerability-catalog.md>
+- **Location:** `path/to/file.ext:line`
+- **Affected endpoints:** `METHOD /path`, `METHOD /path`, ...
+
+**Evidence**
+
+```<lang>
+// path/to/file.ext:line
+<minimal code snippet demonstrating the issue — redact secrets as [REDACTED]>
+```
+
+**Exploit reasoning**
+
+<2–5 sentences: who the attacker is, what they send, what the server does wrong, what they obtain. Be specific about preconditions.>
+
+**Remediation**
+
+<concrete change: library call to use, pattern to apply, test to add. Show a before/after if non-obvious.>
+
+**References**
+
+- `references/vulnerability-catalog.md#<section>`
+- <CWE link, OWASP cheat sheet, RFC if applicable — only well-known canonical links; do not invent URLs>
+
+---
+
+## Issues to File
+
+Each finding pre-formatted as a GitHub issue body. Paste as-is into `gh issue create --body-file ...` or the GitHub UI.
+
+### Issue for F-001
+
+**Title:** `[auth-review] <Severity>: <short title>`
+
+**Body:**
+
+```markdown
+## Summary
+
+<1-sentence statement of the bug and its impact.>
+
+## Details
+
+- **Severity:** <level>
+- **CWE:** CWE-XXX
+- **Location:** `path/to/file.ext:line`
+
+## Evidence
+
+\`\`\`<lang>
+<snippet>
+\`\`\`
+
+## Suggested fix
+
+<concrete change>
+
+## Test to add
+
+<one sentence describing the regression test>
+
+---
+_Found by `auth-review` static review on <date>. Finding ID: F-001._
+```
+
+(Repeat the issue block for each finding.)
+
+## Open Questions
+
+Things static analysis cannot resolve. The maintainer must answer each before closing the review.
+
+- [ ] Is endpoint `X` intentionally public?
+- [ ] Does a reverse proxy or API gateway enforce auth for `/admin/*` before requests reach the app?
+- [ ] Is the session store configured with `secure: true` in production (env-driven)?
+- [ ] Is field `role` meant to be user-editable on the profile endpoint?
+- [ ] Which tenant-scoping mechanism is authoritative — the ORM default scope or the handler check?
+
+## Methodology
+
+- **Phases:** (1) Entrypoint enumeration, (2) Authorization matrix, (3) Catalog sweep, (4) Report.
+- **Catalog:** `references/vulnerability-catalog.md` covers AuthN, JWT/tokens, sessions, IDOR/BOLA, privilege escalation and mass assignment, OAuth/OIDC/SAML, password reset, MFA, rate limiting, CSRF/CORS, SSRF adjacent to identity.
+- **False-positive controls:** every flagged check was confirmed by reading the file; upstream middleware and guards were considered before calling a check missing.
+- **Not performed:** dynamic probing, authenticated crawling, dependency CVE scan, infrastructure review.
+
+## Appendix — Files Reviewed
+
+<optional: list of files opened during the review, for auditability>
+````
+
+## Conventions
+
+- Use fenced code blocks with language hints (`ts`, `py`, `go`, `rb`, `java`, `cs`, ...) so syntax highlighting works in GitHub.
+- Keep evidence snippets short — 3 to 10 lines. Elide with `// ...` if the relevant code spans a larger function.
+- Redact secrets: replace token/key strings with `[REDACTED]`.
+- Use absolute repo-relative paths (`src/routes/users.ts:42`), not absolute filesystem paths.
+- Keep finding titles factual: `"Admin refund endpoint lacks role check"`, not `"Critical bug!!"`.
+- If severity is ambiguous, pick the lower level and explain why in the finding body.
+- When no findings exist in a category, omit that finding entirely — do not add empty sections. The executive summary's counts should reflect that.
+- If the review surfaces zero findings, state this plainly and list what was checked; a clean report is valuable.

--- a/skills/auth-review/references/vulnerability-catalog.md
+++ b/skills/auth-review/references/vulnerability-catalog.md
@@ -1,0 +1,303 @@
+# Vulnerability Catalog
+
+Walk every category. For each, run the detection heuristics, then **read** the matched file to confirm. Never report from a grep hit alone.
+
+Severity defaults assume an internet-facing service with real users. Downgrade one level for internal-only or pre-auth-gated surfaces.
+
+---
+
+## 1. Broken or Missing Authentication
+
+### 1.1 Endpoint exposed without authentication (CWE-306)
+**Detect:** handlers in the inventory marked `auth required? = n` that mutate state, return user data, or touch admin functionality. Grep for handlers that never invoke `getSession`, `currentUser`, `req.user`, `@login_required`, `[Authorize]`, `authenticate!`, or a known guard.
+**Fix:** add auth middleware globally and opt *out* for public endpoints explicitly (allow-list, not deny-list).
+**Severity:** High.
+
+### 1.2 Hand-rolled password compare (CWE-208, CWE-327)
+**Detect:** `password ==`, `password ===`, `strcmp`, `Equals(password`, `.equals(password`. Compares not using `bcrypt.compare`, `argon2.verify`, `crypto.timingSafeEqual`, `hmac.compare_digest`, or `MessageDigest.isEqual`.
+**Fix:** constant-time compare + modern password hash (argon2id preferred, bcrypt acceptable).
+**Severity:** Medium (High when timing-observable over an API).
+
+### 1.3 Plaintext or weak password hash (CWE-256, CWE-916)
+**Detect:** `md5`/`sha1`/`sha256` over a password field; `password:` column written directly; no hash library imported in auth code.
+**Fix:** argon2id or bcrypt (cost ≥ 12). Migrate on next login.
+**Severity:** High.
+
+### 1.4 Authentication bypass via SQL injection (CWE-89)
+**Detect:** string concatenation or `f"...{input}..."` in `SELECT ... WHERE username = ...`; raw `exec`/`query`/`execute` with user input. Check the login handler specifically.
+**Fix:** parameterized queries / ORM query builder.
+**Severity:** High.
+
+### 1.5 User enumeration via differential responses (CWE-203)
+**Detect:** login/reset/signup returning different messages (`"user not found"` vs `"wrong password"`), different status codes, or different timing branches.
+**Fix:** single generic message; uniform timing.
+**Severity:** Low (Medium if no rate limit).
+
+### 1.6 Credentials in code, config, or logs (CWE-798, CWE-532)
+**Detect:** `password\s*=\s*["']`, `api[_-]?key\s*=\s*["']`, `secret\s*=\s*["']`, `Bearer [A-Za-z0-9._-]{20,}`, `-----BEGIN`, `AKIA[0-9A-Z]{16}`. Also `console.log`/`logger.info`/`print` with `password`/`token`/`authorization`.
+**Fix:** env/secret manager; scrub logs.
+**Severity:** High for live secrets; Medium for credentials in logs.
+
+---
+
+## 2. JWT / Token Validation
+
+### 2.1 `alg: none` accepted (CWE-347)
+**Detect:** `algorithms=None`, `algorithms=['none']`, `jwt.decode(...)` without an `algorithms=` arg, `verify: false`, `verify_signature: false`.
+**Fix:** explicit algorithm allow-list containing only your algorithm.
+**Severity:** High.
+
+### 2.2 Algorithm confusion (RS256 → HS256) (CWE-347)
+**Detect:** accepted algorithms list includes both HS* and RS*, or dynamic algorithm selection, with verify key passed as a symmetric secret.
+**Fix:** restrict to a single algorithm; for RS256 verify with public key only.
+**Severity:** High.
+
+### 2.3 Unverified decode (CWE-345)
+**Detect:** `jwt.decode(` without `verify=True` or key; `jsonwebtoken` `decode()` used where `verify()` is required; `jose` `decodeJwt` used for authz decisions.
+**Fix:** use verifying API (`jwt.verify`, `jwtVerify`). `decode` is inspection-only.
+**Severity:** High.
+
+### 2.4 Missing claim validation (CWE-345)
+**Detect:** verification that skips `iss`, `aud`, `exp`, `nbf`, or `sub`. Flags: `ignore_exp`, `verify_exp=False`, absent `audience:` parameter.
+**Fix:** validate `iss`, `aud`, `exp`, `nbf` on every request. For OIDC also validate `nonce` and `azp`.
+**Severity:** Medium (High if `exp` skipped).
+
+### 2.5 Weak, hardcoded, or committed JWT secret (CWE-321, CWE-798)
+**Detect:** secrets < 32 bytes, strings like `"secret"`/`"changeme"`, `.env.example` values matching production.
+**Fix:** 32+ random bytes from a CSPRNG; secret manager; rotate on exposure.
+**Severity:** High if production; Medium for dev-only.
+
+### 2.6 Tokens accepted from query string (CWE-598)
+**Detect:** `req.query.token`, `request.args.get('token')`, routes accepting `?access_token=`. URLs leak via logs, referrers, history.
+**Fix:** require `Authorization: Bearer` header or HTTP-only cookie.
+**Severity:** Medium.
+
+---
+
+## 3. Session Management
+
+### 3.1 Missing cookie flags (CWE-614, CWE-1004, CWE-1275)
+**Detect:** `res.cookie(`/`Set-Cookie`/session middleware config — `httpOnly: false`, absent `secure`, absent `sameSite`, or `SameSite=None` without `Secure`.
+**Fix:** `HttpOnly; Secure; SameSite=Lax` (or Strict). Use `None; Secure` only for known cross-site needs.
+**Severity:** Medium.
+
+### 3.2 Session not invalidated on logout (CWE-613)
+**Detect:** logout clears cookie client-side only; no server-side revocation list, no session record deletion, no `jti` denylist for JWTs.
+**Fix:** server-side invalidation. For stateless JWTs: short TTL + revocation list keyed on `jti` or user+iat.
+**Severity:** Medium.
+
+### 3.3 Session fixation (CWE-384)
+**Detect:** login does not regenerate session ID. Absence of `session.regenerate`, `request.session.cycle_key()`, `reset_session`.
+**Fix:** regenerate session ID on every privilege change (login, MFA, role/password change).
+**Severity:** Medium.
+
+### 3.4 Predictable or low-entropy session/token IDs (CWE-330, CWE-340)
+**Detect:** `Math.random`, `rand()`, `new Random()`, `uuid1` (time-based), `Date.now()`-seeded IDs in auth code.
+**Fix:** `crypto.randomBytes`, `secrets.token_urlsafe`, `SecureRandom`, framework CSPRNG.
+**Severity:** High.
+
+### 3.5 Long-lived or never-expiring sessions (CWE-613)
+**Detect:** `maxAge: Infinity`, multi-year cookie expiry, refresh tokens with no rotation, absent inactivity timeout.
+**Fix:** short access tokens, rotating refresh tokens with replay detection, absolute session maximum.
+**Severity:** Low (Medium for admin/financial).
+
+---
+
+## 4. Broken Access Control / IDOR / BOLA
+
+### 4.1 Object ID from request, no ownership check (CWE-639 / OWASP API1)
+**Detect:** handlers using `req.params.id`, `request.args['id']`, `@PathVariable Long id`, `params[:id]` to fetch a record without comparing owner to authenticated principal. Grep `findById`, `get_object_or_404`, `.findOne(`, `.FindByID(` and inspect.
+**Fix:** scope queries by owner: `findOne({ id, userId: currentUser.id })`, or explicit `assert record.owner_id == user.id`. For multi-tenant, scope by tenant too.
+**Severity:** High.
+
+### 4.2 Predictable object IDs (CWE-340)
+**Detect:** auto-incrementing integer IDs in URLs with per-user resources. Amplifies 4.1 — not a standalone vuln.
+**Fix:** UUIDv4/v7 or opaque IDs, **in addition to** a real ownership check.
+**Severity:** Low alone.
+
+### 4.3 Missing function-level authorization / BFLA (CWE-862 / OWASP API5)
+**Detect:** admin endpoints (`/admin/`, `/internal/`, handler names with `delete`/`promote`/`impersonate`/`grant`/`refund`) that require auth but no role check. Absence of `isAdmin`/`role ==`/`@PreAuthorize`/`has_role` on these handlers is the finding.
+**Fix:** role/permission check at handler or via a guard scoped to the admin router.
+**Severity:** High.
+
+### 4.4 Authorization via client-supplied role (CWE-602, CWE-807)
+**Detect:** `req.body.role`, `req.headers['x-user-role']`, `params[:admin]`, `user_id` from request body instead of session. `req.user = req.body.user` patterns.
+**Fix:** derive principal and role from session/token only.
+**Severity:** High.
+
+### 4.5 Tenant / organization crossing (CWE-863)
+**Detect:** multi-tenant app filtering queries by resource ID but not by `tenantId`/`orgId`/`workspace_id`. Missing filter = crossing risk.
+**Fix:** enforce tenant scope in ORM/repository (row-level security, default scopes, or required parameter).
+**Severity:** High.
+
+### 4.6 Authorization trusting request object for identity (CWE-639)
+**Detect:** `if req.body.userId === token.sub` or `if resource.owner === req.body.ownerClaim` — attacker controls the compared value.
+**Fix:** compare against server-resolved values only.
+**Severity:** High.
+
+---
+
+## 5. Privilege Escalation & Mass Assignment
+
+### 5.1 Mass assignment on user object (CWE-915)
+**Detect:** `User.create(req.body)`, `user.update(params)`, `Object.assign(user, req.body)`, `**request.json()`, Active Record `update_attributes(params[:user])` without strong params. Flag when `role`/`is_admin`/`permissions`/`tenant_id`/`email_verified`/`mfa_enabled` are fields on the model.
+**Fix:** explicit allow-list of updatable fields; DTOs; `permit(:name, :email)`.
+**Severity:** High.
+
+### 5.2 Self-service role change (CWE-269)
+**Detect:** profile-update endpoint accepting `role`/`groups`/`scope` in body. Admin-promote endpoints reachable without admin check.
+**Fix:** split role mutation into a separate admin-only endpoint.
+**Severity:** High.
+
+### 5.3 Horizontal escalation via parameter tampering
+**Detect:** endpoints taking `userId`/`accountId` from request and acting on the named account without verifying it matches session.
+**Fix:** default to session user; require an explicit admin path to act on others.
+**Severity:** High.
+
+---
+
+## 6. OAuth / OIDC / SAML
+
+### 6.1 Missing `state` / PKCE (CWE-352)
+**Detect:** authorization-code callback handlers without `state` verification. For public clients: absent `code_challenge`/`code_verifier`.
+**Fix:** cryptographic `state` bound to session, verified on callback. Require PKCE (`S256`) for public clients.
+**Severity:** High.
+
+### 6.2 Open redirect on OAuth callback / `returnTo` (CWE-601)
+**Detect:** callback handlers redirecting to `redirect_uri`/`returnTo`/`next`/`continue` from the request without allow-list validation.
+**Fix:** allow-list of hosts; prefer relative paths.
+**Severity:** High.
+
+### 6.3 ID token / access token not validated (CWE-345)
+**Detect:** OIDC ID tokens passed through without signature/`iss`/`aud`/`nonce`/`exp` checks. Access token treated as identity.
+**Fix:** verify ID token per OIDC spec. Access tokens are not identity assertions.
+**Severity:** High.
+
+### 6.4 Implicit flow in use (CWE-522)
+**Detect:** `response_type=token` or `response_type=id_token token`; tokens in URL fragment.
+**Fix:** migrate to authorization code + PKCE.
+**Severity:** Medium.
+
+### 6.5 SAML signature not verified / XSW (CWE-347)
+**Detect:** SAML handlers parsing assertions without validating signature, or validating outer `Response` only while trusting inner `Assertion` content (XML Signature Wrapping).
+**Fix:** vetted SAML library with XSW mitigations; validate signatures on the exact trusted elements.
+**Severity:** High.
+
+### 6.6 SSO account linking without verification (CWE-287)
+**Detect:** first-login flow linking IdP account to existing local account by email alone, without owner consent.
+**Fix:** re-auth to existing account or email confirmation before linking.
+**Severity:** High.
+
+---
+
+## 7. Password Reset & Account Recovery
+
+### 7.1 Predictable or non-expiring reset tokens (CWE-330, CWE-613)
+**Detect:** `Math.random`, sequential IDs, tokens without expiry, tokens that persist until used.
+**Fix:** CSPRNG tokens, 32+ bytes, ≤15 min TTL, single-use (invalidate on use and on new request).
+**Severity:** High.
+
+### 7.2 Host-header poisoning in reset link (CWE-20, CWE-640)
+**Detect:** reset emails built from `req.headers.host`/`request.get_host()`/`request.url` without a configured canonical origin.
+**Fix:** build reset URLs from a server-configured base URL.
+**Severity:** High.
+
+### 7.3 User enumeration in reset / signup (CWE-203)
+**Detect:** reset replying "email not found" vs "email sent".
+**Fix:** identical response regardless of existence.
+**Severity:** Low.
+
+### 7.4 Recovery bypasses MFA (CWE-287)
+**Detect:** password reset flow that logs user in or clears MFA without re-enrollment.
+**Fix:** reset sets new password only; MFA remains required; notify user.
+**Severity:** High.
+
+### 7.5 Email / phone change without re-auth (CWE-287)
+**Detect:** profile endpoint allowing email/phone change without current-password or MFA challenge; no confirmation to the **old** address.
+**Fix:** require re-auth; confirm on both old and new before taking effect.
+**Severity:** High.
+
+---
+
+## 8. MFA & Step-Up
+
+### 8.1 MFA step skippable (CWE-287)
+**Detect:** login issues full session before MFA completes; MFA step reachable by direct "after MFA" endpoint call; remember-device cookie without integrity binding.
+**Fix:** pre-auth session flagged unverified until MFA completes; bind remember-device tokens to user, device, recent IP.
+**Severity:** High.
+
+### 8.2 Missing rate limit on OTP (CWE-307)
+**Detect:** OTP verify handler with no attempt counter, no lockout, short OTP (< 6 digits).
+**Fix:** per-OTP attempt cap, per-IP rate limit, OTP length ≥ 6, short TTL.
+**Severity:** High.
+
+### 8.3 Sensitive actions without step-up (CWE-862)
+**Detect:** password change, email change, API-key creation, payment change without re-challenge.
+**Fix:** step-up within a short window before sensitive mutations.
+**Severity:** Medium.
+
+---
+
+## 9. Rate Limiting & Enumeration
+
+### 9.1 No rate limit on auth endpoints (CWE-307)
+**Detect:** login/signup/reset/OTP/refresh/SSO-callback without rate limiter. Grep middleware for `rateLimit`/`Throttle`/`limiter`/`express-rate-limit`/`ratelimit-spring`.
+**Fix:** per-IP and per-account limits; exponential backoff; CAPTCHA after N failures.
+**Severity:** Medium (High if also no account lockout on login).
+
+### 9.2 Rate limit keyed only on IP (CWE-307)
+**Detect:** limiter scoped by `req.ip` only — ineffective against credential stuffing from botnets.
+**Fix:** also key by username/email; track failed attempts per account.
+**Severity:** Medium.
+
+---
+
+## 10. CSRF & CORS
+
+### 10.1 State-changing GET (CWE-352)
+**Detect:** `GET` handlers that write DB, send emails, charge payments.
+**Fix:** move to `POST`/`PUT`/`DELETE`; CSRF token or SameSite cookie policy on mutations.
+**Severity:** Medium.
+
+### 10.2 Missing CSRF on cookie-auth endpoints (CWE-352)
+**Detect:** cookie session without CSRF middleware (`csurf`, `django-csrf`, `Rack::Csrf`) and without `SameSite=Lax/Strict`.
+**Fix:** `SameSite=Lax` minimum plus CSRF token on sensitive mutations, or switch to `Authorization` header.
+**Severity:** Medium.
+
+### 10.3 Permissive CORS with credentials (CWE-942, CWE-346)
+**Detect:** `Access-Control-Allow-Origin: *` with `Allow-Credentials: true`; reflective origin without allow-list; `null` origin accepted.
+**Fix:** exact allow-list; never reflect unvalidated; never trust `null`.
+**Severity:** High if credentialed; Medium otherwise.
+
+---
+
+## 11. Identity-adjacent SSRF & Token Leakage
+
+### 11.1 SSRF reaching metadata / internal identity (CWE-918)
+**Detect:** HTTP clients called with user-supplied URLs and no allow-list. In cloud envs this can reach `169.254.169.254` and steal instance credentials.
+**Fix:** allow-list hosts; block RFC1918, loopback, link-local; resolve DNS and re-check.
+**Severity:** High.
+
+### 11.2 Tokens logged or returned in errors (CWE-532, CWE-209)
+**Detect:** `console.error(err)`, `logger.error(req)`, `res.json({ error: err })` in auth paths. Error responses echoing request or stack.
+**Fix:** structured errors; redact auth headers and tokens; generic client messages.
+**Severity:** Medium.
+
+---
+
+## Quick heuristics (run these greps first, then read matches)
+
+```
+rg -n "^(export\s+)?(async\s+)?function\s+(GET|POST|PUT|PATCH|DELETE)" --type=ts
+rg -n "req\.(body|query|params)\.(user_?id|role|is_?admin|tenant)"
+rg -n "findById\(|get_object_or_404|findOne\(|FindByID\("
+rg -n "jwt\.decode\(|jsonwebtoken.*decode\(|verify:\s*false|verify_signature\s*=\s*False"
+rg -n "algorithms\s*=\s*\[?['\"]?none" -i
+rg -n "Math\.random|rand\(\)|uuid1\("
+rg -n "cookie.*(httpOnly|secure|sameSite)" -i
+rg -n "Access-Control-Allow-Origin.*\*"
+rg -n "md5|sha1" -i
+rg -n "password\s*[=:]=\s*"
+```
+
+Confirm every match by reading the file.


### PR DESCRIPTION
Static, framework- and vendor-agnostic security review for
authentication and authorization vulnerabilities. Triggers on
/auth-review. Runs a four-phase workflow:

1. Enumerate every entrypoint (HTTP, GraphQL, WebSocket, RPC,
   serverless, queues, admin surfaces) across JS/TS, Python, Go,
   Ruby, Java, .NET, PHP, Elixir, Rust stacks.
2. Build an authorization matrix (expected vs. enforced principal).
3. Apply a vulnerability catalog covering broken authN, JWT/token
   flaws, session management, IDOR/BOLA, privilege escalation and
   mass assignment, OAuth/OIDC/SAML, password reset and recovery,
   MFA, rate limiting, CSRF/CORS, and identity-adjacent SSRF.
4. Write a triage report to ./auth-review/report-YYYY-MM-DD.md
   with severity (High/Med/Low), CWE IDs, file:line evidence,
   exploit reasoning, remediation, and pre-formatted issue bodies.

Read-only: does not modify code, run the app, make network probes,
or file issues directly.