### PR TITLE
feat(fga-schema): support `with` on permission expressions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "descope-skills",
   "description": "Skills for integrating Descope authentication, managing projects with Terraform, and authoring FGA authorization schemas",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Descope",
     "email": "support@descope.com"

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -299,3 +299,22 @@ type Resource
 ```
 
 `allowed` carries geo-gating on the relation — it applies to every permission that uses `allowed`. `can_delete` uses `with` on the permission itself so the IP restriction scopes only deletion, not access.
+
+### Nested permissions with `with` — conditions stack
+
+```
+model AuthZ 1.0
+
+constraint BusinessHours:NumRange(32400, 61200)
+constraint OfficeNetwork:IpRange("10.0.0.0/8")
+
+type User
+
+type Document
+  relation reader: User
+  relation editor: User
+  permission can_read: reader with BusinessHours
+  permission can_edit: can_read with OfficeNetwork | editor with BusinessHours & OfficeNetwork
+```
+
+`can_edit` via the `can_read` path requires both `BusinessHours` (from `can_read`) **and** `OfficeNetwork` (from `can_edit`'s own `with`). Both conditions must be true at check time — `with` clauses on nested permissions accumulate.

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -280,17 +280,22 @@ type PatientRecord
   permission can_view: viewer | owner
 ```
 
-### Reused constraint kind with aliases
+### Reused constraint kind with aliases — and `with` on a permission
 
 ```
 model AuthZ 1.0
 
 constraint FiveEyes:GeoCountry("US","GB","CA","AU","NZ")
 constraint Sanction:GeoCountry("KP","IR","SY","RU")
+constraint OfficeOnly:IpRange("10.0.0.0/8")
 
 type User
 
 type Resource
   relation allowed: User with FiveEyes & !Sanction
+  relation owner: User
   permission can_access: allowed
+  permission can_delete: owner with OfficeOnly
 ```
+
+`allowed` carries geo-gating on the relation — it applies to every permission that uses `allowed`. `can_delete` uses `with` on the permission itself so the IP restriction scopes only deletion, not access.

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -50,7 +50,7 @@ Operators:
 - Permission expr: `|` union, `&` intersect, `-` subtract. Mix operators with parens: `a | (b - c)`
 - Set arrow: `relation.permission` — walks a stored relation to reach the subject's own permissions (e.g. `parent.can_view`)
 - Target set: `Type#relation` — see dedicated section below
-- `with` clause (relations and permissions): `&` AND, `|` OR, `!` NOT, parens: `with A & (B | !C)`. Conditions are evaluated at **check time** — `with` gates whether the relation or permission counts during evaluation. Only one `with` clause is allowed per relation or permission definition — combine multiple conditions inside it with `&`/`|`/`!`. Use `with` on a relation when the condition should apply everywhere that relation is used; use it on a permission when the condition should scope only that permission (e.g. `permission can_delete: creator with !NorthKorea` gates deletion by country without affecting other permissions that also use `creator`).
+- `with` clause (relations and permissions): `&` AND, `|` OR, `!` NOT, parens: `with A & (B | !C)`. Conditions are evaluated at **check time** — `with` gates whether the relation or permission counts during evaluation. Only one `with` clause is allowed per relation or permission definition — combine multiple conditions inside it with `&`/`|`/`!`.
 
 **No comments** — the DSL parser has no comment token.
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -50,7 +50,7 @@ Operators:
 - Permission expr: `|` union, `&` intersect, `-` subtract. Mix operators with parens: `a | (b - c)`
 - Set arrow: `relation.permission` — walks a stored relation to reach the subject's own permissions (e.g. `parent.can_view`)
 - Target set: `Type#relation` — see dedicated section below
-- `with` clause (relations only): `&` AND, `|` OR, `!` NOT, parens: `with A & (B | !C)`. Conditions are evaluated at **check time** — relations are stored unconditionally; `with` only affects whether the relation counts during permission evaluation.
+- `with` clause (relations and permissions): `&` AND, `|` OR, `!` NOT, parens: `with A & (B | !C)`. Conditions are evaluated at **check time**. On a relation, `with` gates whether that relation counts during evaluation; on a permission expression, `with` gates the entire permission result.
 
 **No comments** — the DSL parser has no comment token.
 
@@ -96,7 +96,7 @@ relation creator: User with !NorthKorea
 permission can_delete: creator
 ```
 
-**Note:** `with` is currently only supported on **relation definitions**, not on permission expressions. If the user needs a condition on a permission expression directly (e.g. `permission can_delete: creator with !NorthKorea`), that is not yet supported — tell them and ask how they'd like to handle it.
+`with` on a permission is useful when the condition should scope only that permission, not the relation itself — e.g. `permission can_delete: creator with !NorthKorea` gates deletion by country without affecting other permissions that also use `creator`.
 
 ### Don't write custom CEL when a built-in constraint covers it
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -41,7 +41,7 @@ model AuthZ 1.0
 
 type <TypeName>
   [relation <name>: <TypeRef> [| <TypeRef>]* [with <condExpr>]]*
-  [permission <name>: <expr>]*
+  [permission <name>: <expr> [with <condExpr>]]*
 ```
 
 Keywords: `model` `type` `relation` `permission` `condition` `constraint` `with`

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -312,9 +312,8 @@ type User
 
 type Document
   relation reader: User
-  relation editor: User
   permission can_read: reader with BusinessHours
-  permission can_edit: can_read with OfficeNetwork | editor with BusinessHours & OfficeNetwork
+  permission can_edit: can_read with OfficeNetwork
 ```
 
-`can_edit` via the `can_read` path requires both `BusinessHours` (from `can_read`) **and** `OfficeNetwork` (from `can_edit`'s own `with`). Both conditions must be true at check time — `with` clauses on nested permissions accumulate.
+`can_edit` requires both `BusinessHours` (from `can_read`) **and** `OfficeNetwork` (from `can_edit`'s own `with`). Both conditions must be true at check time — `with` clauses on nested permissions accumulate.

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -50,7 +50,7 @@ Operators:
 - Permission expr: `|` union, `&` intersect, `-` subtract. Mix operators with parens: `a | (b - c)`
 - Set arrow: `relation.permission` — walks a stored relation to reach the subject's own permissions (e.g. `parent.can_view`)
 - Target set: `Type#relation` — see dedicated section below
-- `with` clause (relations and permissions): `&` AND, `|` OR, `!` NOT, parens: `with A & (B | !C)`. Conditions are evaluated at **check time**. On a relation, `with` gates whether that relation counts during evaluation; on a permission expression, `with` gates the entire permission result.
+- `with` clause (relations and permissions): `&` AND, `|` OR, `!` NOT, parens: `with A & (B | !C)`. Conditions are evaluated at **check time** — `with` gates whether the relation or permission counts during evaluation.
 
 **No comments** — the DSL parser has no comment token.
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -50,7 +50,7 @@ Operators:
 - Permission expr: `|` union, `&` intersect, `-` subtract. Mix operators with parens: `a | (b - c)`
 - Set arrow: `relation.permission` — walks a stored relation to reach the subject's own permissions (e.g. `parent.can_view`)
 - Target set: `Type#relation` — see dedicated section below
-- `with` clause (relations and permissions): `&` AND, `|` OR, `!` NOT, parens: `with A & (B | !C)`. Conditions are evaluated at **check time** — `with` gates whether the relation or permission counts during evaluation.
+- `with` clause (relations and permissions): `&` AND, `|` OR, `!` NOT, parens: `with A & (B | !C)`. Conditions are evaluated at **check time** — `with` gates whether the relation or permission counts during evaluation. Use `with` on a relation when the condition should apply everywhere that relation is used; use it on a permission when the condition should scope only that permission (e.g. `permission can_delete: creator with !NorthKorea` gates deletion by country without affecting other permissions that also use `creator`).
 
 **No comments** — the DSL parser has no comment token.
 
@@ -95,8 +95,6 @@ permission can_delete: creator - blocked
 relation creator: User with !NorthKorea
 permission can_delete: creator
 ```
-
-`with` on a permission is useful when the condition should scope only that permission, not the relation itself — e.g. `permission can_delete: creator with !NorthKorea` gates deletion by country without affecting other permissions that also use `creator`.
 
 ### Don't write custom CEL when a built-in constraint covers it
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -50,7 +50,7 @@ Operators:
 - Permission expr: `|` union, `&` intersect, `-` subtract. Mix operators with parens: `a | (b - c)`
 - Set arrow: `relation.permission` — walks a stored relation to reach the subject's own permissions (e.g. `parent.can_view`)
 - Target set: `Type#relation` — see dedicated section below
-- `with` clause (relations and permissions): `&` AND, `|` OR, `!` NOT, parens: `with A & (B | !C)`. Conditions are evaluated at **check time** — `with` gates whether the relation or permission counts during evaluation. Use `with` on a relation when the condition should apply everywhere that relation is used; use it on a permission when the condition should scope only that permission (e.g. `permission can_delete: creator with !NorthKorea` gates deletion by country without affecting other permissions that also use `creator`).
+- `with` clause (relations and permissions): `&` AND, `|` OR, `!` NOT, parens: `with A & (B | !C)`. Conditions are evaluated at **check time** — `with` gates whether the relation or permission counts during evaluation. Only one `with` clause is allowed per relation or permission definition — combine multiple conditions inside it with `&`/`|`/`!`. Use `with` on a relation when the condition should apply everywhere that relation is used; use it on a permission when the condition should scope only that permission (e.g. `permission can_delete: creator with !NorthKorea` gates deletion by country without affecting other permissions that also use `creator`).
 
 **No comments** — the DSL parser has no comment token.
 


### PR DESCRIPTION
## Related Issues
Required for:
- https://github.com/descope/etc/issues/15290

## Summary
- Removes the "not yet supported" note restricting `with` to relations only
- Updates grammar section to document `with` on both relations and permissions
- Adds clarifying note on when to prefer permission-level vs relation-level `with`

## Checklist
- [x] Follows skill editing conventions (patch bump not needed — already in open PR context... actually this is a new PR so bump needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)