### PR TITLE
feat: improve descope-auth skill score (89% → 97%)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "descope-skills",
   "description": "Skills for integrating Descope authentication, managing projects with Terraform, and authoring FGA authorization schemas",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "Descope",
     "email": "support@descope.com"

--- a/skills/descope-auth/SKILL.md
+++ b/skills/descope-auth/SKILL.md
@@ -22,6 +22,26 @@ Detect the user's framework and use the appropriate reference:
 1. Get Project ID from https://app.descope.com/settings/project
 2. Set environment variable: `NEXT_PUBLIC_DESCOPE_PROJECT_ID=<your-id>`
 3. Follow framework-specific reference
+4. **Verify**: After setup, confirm the `<Descope>` component renders the login form. Check the browser console — a missing or invalid Project ID produces a clear `Could not load flows` error.
+
+### Minimal Inline Example (Next.js)
+
+```tsx
+// src/app/login/page.tsx
+import { Descope } from '@descope/nextjs-sdk';
+
+export default function LoginPage() {
+  return (
+    <Descope
+      flowId="sign-up-or-in"
+      onSuccess={(e) => console.log('Authenticated:', e.detail.user)}
+      onError={(e) => console.error('Auth failed:', e.detail)}
+    />
+  );
+}
+```
+
+For React SPA or backend-only setups, see the framework-specific references below.
 
 ## Valid Flow IDs (CRITICAL - do not invent others)
 


### PR DESCRIPTION
Hey @orius123 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| descope-auth | 89% | 97% | +8% |

<details>
<summary>Changes Summary</summary>

Surgical improvement to the `descope-auth` skill focused on two gaps flagged by evaluation:

**Actionability (Content score 73% → 92%):**
- Added a minimal inline Next.js code example (`<Descope>` component with `sign-up-or-in` flow) so the skill is immediately actionable without consulting reference files first

**Workflow clarity:**
- Added a verification step (step 4) to the Quick Start - confirms the component renders and calls out the specific `Could not load flows` console error for invalid Project IDs

**Version bump:**
- Bumped `.claude-plugin/plugin.json` version `1.1.1 → 1.1.2` (patch, per CONTRIBUTING.md)

</details>

---

I also stress-tested your `auth0-to-descope` skill against a [few real-world task evals](https://tessl.io/registry/skills/github/descope/skills/auth0-to-descope) and it held up really well on multi-framework detection with flow ID routing. The guardrails against inventing flow IDs are a nice touch.

Honest disclosure. I work at @tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

If you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@yogesh-tessl](https://github.com/yogesh-tessl), if you hit any snags.