### PR TITLE
feat(descope-fga-schema): add descope-fga-schema skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "descope-skills",
-  "description": "Skills for integrating Descope authentication and managing projects with Terraform",
-  "version": "1.0.0",
+  "description": "Skills for integrating Descope authentication, managing projects with Terraform, and authoring FGA authorization schemas",
+  "version": "1.1.0",
   "author": {
     "name": "Descope",
     "email": "support@descope.com"
@@ -9,5 +9,5 @@
   "homepage": "https://docs.descope.com",
   "repository": "https://github.com/descope/skills",
   "license": "MIT",
-  "keywords": ["descope", "authentication", "terraform", "oauth", "sso", "passkey", "mfa"]
+  "keywords": ["descope", "authentication", "terraform", "oauth", "sso", "passkey", "mfa", "fga", "authorization", "rebac", "abac"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# CLAUDE.md — Descope Skills Repo
+
+## Plugin Version Bumps
+
+Every PR must bump the version in `.claude-plugin/plugin.json`. Use semantic versioning:
+
+| Change type | Bump | Examples |
+|---|---|---|
+| Edit to an existing skill | **patch** (`1.0.0 → 1.0.1`) | Fix a code example, reword an instruction, add a clarification |
+| New skill added | **minor** (`1.0.0 → 1.1.0`) | Add a new `SKILL.md` under `skills/` |
+| Breaking change to an existing skill | **major** (`1.0.0 → 2.0.0`) | Rename a skill, remove a skill, change behavior in a way that breaks existing workflows |
+
+Breaking changes should be very rare. When in doubt, treat a change as non-breaking (patch or minor).

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -116,7 +116,7 @@ constraint BusinessHours:NumRange(32400, 61200)
 
 ## Relations vs Permissions
 
-A **relation** adds an edge to the pure relations graph and requires an explicit API call to create. A **permission** is a derived rule that reuses existing relations — it adds edges only in the ReBAC graph without introducing new pure-graph edges. Fewer pure-graph edges means less to iterate during checks and a higher chance of cache hits, so permissions are both more concise and typically faster. Prefer satisfying a requirement with a permission whenever possible. Only introduce a new relation when a direct stored link is truly needed.
+A **relation** adds an edge to the pure relations graph. A **permission** is a derived rule that reuses existing relations — it adds edges only in the ReBAC graph without introducing new pure-graph edges. Fewer pure-graph edges means less to iterate during checks and a higher chance of cache hits, so permissions are both more concise and typically faster. Prefer satisfying a requirement with a permission whenever possible. Only introduce a new relation when a direct stored link is truly needed.
 
 ## Built-in Constraints
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -60,16 +60,16 @@ Naming: **PascalCase** for Types, Conditions, Constraints. **snake_case** for re
 
 When a relation should be held by members of a group (e.g. "any member of this Team"), put `Type#relation` directly in the relation definition. This stores individual member subjects — the right granularity for permission checks.
 
-The tempting wrong way is to store the group itself and walk to its members via a permission. This looks like it works but stores the wrong thing (a group object instead of its members), and the permission traversal does not expand correctly at check time.
+The indirect way — storing the group itself and deriving membership via a permission — produces correct relation expansion, but it introduces a `contributor_team` relation with no semantic meaning of its own. The only meaningful entity is the individual member. The target set syntax is more concise and directly expresses the intent.
 
-**Wrong:**
+**Avoid (extra relation with no semantic value):**
 ```
 type Repository
   relation contributor_team: Team
   permission contributor: contributor_team.member
 ```
 
-**Right:**
+**Prefer (concise, direct):**
 ```
 type Repository
   relation contributor: Team#member

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -49,14 +49,14 @@ Keywords: `model` `type` `relation` `permission` `condition` `constraint` `with`
 Operators:
 - Permission expr: `|` union, `&` intersect, `-` subtract. Mix operators with parens: `a | (b - c)`
 - Set arrow: `relation.permission` — walks a stored relation to reach the subject's own permissions (e.g. `parent.can_view`)
-- Userset: `Type#relation` — see dedicated section below
+- Target set: `Type#relation` — see dedicated section below
 - `with` clause (relations only): `&` AND, `|` OR, `!` NOT, parens: `with A & (B | !C)`. Conditions are evaluated at **check time** — relations are stored unconditionally; `with` only affects whether the relation counts during permission evaluation.
 
 **No comments** — the DSL parser has no comment token.
 
 Naming: **PascalCase** for Types, Conditions, Constraints. **snake_case** for relations and permissions.
 
-## Userset Pattern (`Type#relation`)
+## Target Set Pattern (`Type#relation`)
 
 When a relation should be held by members of a group (e.g. "any member of this Team"), put `Type#relation` directly in the relation definition. This stores individual member subjects — the right granularity for permission checks.
 
@@ -75,7 +75,7 @@ type Repository
   relation contributor: Team#member
 ```
 
-You can mix direct subjects with userset subjects: `relation editor: User | Team#member`
+You can mix direct subjects with target set subjects: `relation editor: User | Team#member`
 
 ## ABAC Anti-Patterns to Avoid
 
@@ -221,7 +221,7 @@ type Doc
   permission can_edit: owner
 ```
 
-### Group membership via userset
+### Group membership via target set
 
 ```
 model AuthZ 1.0

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -157,9 +157,9 @@ CEL param types: `int`, `string`, `bool`, `double`, `list`, `ipaddress`. Body mu
 When editing an existing schema, first read the current schema with `GetFGASchema` so you have the real state.
 
 - If the user asks to add something already present, tell them exactly what exists and stop — don't silently overwrite.
-- Removing an entire **type** or a **relation definition** from the schema may cause all relation tuples of that type or relation to be permanently deleted from the database. Always confirm this with the user and make sure they understand the impact before proceeding.
-- Removing a **permission** deletes no data, but any downstream permissions or checks that depended on it will silently stop working. Confirm with user.
-- Adding relations or permissions is generally safe. One exception: modifying or deleting a relation that appears in a **subtraction** (`-`) clause is risky — if existing tuples of that relation type are lost as part of the schema change, users who were being blocked will silently gain access. Flag this when proposing any change to such a relation.
+- Removing an entire **type** or a **relation definition** from the schema may cause all relation tuples of that type or relation to be permanently deleted from the database. **Editing a relation definition is equivalent to deleting it and recreating it** — the same data loss risk applies. Always confirm with the user and make sure they understand the impact before proceeding.
+- Removing or editing a **permission** deletes no relation tuples, but any downstream permissions or checks that depended on it will silently stop working. Confirm with user.
+- Adding a new type, relation, or permission is generally safe.
 
 ## Validation and Apply Workflow
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -120,7 +120,7 @@ A **relation** adds an edge to the pure relations graph. A **permission** is a d
 
 ## Built-in Constraints
 
-Use built-in constraints before reaching for custom CEL — they're validated at schema-save time and cheaper to evaluate.
+Use built-in constraints before reaching for custom CEL — they're validated at schema-save time.
 
 | Constraint | Runtime params (zero-arg form) | Hardcoded form |
 |---|---|---|

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -118,7 +118,7 @@ constraint BusinessHours:NumRange(32400, 61200)
 
 A **relation** adds an edge to the pure relations graph. A **permission** is a derived rule that reuses existing relations — it adds edges only in the ReBAC graph without introducing new pure-graph edges. Fewer pure-graph edges means less to iterate during checks and a higher chance of cache hits across all checks in the schema, so permissions are more concise and keeping the pure graph lean tends to improve overall check performance as the system scales. Prefer satisfying a requirement with a permission whenever possible. Only introduce a new relation when a direct stored link is truly needed.
 
-When a permission is a strict superset of another, express it by referencing the narrower permission rather than repeating its expansion. This keeps schemas concise and makes the access hierarchy self-documenting — a reader immediately sees that `can_write` implies `can_admin`.
+When a permission is a strict superset of another, express it by referencing the narrower permission rather than repeating its expansion. This keeps schemas concise and makes the access hierarchy self-documenting — a reader immediately sees that `can_admin` implies `can_write`, which implies `can_read`.
 
 **Avoid (repeats relations across permissions):**
 ```

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -157,7 +157,7 @@ CEL param types: `int`, `string`, `bool`, `double`, `list`, `ipaddress`. Body mu
 When editing an existing schema, first read the current schema with `GetFGASchema` so you have the real state.
 
 - If the user asks to add something already present, tell them exactly what exists and stop — don't silently overwrite.
-- Removing a **relation type** is permanent data loss: all stored relations of that type are deleted from the database. Always confirm this with the user and make sure they understand the impact before proceeding.
+- Removing an entire **type** or a **relation definition** from the schema may cause all relation tuples of that type or relation to be permanently deleted from the database. Always confirm this with the user and make sure they understand the impact before proceeding.
 - Removing a **permission** deletes no data, but any downstream permissions or checks that depended on it will silently stop working. Confirm with user.
 - Adding relations or permissions is generally safe. One exception: modifying or deleting a relation that appears in a **subtraction** (`-`) clause is risky — if existing tuples of that relation type are lost as part of the schema change, users who were being blocked will silently gain access. Flag this when proposing any change to such a relation.
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -136,12 +136,15 @@ Use built-in constraints before reaching for custom CEL.
 | `IntList` | `int int, allowed_ints list` | `IntList(1,2,3)` |
 | `LabelList` | `label string, allowed_labels list` | `LabelList("foo","bar")` |
 
-**Unique param names:** Each constraint exposes its runtime params by name in check requests. If two constraints of the same kind appear in a schema, their param names collide — use named aliases to give them distinct names:
+**Multiple constraints of the same kind:** You cannot declare the same constraint kind more than once without a named alias — the alias is required to distinguish them. Named aliases share the same runtime param names as the original kind (the alias only changes the constraint's identifier, not its params). This is fine when both constraints operate on the same parameter. If you need two constraints that operate on genuinely different parameters, use a custom CEL condition with a unique param name instead:
 ```
+// Two GeoCountry constraints sharing the same country_code param — alias required, shared param is intentional
 constraint FiveEyes:GeoCountry("US","GB","CA","AU","NZ")
 constraint Sanction:GeoCountry("KP","IR","SY","RU")
+
+// Need a second IP check with a different param name? Use a custom condition
+condition OfficeNetwork(office_ip ipaddress, office_range string) { office_ip.in_cidr(office_range) }
 ```
-The alias form (`Name:Kind`) also applies when two zero-arg constraints of the same kind would produce identical param names.
 
 **Custom CEL** — only when no built-in covers the logic, or when alias-based param separation isn't enough:
 ```

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: fga-dsl
+name: descope-fga-schema
 description: Author, edit, or apply a Descope FGA schema using the ReBAC/ABAC DSL. Use this skill whenever the user asks to create a new FGA schema, modify an existing one, add types/relations/permissions/conditions, review an authorization model, or apply schema changes to a Descope project. Trigger even if the user says things like "set up authorization", "define roles and permissions", "add team-based access", "make this endpoint check FGA", or "update my authz model" — these almost always mean an FGA schema change.
 ---
 
@@ -13,12 +13,12 @@ Help the user design and apply Descope FGA schemas. The workflow is: understand 
 
 **If the tools are not found:** output only the message below, then end your turn. Do not generate a schema, do not say "here's what I'll apply once connected", do not do any design work, do not continue:
 
-> The Descope Management MCP is required. If not yet installed, install and authorize it, then restart Claude Code and re-run `/fga-dsl`.
-> If already installed, it may need authorization. Authorize the Descope MCP, then restart Claude Code and re-run `/fga-dsl`.
+> The Descope Management MCP is required. If not yet installed, install and authorize it, then restart Claude Code and re-run `/descope-fga-schema`.
+> If already installed, it may need authorization. Authorize the Descope MCP, then restart Claude Code and re-run `/descope-fga-schema`.
 
 **If the tools are found:** call `GetFGASchema` immediately as a connectivity probe before doing any other work. If this call returns an authorization error, output only the message below and end your turn:
 
-> The Descope MCP is installed but not authorized. Authorize it and re-run `/fga-dsl`.
+> The Descope MCP is installed but not authorized. Authorize it and re-run `/descope-fga-schema`.
 
 All FGA operations go through MCP tool calls — never make raw HTTP requests yourself.
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -157,7 +157,7 @@ CEL param types: `int`, `string`, `bool`, `double`, `list`, `ipaddress`. Body mu
 When editing an existing schema, first read the current schema with `GetFGASchema` so you have the real state.
 
 - If the user asks to add something already present, tell them exactly what exists and stop — don't silently overwrite.
-- Removing an entire **type** or a **relation definition** from the schema may cause all relation tuples of that type or relation to be permanently deleted from the database. **Editing a relation definition is equivalent to deleting it and recreating it** — the same data loss risk applies. Always confirm with the user and make sure they understand the impact before proceeding.
+- Removing an entire **type** or a **relation definition** from the schema will cause all relation tuples of that type or relation to be permanently deleted from the database. **Editing a relation definition is equivalent to deleting it and recreating it** — the same data loss risk applies. Always confirm with the user and make sure they understand the impact before proceeding.
 - Removing or editing a **permission** deletes no relation tuples, but any downstream permissions or checks that depended on it will silently stop working. Confirm with user.
 - Adding a new type, relation, or permission is generally safe.
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -18,7 +18,7 @@ Help the user design and apply Descope FGA schemas. The workflow is: understand 
 
 **If the tools are found:** call `GetFGASchema` immediately as a connectivity probe before doing any other work. If this call returns an authorization error, output only the message below and end your turn:
 
-> The Descope MCP is installed but not authorized. Authorize it and re-run `/descope-fga-schema`.
+> The Descope MCP is installed but not authorized. Authorize it, restart Claude Code, and re-run `/descope-fga-schema`.
 
 All FGA operations go through MCP tool calls — never make raw HTTP requests yourself.
 
@@ -156,7 +156,7 @@ When editing an existing schema, first read the current schema with `GetFGASchem
 - If the user asks to add something already present, tell them exactly what exists and stop — don't silently overwrite.
 - Removing a **relation type** is permanent data loss: all stored relations of that type are deleted from the database. Always confirm this with the user and make sure they understand the impact before proceeding.
 - Removing a **permission** deletes no data, but any downstream permissions or checks that depended on it will silently stop working. Confirm with user.
-- Adding relations or permissions is generally safe. One exception: adding a new subject to a **subtraction** (`-`) clause narrows who gets blocked, which could unintentionally grant access to users who were previously excluded. Flag this.
+- Adding relations or permissions is generally safe. One exception: modifying or deleting a relation that appears in a **subtraction** (`-`) clause is risky — if existing tuples of that relation type are lost as part of the schema change, users who were being blocked will silently gain access. Flag this when proposing any change to such a relation.
 
 ## Validation and Apply Workflow
 
@@ -264,7 +264,6 @@ constraint Sanction:GeoCountry("KP","IR","SY","RU")
 type User
 
 type Resource
-  relation allowed: User with FiveEyes
-  relation blocked: User with Sanction
-  permission can_access: allowed - blocked
+  relation allowed: User with FiveEyes & !Sanction
+  permission can_access: allowed
 ```

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -104,12 +104,12 @@ A custom `condition` that checks a numeric range is just reinventing `NumRange` 
 
 **Wrong:**
 ```
-condition DuringBusinessHours(hour_utc int) { hour_utc >= 10 && hour_utc < 22 }
+condition DuringBusinessHours(seconds_since_midnight int) { seconds_since_midnight >= 32400 && seconds_since_midnight < 61200 }
 ```
 
 **Right:**
 ```
-constraint BusinessHours:NumRange(10, 21)
+constraint BusinessHours:NumRange(32400, 61200)
 ```
 
 (Use a named alias when you want a descriptive name for the constraint.)

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -201,11 +201,20 @@ If `hasDeletes` is false, just show the schema and ask for confirmation.
 
 ### Step 3 — Get confirmation
 
-Wait for explicit user approval before applying. Do not apply automatically.
+End your turn after Step 2. Do not call `CreateFGASchema` in the same turn as `DryRunSchema` — the user must see the schema and any deletion warnings before you proceed. Wait for the user to reply with explicit approval ("yes", "apply", "go ahead", etc.).
 
 ### Step 4 — Apply
 
-Use the `CreateFGASchema` MCP tool with the same DSL. Confirm success to the user.
+Before calling `CreateFGASchema`, verify all three of the following are true:
+- You showed the full DSL in a code block in a prior turn (not in this turn)
+- You surfaced all deletion warnings from the dry-run response (or confirmed `hasDeletes` was false)
+- The user's most recent message is an explicit approval in response to your confirmation prompt
+
+If any of these are not true, do not call `CreateFGASchema`. Go back to Step 2 instead.
+
+When all three are confirmed, call `CreateFGASchema` with the same DSL from the dry run. Confirm success to the user.
+
+The reason this gate matters: `CreateFGASchema` is irreversible. Relation tuples deleted by a schema change cannot be recovered. Skipping confirmation is never safe, even when the change looks minor.
 
 ## Examples
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -100,7 +100,7 @@ permission can_delete: creator
 
 ### Don't write custom CEL when a built-in constraint covers it
 
-A custom `condition` that checks a numeric range is just reinventing `NumRange` (or `NumAtLeast`/`NumAtMost`). Built-in constraints are validated at schema-save time and have no CEL cost. Use them.
+A custom `condition` that checks a numeric range is just reinventing `NumRange` (or `NumAtLeast`/`NumAtMost`). Built-in constraints are more concise, less error-prone, and form a common vocabulary that makes schemas easier for both humans and agents to read and reason about. Use them.
 
 **Wrong:**
 ```

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -116,7 +116,7 @@ constraint BusinessHours:NumRange(32400, 61200)
 
 ## Relations vs Permissions
 
-A **relation** adds an edge to the pure relations graph. A **permission** is a derived rule that reuses existing relations — it adds edges only in the ReBAC graph without introducing new pure-graph edges. Fewer pure-graph edges means less to iterate during checks and a higher chance of cache hits, so permissions are both more concise and tend to perform better as the system scales. Prefer satisfying a requirement with a permission whenever possible. Only introduce a new relation when a direct stored link is truly needed.
+A **relation** adds an edge to the pure relations graph. A **permission** is a derived rule that reuses existing relations — it adds edges only in the ReBAC graph without introducing new pure-graph edges. Fewer pure-graph edges means less to iterate during checks and a higher chance of cache hits across all checks in the schema, so permissions are more concise and keeping the pure graph lean tends to improve overall check performance as the system scales. Prefer satisfying a requirement with a permission whenever possible. Only introduce a new relation when a direct stored link is truly needed.
 
 ## Built-in Constraints
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -120,7 +120,7 @@ A **relation** adds an edge to the pure relations graph. A **permission** is a d
 
 ## Built-in Constraints
 
-Use built-in constraints before reaching for custom CEL — they're validated at schema-save time.
+Use built-in constraints before reaching for custom CEL.
 
 | Constraint | Runtime params (zero-arg form) | Hardcoded form |
 |---|---|---|

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -157,7 +157,8 @@ CEL param types: `int`, `string`, `bool`, `double`, `list`, `ipaddress`. Body mu
 When editing an existing schema, first read the current schema with `GetFGASchema` so you have the real state.
 
 - If the user asks to add something already present, tell them exactly what exists and stop — don't silently overwrite.
-- Removing an entire **type** or a **relation definition** from the schema will cause all relation tuples of that type or relation to be permanently deleted from the database. **Editing a relation definition is equivalent to deleting it and recreating it** — the same data loss risk applies. Always confirm with the user and make sure they understand the impact before proceeding.
+- Removing an entire **type** or a **relation definition** from the schema will cause all relation tuples of that type or relation to be permanently deleted from the database. **Editing the target type(s) of a relation definition is equivalent to deleting it and recreating it** — the same data loss risk applies. Always confirm with the user and make sure they understand the impact before proceeding.
+- **Exception: editing only the `with` condition of a relation does NOT delete tuples.** Relations are stored unconditionally; the condition is evaluated at check time. Changing `with CondA` to `with CondB` on an otherwise unchanged relation preserves all existing tuples — they simply start being evaluated against the new condition. This is safer than a full relation edit, but still requires caution: callers relying on the old condition's behavior will get different access results after the change.
 - Removing or editing a **permission** deletes no relation tuples, but any downstream permissions or checks that depended on it will silently stop working. Confirm with user.
 - Adding a new type, relation, or permission is generally safe.
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -116,7 +116,7 @@ constraint BusinessHours:NumRange(32400, 61200)
 
 ## Relations vs Permissions
 
-A **relation** adds an edge to the pure relations graph. A **permission** is a derived rule that reuses existing relations — it adds edges only in the ReBAC graph without introducing new pure-graph edges. Fewer pure-graph edges means less to iterate during checks and a higher chance of cache hits, so permissions are both more concise and typically faster. Prefer satisfying a requirement with a permission whenever possible. Only introduce a new relation when a direct stored link is truly needed.
+A **relation** adds an edge to the pure relations graph. A **permission** is a derived rule that reuses existing relations — it adds edges only in the ReBAC graph without introducing new pure-graph edges. Fewer pure-graph edges means less to iterate during checks and a higher chance of cache hits, so permissions are both more concise and tend to perform better as the system scales. Prefer satisfying a requirement with a permission whenever possible. Only introduce a new relation when a direct stored link is truly needed.
 
 ## Built-in Constraints
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -118,6 +118,22 @@ constraint BusinessHours:NumRange(32400, 61200)
 
 A **relation** adds an edge to the pure relations graph. A **permission** is a derived rule that reuses existing relations — it adds edges only in the ReBAC graph without introducing new pure-graph edges. Fewer pure-graph edges means less to iterate during checks and a higher chance of cache hits across all checks in the schema, so permissions are more concise and keeping the pure graph lean tends to improve overall check performance as the system scales. Prefer satisfying a requirement with a permission whenever possible. Only introduce a new relation when a direct stored link is truly needed.
 
+When a permission is a strict superset of another, express it by referencing the narrower permission rather than repeating its expansion. This keeps schemas concise and makes the access hierarchy self-documenting — a reader immediately sees that `can_write` implies `can_admin`.
+
+**Avoid (repeats relations across permissions):**
+```
+permission can_admin: owner
+permission can_write: owner | editor
+permission can_read: owner | editor | viewer
+```
+
+**Prefer (each permission builds on the previous):**
+```
+permission can_admin: owner
+permission can_write: can_admin | editor
+permission can_read: can_write | viewer
+```
+
 ## Built-in Constraints
 
 Use built-in constraints before reaching for custom CEL.

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -247,12 +247,12 @@ type Repository
 ```
 model AuthZ 1.0
 
-condition DuringShift(now int, begin int, end int) { now >= begin && now <= end }
+constraint ShiftHours:NumRange
 
 type User
 
 type PatientRecord
-  relation viewer: User with DuringShift
+  relation viewer: User with ShiftHours
   relation owner: User
   permission can_view: viewer | owner
 ```

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -116,7 +116,7 @@ constraint BusinessHours:NumRange(32400, 61200)
 
 ## Relations vs Permissions
 
-A **relation** is a stored edge written to the database. A **permission** is a derived rule — no DB write, no stored state, just logic over existing relations. Because every relation requires an explicit API call to create, prefer satisfying a requirement with a permission whenever possible. Only introduce a new relation when a direct stored link is truly needed.
+A **relation** adds an edge to the pure relations graph and requires an explicit API call to create. A **permission** is a derived rule that reuses existing relations — it adds edges only in the ReBAC graph without introducing new pure-graph edges. Fewer pure-graph edges means less to iterate during checks and a higher chance of cache hits, so permissions are both more concise and typically faster. Prefer satisfying a requirement with a permission whenever possible. Only introduce a new relation when a direct stored link is truly needed.
 
 ## Built-in Constraints
 

--- a/skills/fga-dsl/SKILL.md
+++ b/skills/fga-dsl/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: fga-dsl
+description: Author, edit, or apply a Descope FGA schema using the ReBAC/ABAC DSL. Use this skill whenever the user asks to create a new FGA schema, modify an existing one, add types/relations/permissions/conditions, review an authorization model, or apply schema changes to a Descope project. Trigger even if the user says things like "set up authorization", "define roles and permissions", "add team-based access", "make this endpoint check FGA", or "update my authz model" — these almost always mean an FGA schema change.
+---
+
+# FGA DSL Authoring
+
+Help the user design and apply Descope FGA schemas. The workflow is: understand the requirement → draft the DSL → validate via dry run → show the user + any data loss warnings → get confirmation → apply.
+
+## MCP Setup — check first, stop if missing
+
+**Before doing anything else**, check whether the Descope Management MCP is connected by looking for tools whose names contain `FGASchema` or `DryRunSchema` (e.g. `mcp__descope__DryRunSchema`). The exact prefix depends on how the user installed the MCP, but the operation IDs are `DryRunSchema`, `CreateFGASchema`, and `GetFGASchema`.
+
+**If the tools are not found:** output only the message below, then end your turn. Do not generate a schema, do not say "here's what I'll apply once connected", do not do any design work, do not continue:
+
+> The Descope Management MCP is required. If not yet installed, install and authorize it, then restart Claude Code and re-run `/fga-dsl`.
+> If already installed, it may need authorization. Authorize the Descope MCP, then restart Claude Code and re-run `/fga-dsl`.
+
+**If the tools are found:** call `GetFGASchema` immediately as a connectivity probe before doing any other work. If this call returns an authorization error, output only the message below and end your turn:
+
+> The Descope MCP is installed but not authorized. Authorize it and re-run `/fga-dsl`.
+
+All FGA operations go through MCP tool calls — never make raw HTTP requests yourself.
+
+Once connected, use the `GetFGASchema` tool to read the current schema before editing — always do this when the user asks to modify an existing schema.
+
+## Grammar
+
+Every schema begins with exactly:
+```
+model AuthZ 1.0
+```
+No other name or version is accepted by the API.
+
+Full structure:
+```
+model AuthZ 1.0
+
+[constraint <Name>[:<Kind>][(args...)]]*
+[condition <Name>(<param type, ...>) { <CEL bool expr> }]*
+
+type <TypeName>
+  [relation <name>: <TypeRef> [| <TypeRef>]* [with <condExpr>]]*
+  [permission <name>: <expr>]*
+```
+
+Keywords: `model` `type` `relation` `permission` `condition` `constraint` `with`
+
+Operators:
+- Permission expr: `|` union, `&` intersect, `-` subtract. Mix operators with parens: `a | (b - c)`
+- Set arrow: `relation.permission` — walks a stored relation to reach the subject's own permissions (e.g. `parent.can_view`)
+- Userset: `Type#relation` — see dedicated section below
+- `with` clause (relations only): `&` AND, `|` OR, `!` NOT, parens: `with A & (B | !C)`. Conditions are evaluated at **check time** — relations are stored unconditionally; `with` only affects whether the relation counts during permission evaluation.
+
+**No comments** — the DSL parser has no comment token.
+
+Naming: **PascalCase** for Types, Conditions, Constraints. **snake_case** for relations and permissions.
+
+## Userset Pattern (`Type#relation`)
+
+When a relation should be held by members of a group (e.g. "any member of this Team"), put `Type#relation` directly in the relation definition. This stores individual member subjects — the right granularity for permission checks.
+
+The tempting wrong way is to store the group itself and walk to its members via a permission. This looks like it works but stores the wrong thing (a group object instead of its members), and the permission traversal does not expand correctly at check time.
+
+**Wrong:**
+```
+type Repository
+  relation contributor_team: Team
+  permission contributor: contributor_team.member
+```
+
+**Right:**
+```
+type Repository
+  relation contributor: Team#member
+```
+
+You can mix direct subjects with userset subjects: `relation editor: User | Team#member`
+
+## ABAC Anti-Patterns to Avoid
+
+### Never use a "blocked" relation + subtraction to express a condition
+
+`with` conditions are evaluated at **check time** — when a permission check is made against the context passed in the request. Relations are always stored unconditionally; the condition only affects whether the relation counts during permission evaluation.
+
+The `blocked` relation + subtraction pattern is wrong because it requires manually maintaining a separate set of `blocked` edges in the DB for every excluded user. It's the wrong tool: use `with !Condition` on the relation that grants access instead — it is evaluated automatically at check time with no extra stored relations.
+
+```
+// NEVER do this — requires maintaining a separate "blocked" edge per user in the DB
+relation creator: User
+relation blocked: User with NorthKorea
+permission can_delete: creator - blocked
+
+// Right — condition evaluated automatically at check time; no extra edges
+relation creator: User with !NorthKorea
+permission can_delete: creator
+```
+
+**Note:** `with` is currently only supported on **relation definitions**, not on permission expressions. If the user needs a condition on a permission expression directly (e.g. `permission can_delete: creator with !NorthKorea`), that is not yet supported — tell them and ask how they'd like to handle it.
+
+### Don't write custom CEL when a built-in constraint covers it
+
+A custom `condition` that checks a numeric range is just reinventing `NumRange` (or `NumAtLeast`/`NumAtMost`). Built-in constraints are validated at schema-save time and have no CEL cost. Use them.
+
+**Wrong:**
+```
+condition DuringBusinessHours(hour_utc int) { hour_utc >= 10 && hour_utc < 22 }
+```
+
+**Right:**
+```
+constraint BusinessHours:NumRange(10, 21)
+```
+
+(Use a named alias when you want a descriptive name for the constraint.)
+
+## Relations vs Permissions
+
+A **relation** is a stored edge written to the database. A **permission** is a derived rule — no DB write, no stored state, just logic over existing relations. Because every relation requires an explicit API call to create, prefer satisfying a requirement with a permission whenever possible. Only introduce a new relation when a direct stored link is truly needed.
+
+## Built-in Constraints
+
+Use built-in constraints before reaching for custom CEL — they're validated at schema-save time and cheaper to evaluate.
+
+| Constraint | Runtime params (zero-arg form) | Hardcoded form |
+|---|---|---|
+| `IpRange` | `ip ipaddress, ip_range string` | `IpRange("10.0.0.0/8")` |
+| `IpList` | `ip ipaddress, allowed_ips list` | `IpList("1.2.3.4","5.6.7.8")` |
+| `DateExpiryEpochSeconds` | `now_epoch_seconds int, expiry_epoch_seconds int` | `DateExpiryEpochSeconds(1735689600)` |
+| `StringMatchRegex` | `str string` | `StringMatchRegex("^admin_.*")` (regex required) |
+| `NumAtLeast` | `num double, min int` | `NumAtLeast(18)` |
+| `NumAtMost` | `num double, max int` | `NumAtMost(100)` |
+| `NumRange` | `num double, min int, max int` | `NumRange(0,100)` (min ≤ max) |
+| `BoolCheck` | `bool bool, expected bool` | `BoolCheck(true)` |
+| `GeoCountry` | `country_code string, allowed_countries list` | `GeoCountry("US","GB")` (ISO 3166-1 alpha-2) |
+| `IntList` | `int int, allowed_ints list` | `IntList(1,2,3)` |
+| `LabelList` | `label string, allowed_labels list` | `LabelList("foo","bar")` |
+
+**Unique param names:** Each constraint exposes its runtime params by name in check requests. If two constraints of the same kind appear in a schema, their param names collide — use named aliases to give them distinct names:
+```
+constraint FiveEyes:GeoCountry("US","GB","CA","AU","NZ")
+constraint Sanction:GeoCountry("KP","IR","SY","RU")
+```
+The alias form (`Name:Kind`) also applies when two zero-arg constraints of the same kind would produce identical param names.
+
+**Custom CEL** — only when no built-in covers the logic, or when alias-based param separation isn't enough:
+```
+condition InNetwork(user_ip ipaddress, allowed_range string) { user_ip.in_cidr(allowed_range) }
+```
+CEL param types: `int`, `string`, `bool`, `double`, `list`, `ipaddress`. Body must return `bool`. Avoid nested `exists` — the evaluator enforces a cost limit.
+
+## Edit-Safety Protocol
+
+When editing an existing schema, first read the current schema with `GetFGASchema` so you have the real state.
+
+- If the user asks to add something already present, tell them exactly what exists and stop — don't silently overwrite.
+- Removing a **relation type** is permanent data loss: all stored relations of that type are deleted from the database. Always confirm this with the user and make sure they understand the impact before proceeding.
+- Removing a **permission** deletes no data, but any downstream permissions or checks that depended on it will silently stop working. Confirm with user.
+- Adding relations or permissions is generally safe. One exception: adding a new subject to a **subtraction** (`-`) clause narrows who gets blocked, which could unintentionally grant access to users who were previously excluded. Flag this.
+
+## Validation and Apply Workflow
+
+Follow this sequence every time you generate or edit a DSL:
+
+### Step 1 — Dry run
+
+Use the `DryRunSchema` MCP tool with the proposed DSL. This validates the schema and reports what data would be deleted if applied.
+
+- On error: the schema is invalid. Read the error message, fix the DSL, retry. Cap at 5 iterations — if still failing, stop and show the user the last error.
+- On success: continue to Step 2.
+
+The response contains:
+```json
+{
+  "deletesPreview": {
+    "hasDeletes": true,
+    "relations": ["folder#viewer", "doc#editor"],
+    "types": ["LegacyRole"]
+  }
+}
+```
+
+### Step 2 — Show the user
+
+Present:
+1. The full proposed DSL (formatted in a code block)
+2. If `hasDeletes` is true — a clear warning listing every relation type and namespace type that will be **permanently deleted** from the database
+
+Example warning:
+> **Warning: applying this schema will permanently delete all stored relations of these types:**
+> - `folder#viewer`
+> - `doc#editor`
+>
+> This cannot be undone. Confirm to proceed.
+
+If `hasDeletes` is false, just show the schema and ask for confirmation.
+
+### Step 3 — Get confirmation
+
+Wait for explicit user approval before applying. Do not apply automatically.
+
+### Step 4 — Apply
+
+Use the `CreateFGASchema` MCP tool with the same DSL. Confirm success to the user.
+
+## Examples
+
+### Basic ReBAC with hierarchy
+
+```
+model AuthZ 1.0
+
+type User
+
+type Folder
+
+type Doc
+  relation owner: User
+  relation parent: Folder
+  permission can_view: owner | parent.owner
+  permission can_edit: owner
+```
+
+### Group membership via userset
+
+```
+model AuthZ 1.0
+
+type User
+
+type Team
+  relation member: User
+
+type Repository
+  relation owner: User
+  relation contributor: User | Team#member
+  permission can_push: owner | contributor
+  permission can_read: can_push
+```
+
+### ABAC: time-gated access
+
+```
+model AuthZ 1.0
+
+condition DuringShift(now int, begin int, end int) { now >= begin && now <= end }
+
+type User
+
+type PatientRecord
+  relation viewer: User with DuringShift
+  relation owner: User
+  permission can_view: viewer | owner
+```
+
+### Reused constraint kind with aliases
+
+```
+model AuthZ 1.0
+
+constraint FiveEyes:GeoCountry("US","GB","CA","AU","NZ")
+constraint Sanction:GeoCountry("KP","IR","SY","RU")
+
+type User
+
+type Resource
+  relation allowed: User with FiveEyes
+  relation blocked: User with Sanction
+  permission can_access: allowed - blocked
+```


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/etc/issues/15268

## Related PRs

### Upstream PRs (need to wait for deploy before releasing ⚠️ )
- https://github.com/descope/descope/pull/630

## Description
Adds the `descope-fga-schema` Claude Code skill for authoring, editing, and applying Descope FGA schemas via the ReBAC/ABAC DSL.

The skill:
- Requires the Descope Management MCP (`GetFGASchema`, `DryRunSchema`, `CreateFGASchema`) and stops immediately if not connected, with install instructions
- Enforces dry-run → show data loss warnings → confirm → apply workflow
- Includes full DSL grammar reference, userset `Type#relation` pattern (with anti-pattern callout), ABAC built-in constraints table, ABAC anti-patterns (blocked-relation subtraction, custom CEL vs NumRange), `with` check-time semantics, and edit-safety rules
- Never applies a schema without explicit user confirmation

Also adds `CLAUDE.md` to document plugin version bump conventions: patch for skill edits, minor for new skills, major for breaking changes.

## Example using Claude Code
Prompt:
```
I'm building a document management system. Documents live inside folders. Folder owners should be able to do everything with documents inside. Editors can read and write documents, viewers can only read. I also want editors to only have access during business hours (9am–5pm, as seconds since midnight)
```
Chat:
```
⏺ Skill(descope-skills:descope-fga-schema)
  ⎿  Successfully loaded skill
  ⎿  Async hook UserPromptSubmit completed

⏺ Checking for FGA tools via the Descope MCP.

⏺ descope - listOperations (MCP)(category: "fga")

⏺ FGA ops found. Probing connectivity.

⏺ descope - executeOperation (MCP)(operationId: "GetFGASchema")

⏺ Connected. Current schema exists (has User, Team, Repository, Issue, Comment types). Designing doc management schema
  — will dry-run before showing.

⏺ descope - executeOperation (MCP)(operationId: "DryRunSchema", params: {"dsl":"model AuthZ 1.0\n\nconstraint
  BusinessHours:NumRange(32400, 61200)\n\ntype User\n\ntype Folder\n  relation owner: User\n\ntype Document\n  relation
   parent: Folder\n  relation editor: User with BusinessHours\n  relation viewer: User\n  permission can_read: viewer |
   editor | parent.owner\n  permission can_write: editor | parent.owner\n  permission can_delete: parent.owner\n"})

⏺ Schema valid. Here's the proposed DSL:

  model AuthZ 1.0

  constraint BusinessHours:NumRange(32400, 61200)

  type User

  type Folder
    relation owner: User

  type Document
    relation parent: Folder
    relation editor: User with BusinessHours
    relation viewer: User
    permission can_read: viewer | editor | parent.owner
    permission can_write: editor | parent.owner
    permission can_delete: parent.owner

  Design notes:
  - BusinessHours constraint gates editor at check time — pass num (seconds since midnight) in the check request; no
  tuples stored differently
  - parent.owner walks folder→owner, so folder owners get all perms on documents automatically
  - viewer has no time restriction — read-only always

  ---
  Warning: applying this schema will permanently delete all stored relations of these types:
  - Comment
  - Team
  - Repository
  - Issue

  (These are from your current schema. User is preserved.)

  This cannot be undone. Reply yes / apply to proceed.

✻ Sautéed for 1m 1s

❯ apply
  ⎿  Async hook Stop completed
  ⎿  Async hook Notification completed

⏺ descope - executeOperation (MCP)(operationId: "CreateFGASchema", params: {"dsl":"model AuthZ 1.0\n\nconstraint
  BusinessHours:NumRange(32400, 61200)\n\ntype User\n\ntype Folder\n  relation owner: User\n\ntype Document\n  relation
   parent: Folder\n  relation editor: User with BusinessHours\n  relation viewer: User\n  permission can_read: viewer |
   editor | parent.owner\n  permission can_write: editor | parent.owner\n  permission can_delete: parent.owner\n"})
  ⎿  Async hook UserPromptSubmit completed

⏺ Schema applied.
```



## Must
- [ ] Tests
- [ ] Documentation (if applicable)