### PR TITLE
Feat: add workos migration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Manage Descope projects as infrastructure-as-code using the official [Terraform 
 
 </details>
 
+<details>
 <summary><b>auth0-to-descope</b> — Migrate applications from Auth0 to Descope</summary>
 
 Guides self-service migrations from Auth0 to Descope across any language or framework. Analyzes auth touchpoints, produces a reviewed `MIGRATION-PLAN.md`, then executes the migration. Uses the Descope Docs MCP when available to verify SDK method names and option shapes.
@@ -159,6 +160,36 @@ Guides self-service migrations from Okta Customer Identity Service (CIS) to Desc
 **Workflow:** MCP check → migration plan (human review) → execution. Never skips ahead.
 
 </details>
+
+<details>
+<summary><b>workos-to-descope</b> — Migrate applications from WorkOS to Descope</summary>
+
+Guides self-service migrations from WorkOS to Descope across any language or framework. WorkOS is a B2B/enterprise-readiness platform — not just auth — so the skill first identifies which WorkOS features are in use, maps each to Descope, analyzes auth touchpoints, produces a reviewed `MIGRATION-PLAN.md`, then executes the migration. Uses the Descope Docs MCP when available to verify SDK method names and option shapes.
+
+**Use when:**
+- "Migrate my app from WorkOS to Descope"
+- "Replace WorkOS with Descope"
+- "Our app uses @workos-inc/node / @workos-inc/authkit-nextjs / AuthKit — switch to Descope"
+- "How do WorkOS Organizations / Enterprise SSO / Directory Sync / Admin Portal map to Descope?"
+- "We're moving off WorkOS"
+
+**Covers:**
+- SDK replacement for all major frameworks (Next.js, React, Express, Python, Go, Ruby, etc.)
+- WorkOS feature mappings: AuthKit → Descope Flows, Organizations → Tenants, Enterprise SSO → Tenant SSO, Directory Sync/SCIM → Descope SCIM, Admin Portal → SSO Setup Suite / Widgets, RBAC, FGA → ReBAC/AuthZ, Audit Logs, Radar, Pipes → Outbound Apps
+- Tenant routing / home realm discovery (domain-based vs. explicit tenant slug)
+- Descope Flow, Widget, and SSO Setup Suite setup (console-first approach)
+- OIDC compatibility path for incremental migration
+- Session validation patterns and WorkOS-specific gotchas (JWT claims, sealed sessions, SCIM lifecycle)
+
+**Output:**
+- `MIGRATION-PLAN.md` for human review before any code changes
+- SDK replacement across all auth touchpoints in the codebase
+- Descope Flow, Widget, and Console configuration guidance
+
+**Workflow:** MCP check → migration plan (human review) → execution. Never skips ahead.
+
+</details>
+
 
 <details>
 <summary><b>descope-fga-schema</b> — Author and apply Descope FGA authorization schemas</summary>

--- a/skills/workos-to-descope/SKILL.md
+++ b/skills/workos-to-descope/SKILL.md
@@ -691,7 +691,7 @@ yes, skip to verifying items 5–7 — these are easy to miss even for existing 
 ### 1. Create a project and get your Project ID
 
 - Sign in at [console.descope.com](https://console.descope.com)
-- Your **Project ID** appears in the top-left project selector and under **Project → Settings**. It starts with `P` (e.g. `P2abc123...`).
+- Your **Project ID** appears in the top-left project selector and under **Project → Generak**. It starts with `P` (e.g. `P2abc123...`).
 - For Next.js client-side code, this becomes `NEXT_PUBLIC_DESCOPE_PROJECT_ID`. For all server-side SDKs, it's `DESCOPE_PROJECT_ID`.
 
 ### 2. Get a Management Key (if needed)
@@ -700,14 +700,14 @@ Required for: user management API, role/permission management, tenant operations
 configuration, ReBAC (FGA), Outbound Apps. If the app does any server-side user, tenant, SSO,
 or SCIM management, they need this.
 
-- Console → **Company → Management Keys → Generate Key**
+- Console → **Company → Management Keys → + Management Key**
 - Store as `DESCOPE_MANAGEMENT_KEY`. Treat like a secret — never expose client-side.
 
 ### 3. Choose or create a Flow
 
 A Flow is the auth UI sequence. Reference it by Flow ID in the web component.
 
-- Console → **Authentication → Flows**
+- Console → **Flows**
 - The built-in **"sign-up-or-in"** flow handles email/password, OTP, and social login.
 Use it for most migrations.
 - To customise: duplicate "sign-up-or-in", rename it, then edit in the visual builder.
@@ -720,7 +720,7 @@ Use it for most migrations.
 - Console → **Authentication** → select methods (Email OTP, Magic Link, Social, SSO, Passkeys, etc.)
 - For social providers (Google, GitHub, etc.): configure OAuth credentials here, then add
 the provider step to your Flow.
-- For enterprise SSO (SAML/OIDC): Console → **SSO** → configure per tenant, or enable the SSO Setup Suite for tenant-admin self-serve. For correct SSO callback and ACS URLs (social OAuth, SAML ACS, what NOT to use), see `references/implementation-nuances.md` → Social login / SSO section.
+- For enterprise SSO (SAML/OIDC): To configure SSO for a specific tenant or to enable the SSO Setup Suite for tenant-admin self-serve, go to Console → **Tenants**, select the desired tenant, and click **Tenant Settings**. For correct SSO callback and ACS URLs (social OAuth, SAML ACS, what NOT to use), see `references/implementation-nuances.md` → Social login / SSO section.
 
 ### 5. Configure a JWT Template (almost always needed)
 
@@ -744,7 +744,8 @@ Console before the code that assigns them will work.
 WorkOS Organization `metadata` and User metadata map to Descope `customAttributes`.
 Pre-define them in the Console schema before setting them via the SDK.
 
-- Console → **Project → Custom Attributes**
+- **Tenant** custom attributes (the equivalent of WorkOS Organization `metadata`): Console → **Tenants → Custom Attributes** tab → **Create Attribute**
+- **User** custom attributes: Console → **Project → Custom Attributes**
 
 ### 8. Env var summary
 

--- a/skills/workos-to-descope/SKILL.md
+++ b/skills/workos-to-descope/SKILL.md
@@ -1063,7 +1063,14 @@ cannot express the requirement. Ask which auth methods are enabled before recomm
 ### Organizations → Descope Tenants
 
 - WorkOS `organizationId` → a Descope **tenant ID** (the argument you pass to `management.tenant.*` / `management.user.*` calls). At request time the tenant also appears in the session as the nested `tenants` object (`{ tenantId: { roles, permissions } }`) plus `dct` for the active tenant.
-- WorkOS org-scoped login → Descope routes by email domain or tenant name or tenant id
+- WorkOS org-scoped login → Descope **tenant routing** (also called **home realm discovery**). Two
+  main approaches:
+  1. **Domain-based routing** — set an email domain on the tenant (when not using SSO) or an SSO
+     domain on the tenant's SSO configuration (when using SSO). Descope resolves the tenant/IdP from
+     the user's email domain at login.
+  2. **Explicit tenant slug** — pass a tenant name, ID, or slug hardcoded in the app (e.g.
+     per-customer login URL or `sso.start(tenantId, ...)` for a known tenant). Use when each customer
+     has a dedicated login path rather than a shared email-entry screen.
 - Users are project-level in Descope; associated with tenants, not created per-tenant
 - Organization `metadata` → tenant `customAttributes` (pre-define in the Console schema)
 
@@ -1122,9 +1129,10 @@ tenant's SSO config. Rule of thumb: tenant/enterprise SSO → `sso.*`; social or
 app uses the **backend SDKs**, do not migrate or recreate any per-IdP login UI (separate "Sign in
 with Okta" / "Sign in with Azure AD" buttons, provider-picker screens, etc.), regardless of which
 SSO provider the WorkOS code names. In Descope the IdP is defined as **tenant SSO configuration**,
-and a single `sso.start` call resolves it automatically — either from the **user's email domain**
-(domain-based routing) or by passing the **tenant ID / slug** explicitly (e.g. hardcoded for a known
-tenant). So the login surface just collects an email (or targets a known tenant) and calls
+and a single `sso.start` call resolves it automatically via **home realm discovery** — either
+**domain-based routing** (email domain or SSO domain on the tenant config) or an **explicit tenant
+slug** (tenant ID/name hardcoded in source). So the login surface just collects an email (or targets a
+known tenant) and calls
 `sso.start`; Descope selects the correct IdP from config. Keep the UI generic and push all
 provider-specific details into Console/tenant configuration.
 
@@ -1312,9 +1320,7 @@ payload handling. Identify which event types are business-critical. **Effort: Me
 
 ### Domain Verification / Custom Domains → Descope Custom Domains and Tenant Routing
 
-WorkOS domain verification and custom domains map to Descope custom domains and tenant/domain routing
-— especially important for enterprise SSO discovery (routing a user to the right tenant's SSO
-connection by email domain). CNAME setup + verify in Console, then pass `baseUrl` to the SDK if using
+WorkOS Domain Verification maps most closely to Descope’s tenant SSO domain verification, where the customer proves ownership of their email domain with a DNS TXT record. Descope Custom Domains are separate: they configure a CNAME such as auth.example.com so Descope authentication endpoints, cookies, OAuth callbacks, and related URLs can use your own domain.
 a custom auth domain. **Effort: Low–Medium.**
 
 ### Widgets → Descope Widgets

--- a/skills/workos-to-descope/SKILL.md
+++ b/skills/workos-to-descope/SKILL.md
@@ -14,7 +14,7 @@ description: >
 
 This skill guides self-service migrations from WorkOS to Descope. It runs in three parts:
 
-1. **MCP Check** — confirm whether the Descope Docs MCP is available and suggest installing it if not
+1. **MCP Check** — confirm whether the Descope MCP Server is available and suggest installing it if not
 2. **Migration Plan** — gather context via triage questions, analyze the codebase's auth touchpoints, and produce a human-readable `MIGRATION-PLAN.md` for the user to review
 3. **Execution** — if the user confirms they want to proceed, execute the plan
 
@@ -39,33 +39,33 @@ WorkOS migrations to be more B2B-enterprise heavy than a typical consumer-auth m
 
 **Ask, don't assume.** At any design decision point — embed Flows vs. OIDC compatibility, Flow vs. custom code, Widget vs. custom page, MFA inline vs. separate enrollment, programmatic SSO vs. SSO Setup Suite, one-Organization-to-one-Tenant mapping — use `AskUserQuestion` rather than proceeding with an assumption. The cost of a wrong assumption compounds across 20+ files, and the WorkOS Organization → Descope Tenant mapping in particular ripples into SSO, SCIM, RBAC, and domain routing. Uncertainty about architecture or intent is always worth a question.
 
-**MCP over memory.** When the Docs MCP is available (confirmed in Part 1), use `ask-question-about-descope` to verify every SDK method name, option shape, and return type before writing it. Do not fall back to "verify the exact method name in the SDK type declarations" as a hedge — just verify it directly.
+**MCP over memory.** When the Descope MCP Server is available (confirmed in Part 1), use `docs_ask_question` to verify every SDK method name, option shape, and return type before writing it. Do not fall back to "verify the exact method name in the SDK type declarations" as a hedge — just verify it directly.
 
 ---
 
 ## Part 1: MCP Check (BLOCKING)
 
-Before doing anything else, check whether the Descope Docs MCP is available by calling
-`search-descope-docs` with a simple query (e.g., "session validation").
+Before doing anything else, check whether the Descope MCP Server is available by calling
+`docs_search` with a simple query (e.g., "session validation").
 
 **If the tool is available:** proceed to Part 2 immediately.
 
 **If the tool is not available**, show this message and use `AskUserQuestion` to ask whether
 they want to install it first:
 
-> **Descope Docs MCP is not installed.**
+> **Descope MCP is not installed.**
 >
-> This skill uses the Descope Docs MCP to look up current API signatures, SDK methods, and
+> This skill uses the Descope MCP server to look up current API signatures, SDK methods, and
 > feature availability during migration. Without it, guidance is based on static training data,
 > which may be stale and can produce SDK calls that don't exist.
 >
-> You can install it in a few minutes at **[https://docs-mcp.descope.com/](https://docs-mcp.descope.com/)** (server URL:
-> `https://docs-mcp.descope.com/mcp`). It significantly improves the accuracy of the
+> You can install it in a few minutes at **[https://docs.descope.com/mcp/mcp-server](https://docs.descope.com/mcp/mcp-server)** (server URL:
+> `https://mcp.descope.com`). It significantly improves the accuracy of the
 > migration output — especially for SDK lookups and flow-specific configuration.
 >
 > **Would you like to install the MCP before we continue, or proceed without it?**
 
-- If they choose to install: pause and wait. Once they confirm it's installed, re-check by calling `search-descope-docs` again before proceeding.
+- If they choose to install: pause and wait. Once they confirm it's installed, re-check by calling `docs_search` again before proceeding.
 - If they choose to proceed without it: continue, but flag any SDK-specific answers as "based on last known documentation — verify against the current SDK."
 
 Do not proceed to Part 2 until this step is resolved.
@@ -226,7 +226,7 @@ For each hit, record:
 Read `package.json` (or equivalent) for the exact framework version — this affects async
 behavior (Next.js 15 vs 14) and SDK compatibility.
 
-If the Descope Docs MCP is available, use `search-descope-docs` or `ask-question-about-descope`
+If the Descope Docs MCP is available, use `docs_search` or `docs_ask_question`
 to verify current SDK method names for anything you plan to reference in the plan.
 
 ---
@@ -636,9 +636,9 @@ Run before generating any import, wrapper type, or helper. Skipping produces cod
 compiles but fails at runtime.
 
 **1. Verify SDK exports before writing any import.**
-When the Docs MCP is available, use `ask-question-about-descope` to confirm the exact method name, option shape, and return type before writing any SDK call. This is faster and more reliable than reading type declarations. Do not write a method name and add a hedge like "verify the exact name" — just verify it.
+When the Descope MCP server is available, use `docs_ask_question` to confirm the exact method name, option shape, and return type before writing any SDK call. This is faster and more reliable than reading type declarations. Do not write a method name and add a hedge like "verify the exact name" — just verify it.
 
-When the Docs MCP is unavailable: resolve the package's type declarations (`node_modules/<pkg>/dist/types/` or its `package.json` `types` field) and confirm the exact exported name and signature. For Go, run `go doc`. For Python, check the SDK stubs.
+When the Descope MCP server is unavailable: resolve the package's type declarations (`node_modules/<pkg>/dist/types/` or its `package.json` `types` field) and confirm the exact exported name and signature. For Go, run `go doc`. For Python, check the SDK stubs.
 
 **Prefer local `node_modules/` over GitHub** when reading type declarations. Installed packages reflect the exact version in use. If the Descope package isn't installed yet, install it first, then read local type declarations. Only fall back to GitHub if the package can't be installed in the current environment.
 
@@ -778,7 +778,7 @@ WorkOS publishes exactly two SDK families (per the [WorkOS SDKs page](https://wo
 
 The recipes below cover exactly these SDKs — one section each — annotated with the matching Descope target. Do not infer other frameworks (e.g. Express, Flask, FastAPI); a WorkOS app using those is using the underlying language Backend SDK (`workos-node`, `workos-python`, etc.), so map it via that SDK's section.
 
-> The framework recipes below are stubs listing the WorkOS idioms that need mapping. Confirm the exact WorkOS SDK surface for the user's stack and the matching Descope SDK calls via the Docs MCP or local type declarations before generating any code. Do not ship code from these stubs without verification.
+> The framework recipes below are stubs listing the WorkOS idioms that need mapping. Confirm the exact WorkOS SDK surface for the user's stack and the matching Descope SDK calls via the Descope MCP or local type declarations before generating any code. Do not ship code from these stubs without verification.
 
 Read `references/implementation-nuances.md` in two passes before writing any code:
 
@@ -1038,7 +1038,7 @@ For each WorkOS feature confirmed in triage, write a short paragraph: what it ac
 best Descope approach for that goal, what's different, and what action is required. Reason about
 intent, not just the API surface — the best approach may be a Flow, Widget, SSO Setup Suite, or
 Console configuration rather than a direct SDK equivalent. Only recommend SDK/API code when
-programmatic control is genuinely required, and verify every method name against the Docs MCP
+programmatic control is genuinely required, and verify every method name against the Descope MCP server
 before writing it. Include only confirmed features.
 
 ### AuthKit → Descope Flows + JWT Templates
@@ -1104,7 +1104,7 @@ Use `AskUserQuestion` to ask **two** things here:
 | Per-Organization connection | Per-tenant SSO (Console → SSO or Management SDK)  |
 
 
-(Verify exact method names against the Docs MCP.) Ask whether SSO is configured by internal
+(Verify exact method names against the Descope MCP server.) Ask whether SSO is configured by internal
 engineers or by customer admins. **Effort: Medium** — setup recreated per tenant.
 
 **Runtime login calls — always use `sso.start` / `sso.exchange`, never the OAuth flow.** When code

--- a/skills/workos-to-descope/SKILL.md
+++ b/skills/workos-to-descope/SKILL.md
@@ -88,22 +88,24 @@ time and produces incorrect guidance.
 
 Do not proceed to Step 0.5 until the user has answered.
 
+
+////// comment down here ask kevin
+
 **First `AskUserQuestion` call (up to 4 questions):**
 
 1. **Backend language / framework** — Present the most likely options based on any cues
-  in the conversation (e.g., Next.js, Express, Flask/FastAPI, Go, Rails). The user can always
+  in the conversation (e.g., Node.js, Go, Ruby, Python). The user can always
    pick "Other."
 2. **Migration goal** — Full cut-over, incremental/phased migration, or just evaluating.
 3. **Existing users and organizations** — Are they migrating an app with active users and
   organizations in WorkOS, staging/dev only, or starting fresh? This determines whether user
    and organization migration planning is needed (user export, org-to-tenant mapping, SCIM
-   continuity, phased vs. big-bang cutover, forced re-login on cutover). /////// is the 4th even necessary?
-4. **Preferred migration style** — Do they want to embed Descope Flows/Widgets directly (full native migration), or preserve an existing OIDC client library and point it at Descope's OIDC endpoints (OIDC compatibility layer)? Note: B2B features (Organizations/SSO/SCIM management) have no OIDC-layer equivalent and require native SDK calls regardless of path.
+   continuity, phased vs. big-bang cutover, forced re-login on cutover). 
 
 **Second `AskUserQuestion` call — WorkOS feature usage (use `multiSelect: true`):**
 
 1. **Which WorkOS features are in use?** Present the highest-impact categories:
-  - **AuthKit** 
+  - **AuthKit** — WorkOS's hosted/embeddable login UI and session management (email/password, social login, passkeys, MFA, magic auth); which sign-in methods are enabled and whether the hosted or embedded flow is used.
   - **Organizations** — organization membership, organization switching, metadata, whether users can belong to multiple organizations.
   - **Enterprise SSO** — connections SAML, OIDC, or both; whether setup is handled by internal engineers or by customer admins; whether domain-based SSO routing is used.
   - **Directory Sync / SCIM** — which directories; group sync; group-to-role mapping; deprovisioning behavior; directory webhook handlers.
@@ -111,9 +113,9 @@ Do not proceed to Step 0.5 until the user has answered.
   - **RBAC** — whether roles are global/environment or organization-scoped; where permission checks happen in code; whether roles/permissions are in tokens; whether IdP groups map to roles.
   - **FGA** — the authorization model (resources, relationships, privileges, hierarchy); where checks are performed. Flag as high complexity.
   - **Audit Logs** — whether logs are written to WorkOS, read back from WorkOS, shown to customers, or required for compliance.
-  - **Radar** — whether it blocks, challenges, or only monitors suspicious auth attempts; custom rules.
+  - **Radar** — whether it blocks, challenges, or only notifies about suspicious auth attempts; custom rules.
   - **Pipes** — which providers are connected; where connected-account tokens are used (AI agents, integrations, background jobs).
-  - **Vault / Feature Flags** — flag as potentially outside the core Descope identity migration unless used directly for auth or access control.
+  - **Vault / Feature Flags** — flag as potentially outside the core Descope identity migration.
   - **MCP Auth / Connect** — flag for deeper review before implementation.
   - The user can add others via "Other."
 
@@ -133,7 +135,7 @@ Step 0 answers (e.g., skip user migration planning if they said they're starting
 **Access and credentials**
 
 - Do they have access to the Descope Console and a Project ID? (If not, see Step 1.5.)
-- Do they need a Management Key? (Required for user CRUD, role management, ReBAC, tenant/SSO/SCIM configuration, Outbound Apps.)
+- Do they need a Management Key? (Required for user CRUD, RBAC, ReBAC, tenant/SSO/SCIM configuration, Outbound Apps.)
 
 **Codebase scope**
 
@@ -256,7 +258,7 @@ Include a **Migration at a Glance** table:
 
 |                                  |                                                                     |
 | -------------------------------- | ------------------------------------------------------------------- |
-| **Approach**                     | Full native migration / OIDC compatibility layer                    |
+| **Approach**                     | Full native migration                                               |
 | **Files changing**               | N source files across N areas                                       |
 | **Console setup**                | N configuration steps before launch                                 |
 | **User impact**                  | No re-login required / Users will need to log in once after cutover |
@@ -284,11 +286,33 @@ Tailor to triage findings.
 
 ---
 
+#### Client SDK vs. Backend SDK: A Specific 1-to-1 Mapping
+
+For every WorkOS touchpoint found in triage, produce a concrete, one-to-one mapping — WorkOS construct → the exact Descope SDK and method that replaces it —
+and state explicitly whether that replacement runs in the **client SDK** or the **backend SDK**, and
+why. Use this division of responsibility:
+
+- **Client SDK** (`@descope/web-js-sdk`, `@descope/react-sdk`, `@descope/nextjs-sdk` client
+  components, or the `<descope-wc>` web component) — everything the user's browser/app does:
+  rendering the login/sign-up UI (a Descope Flow replaces AuthKit's hosted or redirect login),
+  initiating authentication, holding the session on the client, refreshing the token, and reading
+  the current user for UI purposes. This replaces AuthKit's UI, the redirect cycle, and any
+  client-side session access. It uses only the public Project ID — never a Management Key.
+- **Backend SDK** (`@descope/node-sdk`, `descope` (Python), `github.com/descope/go-sdk`, etc.) —
+  everything the server does: validating the session JWT on every request (replacing WorkOS
+  server-side `withAuth()` / middleware), checking roles and permissions, and — with a Management
+  Key — all administrative operations done by ID (user and tenant CRUD, role/permission definitions,
+  SSO/SCIM configuration, ReBAC). This replaces WorkOS server-side validation and every WorkOS
+  Management API call.
+
+For each file or area, name the WorkOS call, the Descope SDK that replaces it, which side it runs on,
+and the reason (e.g. "session validation must stay server-side because the validation/Management key
+cannot ship to the browser"). When one WorkOS feature spans both sides — for example AuthKit login
+(now a client Flow) plus per-request `withAuth()` validation (now the backend SDK) — split it into
+its client half and its backend half so the reader sees exactly what moves where, and why each piece
+belongs on that side.
+
 ---
-
-/// Very specific 1 to 1 comparison to using descope client and backend sdk's
-
-make sure 
 
 #### Auth Touchpoints: What the Code Analysis Found
 
@@ -296,12 +320,12 @@ Open with the scope count (e.g., "11 files across 4 areas"). Group by area, not 
 Each group gets a sentence on what it does and what changes.
 
 **Session handling (3 files)** — These files read and validate the current user's login
-state. They'll be updated to use the Descope session SDK instead of WorkOS AuthKit.
+state. They'll be updated to use the Descope session SDK instead of WorkOS AuthKit. 
 
 
 | File               | What it does today                                                            | What changes                                                                                              |
 | ------------------ | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `lib/auth.ts:34`   | Returns WorkOS session via `withAuth()` with `user`, `organizationId`, `role` | Rewritten to return Descope `AuthenticationInfo`; a thin adapter layer preserves the shape callers expect |
+| `lib/auth.ts:34`   | Returns WorkOS session via `withAuth()` with `user`, `organizationId`, `role` | Rewritten to return Descope `authInfo`; a thin adapter layer preserves the shape callers expect |
 | `middleware.ts:12` | `authkitMiddleware()` blocks unauthenticated requests app-wide                | Updated to call Descope session validation; logic is identical, SDK call changes                          |
 
 
@@ -328,12 +352,15 @@ recommend SDK code when programmatic control is genuinely required. Example:
 
 > **Multi-tenancy (WorkOS Organizations → Descope Tenants)**
 > WorkOS Organizations group users by company and scope SSO, SCIM, roles, and domain policies.
-> Descope has the same concept, called Tenants. The main difference is how tenant membership
-> appears in the session token — WorkOS exposes a flat `organizationId`, while Descope uses a
-> nested `tenants` object that includes per-tenant roles (plus `dct` for the active tenant ID).
-> Any backend code that reads `organizationId` will need to be updated to read `token.dct` or
-> `token.tenants`. This is a predictable, mechanical change, but it ripples into SSO, SCIM, and
-> RBAC, so confirm the org→tenant mapping before starting.
+> Descope has the same concept, called Tenants. Most code that handles organizations is
+> management/admin code that passes a WorkOS `organizationId` to the API — that simply becomes a
+> Descope **tenant ID** passed to `descopeClient.management.tenant.*` / `management.user.*` calls
+> (load a tenant, create one, add/remove membership, scope roles). This is by-ID work, not token
+> parsing. The only place a tenant shows up as a claim is request-time session reads: WorkOS's flat
+> `organizationId` (from `withAuth()`) becomes Descope's nested `tenants` object (plus `dct` for the
+> active tenant), which you read off the validated session — ideally via SDK helpers like
+> `validateTenantRoles(authInfo, tenantId, [...])` rather than parsing claims by hand. Confirm the
+> org→tenant mapping first, since it ripples into SSO, SCIM, and RBAC.
 > **Effort: Medium (1–2 hours of code changes).** Confirm the data migration path for orgs first.
 
 Only include confirmed features.
@@ -474,7 +501,7 @@ Work through files in the order listed. Run a compile check after each group.
 - Rewrite session helper / `withAuth()` usage (30 min)
 - Swap AuthKit provider/middleware for Descope equivalents (15 min)
 - Update protected route files to use new session check (45 min)
-- Update org/tenant claim reads (`organizationId` → `token.dct`/`token.tenants`) (varies)
+- Repoint org handling to tenant IDs — management calls pass a `tenantId`; request-time session reads use `tenants`/`dct` (varies)
 - Update logout — two-step logout (15 min)
 - Compile check and fix any type errors before proceeding
 
@@ -786,11 +813,11 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 #### Go
 
-#### *WorkOS SDK: `workos-go` → Descope `github.com/descope/go-sdk`*
+#### *WorkOS SDK: `workos-go` → Descope Go SDK `github.com/descope/go-sdk`*
 
 - Remove the WorkOS Go SDK; add `descope/go-sdk`
 - Session validation: `descopeClient.Auth.ValidateSessionWithToken(ctx, token)` returns `(bool, *descope.Token, error)`
-- WorkOS `organizationId` → Descope `Token.Claims` (`dct` / `tenants`)
+- WorkOS `organizationId` → a Descope **tenant ID**: pass it to management calls (`descopeClient.Management.Tenant()` / user-tenant association); at request time read tenant context off the returned `*descope.Token` (`token.GetTenants()`, or the `dct` claim for the active tenant)
 
 #### Ruby
 
@@ -1016,14 +1043,14 @@ cannot express the requirement. Ask which auth methods are enabled before recomm
 
 ### Organizations → Descope Tenants
 
-- WorkOS `organizationId` (flat string) → Descope /// internal tenant id (nested object: `{ tenantId: { roles, permissions } }`)
+- WorkOS `organizationId` → a Descope **tenant ID** (the argument you pass to `management.tenant.*` / `management.user.*` calls). At request time the tenant also appears in the session as the nested `tenants` object (`{ tenantId: { roles, permissions } }`) plus `dct` for the active tenant.
 - WorkOS org-scoped login → Descope routes by email domain or tenant name or tenant id
 - Users are project-level in Descope; associated with tenants, not created per-tenant
 - Organization `metadata` → tenant `customAttributes` (pre-define in the Console schema)
 
 Confirm the one-Organization-to-one-Tenant mapping before writing code — it ripples into SSO, SCIM,
-RBAC, and domain routing. **Effort: Medium** (clean conceptually; org-claim reads may be spread
-across many files).
+RBAC, and domain routing. **Effort: Medium** (clean conceptually; most `organizationId` usage is
+management calls that take a tenant ID, with a smaller set of session reads that change shape).
 
 ### Enterprise SSO → Descope Tenant SSO
 
@@ -1097,7 +1124,7 @@ Ask which admin workflows are hosted by WorkOS today before choosing a replaceme
 WorkOS roles come in two scopes, and they map to Descope's two scopes:
 
 - **Environment-level role** (defined on the WorkOS environment, available across all organizations) → **Descope project-level role** (applies across all tenants).
-- **Organization-scoped role** (a WorkOS "custom role", defined for a specific organization) → **Descope tenant-level role** (under `token.tenants[tenantId].roles`).
+- **Organization-scoped role** (a WorkOS "custom role", defined for a specific organization) → **Descope tenant-level role**, created by passing a `tenantId` to `management.role.create(...)` (it surfaces per-tenant when you check roles on the session, e.g. `validateTenantRoles`).
 
 
 | WorkOS                                                    | Descope                                          |
@@ -1264,7 +1291,7 @@ as an OAuth provider, an OAuth client, or both. **Effort: Medium–High — flag
 
 ### Vault → Possibly Out of Scope
 
-WorkOS Vault (encrypting/storing/controlling access to sensitive data) may have no direct Descope
+WorkOS Vault and EKM (encrypting/storing/controlling access to sensitive data) may have no direct Descope
 identity equivalent. Flag it separately and ask whether it is part of the identity migration or a
 separate secrets/data-security effort. **Do not present it as an SDK swap.**
 
@@ -1284,11 +1311,14 @@ Descope session JWTs contain `sub`, `amr`, `drn`, `tenants`, `roles`, `permissio
 default. They do **not** contain `email`, `name`, or `picture`. WorkOS AuthKit tokens may expose
 some profile fields, so code that reads them directly will break after migration.
 
-`dct` (Descope Current Tenant) is a flat string holding the active tenant ID — the direct equivalent
-of WorkOS's `organizationId`. For apps where a user is always in a single tenant context, `token.dct`
-is simpler to read than iterating `token.tenants`. Use `token.tenants` when you need per-tenant roles
-or permissions (it is a keyed object: `{ [tenantId]: { roles, permissions } }`); use `token.dct`
-when you only need the tenant ID.
+`dct` and `tenants` only matter when you read a user's tenant context **from their session at
+request time** — not for tenant administration, which is done by tenant ID through
+`management.tenant.*` / `management.user.*`. When you do read the session, `dct` (Descope Current
+Tenant) is a flat string holding the active tenant ID — the direct equivalent of WorkOS's
+`organizationId` — and `tenants` is a keyed object (`{ [tenantId]: { roles, permissions } }`) for
+per-tenant roles/permissions. Prefer the SDK's role/permission helpers (e.g.
+`validateTenantRoles(authInfo, tenantId, [...])`) over reading these claims by hand; reach for `dct`
+when you only need the active tenant ID.
 
 **Action required:** Configure a JWT Template in the Descope Console to add `email`,
 `name`, and any other profile fields the app reads from the token.
@@ -1313,12 +1343,14 @@ Descope session tokens have no `aud` claim by default. Apps that rely on audienc
 must (1) configure a custom `aud` claim in JWT Templates and (2) pass `audience` to
 `validateSession()` on the backend.
 
-### Organization Claim Shape Differs
+### Organization Handling: Tenant IDs, Not Token Parsing
 
-WorkOS exposes a flat `organizationId` (and `connectionId` / `directoryId`). Descope uses `dct`
-(active tenant) and the nested `tenants` object. Any code reading `organizationId` needs to be
-updated — this is mechanical but can span many files, so grep for all org-claim reads and update
-them in one pass.
+Most code that references a WorkOS `organizationId` (and `connectionId` / `directoryId`) is
+management/admin code — it becomes a Descope **tenant ID** passed to `management.tenant.*` /
+`management.user.*` calls. Only request-time code that read the org off the WorkOS session changes
+shape: Descope exposes the active tenant as `dct` and membership as the nested `tenants` object,
+read off the validated session (ideally via SDK helpers). Grep for all `organizationId` reads and
+sort them into these two buckets — by-ID management calls vs. session reads — before updating.
 
 ### One Token, Not Provider-Specific Access Tokens
 
@@ -1407,7 +1439,8 @@ npm test   # or: pytest / go test ./... / etc.
 
 Auth-related test failures usually mean: a mock or fixture still uses WorkOS shapes, or a
 test validates JWT claims that are now missing (e.g., `email` without a JWT Template), or a test
-reads `organizationId` instead of `token.dct`.
+still uses `organizationId` where the code now passes a Descope tenant ID (management calls) or
+reads `dct`/`tenants` off the validated session.
 
 ### Phase 3: Smoke test the running app
 

--- a/skills/workos-to-descope/SKILL.md
+++ b/skills/workos-to-descope/SKILL.md
@@ -1,5 +1,7 @@
 ---
-name: workos-to-descope
+
+## name: workos-to-descope
+
 description: >
   Use this skill whenever anyone asks about migrating from WorkOS to Descope — whether they're
   a developer doing it themselves or a technical lead evaluating the move. Triggers on: "how
@@ -9,7 +11,6 @@ description: >
   Admin Portal, RBAC, FGA, Audit Logs, Radar, Pipes) in the context of Descope. Works for any
   language or framework with a Descope SDK. Always use this skill before producing migration
   guidance — do not rely on memory alone.
----
 
 # WorkOS → Descope Migration Skill
 
@@ -28,6 +29,7 @@ features are in use, then maps each one to the closest Descope feature or migrat
 WorkOS migrations to be more B2B-enterprise heavy than a typical consumer-auth migration.
 
 **Primary references** (both in this skill's directory):
+
 - `references/implementation-nuances.md` — verified migration patterns for each framework, WorkOS feature-to-Descope mappings, and known gotchas
 - `references/flows-and-widgets.md` — Descope terminology/lingo, Flow structure and templates, Widgets, SSO Setup Suite, Console-vs-code decision guide
 
@@ -59,7 +61,7 @@ they want to install it first:
 > feature availability during migration. Without it, guidance is based on static training data,
 > which may be stale and can produce SDK calls that don't exist.
 >
-> You can install it in a few minutes at **https://docs-mcp.descope.com/** (server URL:
+> You can install it in a few minutes at **[https://docs-mcp.descope.com/](https://docs-mcp.descope.com/)** (server URL:
 > `https://docs-mcp.descope.com/mcp`). It significantly improves the accuracy of the
 > migration output — especially for SDK lookups and flow-specific configuration.
 >
@@ -91,47 +93,46 @@ Do not proceed to Step 0.5 until the user has answered.
 **First `AskUserQuestion` call (up to 4 questions):**
 
 1. **Backend language / framework** — Present the most likely options based on any cues
-   in the conversation (e.g., Next.js, Express, Flask/FastAPI, Go, Rails). The user can always
+  in the conversation (e.g., Next.js, Express, Flask/FastAPI, Go, Rails). The user can always
    pick "Other."
 2. **Migration goal** — Full cut-over, incremental/phased migration, or just evaluating.
 3. **Existing users and organizations** — Are they migrating an app with active users and
-   organizations in WorkOS, staging/dev only, or starting fresh? This determines whether user
+  organizations in WorkOS, staging/dev only, or starting fresh? This determines whether user
    and organization migration planning is needed (user export, org-to-tenant mapping, SCIM
    continuity, phased vs. big-bang cutover, forced re-login on cutover).
 4. **Preferred migration style** — Do they want to embed Descope Flows/Widgets directly (full native migration), or preserve an existing OIDC client library and point it at Descope's OIDC endpoints (OIDC compatibility layer)? Note: B2B features (Organizations/SSO/SCIM management) have no OIDC-layer equivalent and require native SDK calls regardless of path.
 
 **Second `AskUserQuestion` call — WorkOS feature usage (use `multiSelect: true`):**
 
-5. **Which WorkOS features are in use?** Present the highest-impact categories:
-   - AuthKit / User Management (core auth replacement)
-   - Organizations (multi-tenancy / B2B)
-   - Enterprise SSO (SAML / OIDC connections)
-   - Directory Sync / SCIM (directory provisioning)
-   - Admin Portal (hosted self-serve admin setup)
-   - Domain Verification / Custom Domains
-   - RBAC / roles / permissions
-   - Fine-Grained Authorization / FGA
-   - Audit Logs
-   - Radar / bot or fraud protection
-   - Pipes / connected accounts
-   - Webhooks / Events
-   - Widgets
-   - MCP Auth / Connect
-   - Vault
-   - Feature Flags
-
+1. **Which WorkOS features are in use?** Present the highest-impact categories:
+  - AuthKit / User Management (core auth replacement)
+  - Organizations (multi-tenancy / B2B)
+  - Enterprise SSO (SAML / OIDC connections)
+  - Directory Sync / SCIM (directory provisioning)
+  - Admin Portal (hosted self-serve admin setup)
+  - Domain Verification / Custom Domains
+  - RBAC / roles / permissions
+  - Fine-Grained Authorization / FGA
+  - Audit Logs
+  - Radar / bot or fraud protection
+  - Pipes / connected accounts
+  - Webhooks / Events
+  - Widgets
+  - MCP Auth / Connect
+  - Vault
+  - Feature Flags
    The user can add others via "Other." Follow up on anything selected:
-   - **Organizations** — organization membership, organization switching, metadata, whether users can belong to multiple organizations.
-   - **Enterprise SSO** — connections SAML, OIDC, or both; whether setup is handled by internal engineers or by customer admins; whether domain-based SSO routing is used.
-   - **Directory Sync / SCIM** — which directories; group sync; group-to-role mapping; deprovisioning behavior; directory webhook handlers.
-   - **Admin Portal / Widgets** — which customer-admin workflows are hosted by WorkOS today; whether the app generates portal links; whether Descope Widgets or the SSO Setup Suite can replace them.
-   - **RBAC** — whether roles are global or organization-scoped; where permission checks happen in code; whether roles/permissions are in tokens; whether IdP groups map to roles.
-   - **FGA** — the authorization model (resources, relationships, privileges, hierarchy); where checks are performed. Flag as high complexity.
-   - **Audit Logs** — whether logs are written to WorkOS, read back from WorkOS, shown to customers, or required for compliance.
-   - **Radar** — whether it blocks, challenges, or only monitors suspicious auth attempts; custom rules.
-   - **Pipes** — which providers are connected; where connected-account tokens are used (AI agents, integrations, background jobs).
-   - **Vault / Feature Flags** — flag as potentially outside the core Descope identity migration unless used directly for auth or access control.
-   - **MCP Auth / Connect** — flag for deeper review before implementation.
+  - **Organizations** — organization membership, organization switching, metadata, whether users can belong to multiple organizations.
+  - **Enterprise SSO** — connections SAML, OIDC, or both; whether setup is handled by internal engineers or by customer admins; whether domain-based SSO routing is used.
+  - **Directory Sync / SCIM** — which directories; group sync; group-to-role mapping; deprovisioning behavior; directory webhook handlers.
+  - **Admin Portal / Widgets** — which customer-admin workflows are hosted by WorkOS today; whether the app generates portal links; whether Descope Widgets or the SSO Setup Suite can replace them.
+  - **RBAC** — whether roles are global or organization-scoped; where permission checks happen in code; whether roles/permissions are in tokens; whether IdP groups map to roles.
+  - **FGA** — the authorization model (resources, relationships, privileges, hierarchy); where checks are performed. Flag as high complexity.
+  - **Audit Logs** — whether logs are written to WorkOS, read back from WorkOS, shown to customers, or required for compliance.
+  - **Radar** — whether it blocks, challenges, or only monitors suspicious auth attempts; custom rules.
+  - **Pipes** — which providers are connected; where connected-account tokens are used (AI agents, integrations, background jobs).
+  - **Vault / Feature Flags** — flag as potentially outside the core Descope identity migration unless used directly for auth or access control.
+  - **MCP Auth / Connect** — flag for deeper review before implementation.
 
 After both calls, summarize findings and flag high-complexity items (Directory Sync/SCIM, FGA,
 Pipes, MCP Auth/Connect, Vault) before proceeding to Step 0.5.
@@ -147,19 +148,23 @@ Batch into calls of up to 4 questions. Skip questions that are clearly inapplica
 Step 0 answers (e.g., skip user migration planning if they said they're starting fresh).
 
 **Access and credentials**
+
 - Do they have access to the Descope Console and a Project ID? (If not, see Step 1.5.)
 - Do they need a Management Key? (Required for user CRUD, role management, ReBAC, tenant/SSO/SCIM configuration, Outbound Apps.)
 
 **Codebase scope**
+
 - Are there places in the app that read claims directly from the session token (e.g. `user.email`, `claims.organization_id`, `role`/`permissions`)? These need a JWT Template configured before they'll work.
 - Does the app read WorkOS `organizationId`, `connectionId`, or `directoryId` in many places? The WorkOS Organization → Descope Tenant remap ripples through SSO, SCIM, RBAC, and membership checks — confirm the org model before writing code.
 - Are there multiple services or microservices validating WorkOS tokens/sessions? Each needs to be updated to validate Descope JWTs.
 
 **Deployment and risk**
+
 - Do they have multiple environments (dev / staging / prod)? Each needs its own Descope project and Project ID.
 - Is there a maintenance window, or does this need to be zero-downtime?
 
 **User and organization migration** (if they indicated existing users/orgs in Step 0)
+
 - How many users and organizations? This determines export approach and whether a phased cutover is warranted.
 - Do they use passwords in AuthKit? Plan how password credentials carry over (export/import vs. reset vs. passwordless). Verify the current WorkOS user-export capability and the Descope import path before committing to an approach.
 - Big-bang cutover or phased? Map each WorkOS Organization to a Descope Tenant first; user membership and tenant-scoped roles depend on it.
@@ -167,12 +172,14 @@ Step 0 answers (e.g., skip user migration planning if they said they're starting
 - Are they aware that active WorkOS sessions will be invalidated on cutover unless a session-bridging approach is used? Plan for a forced re-login or phased rollout.
 
 **Gaps to flag immediately** (don't ask — flag these proactively based on Step 0 answers)
+
 - If they're using **Vault** or **Feature Flags**: these may have no direct Descope identity equivalent. Flag separately; do not pretend they are Descope SDK swaps. Ask whether they're in scope.
 - If they're using **MCP Auth / Connect**: flag for deeper review before any implementation — likely maps to Descope Inbound Apps / OAuth app patterns, but needs dedicated mapping.
 - If they're using **Audit Logs**: set up Descope's Audit Webhook Connector before cutover to avoid gaps in compliance/event logging. Missing this can break compliance visibility even though the app still runs.
 - If they're using **Pipes / connected accounts**: connected third-party tokens may power integrations or background jobs. Identify provider connections and whether users must reconnect accounts.
 
 **Console/Flow/Widget opportunities** (flag before codebase analysis, then ask):
+
 - If the app uses the **WorkOS Admin Portal** or generates portal links: ask whether the SSO Setup Suite + Tenant Profile Widget replaces that workflow instead of rebuilding it as custom code. Do not default to building custom admin setup screens.
 - If the app has a profile edit page or user management UI: ask whether a Descope Widget covers the use case.
 - If the app has a separate MFA enrollment page: ask whether MFA should be integrated into the main sign-in Flow as a step or subflow instead (almost always cleaner in Descope).
@@ -190,11 +197,6 @@ Scan the codebase to map every auth touchpoint before writing the plan.
 
 ```bash
 # Find all WorkOS / AuthKit import sites.
-# Case-insensitive (-i) so it also catches the `WorkOS` class and `WORKOS_` env prefix.
-# "workos" already matches every @workos-inc/* package (Node, widgets, all authkit-* libs:
-# authkit-js, authkit-react, authkit-nextjs, authkit-remix, authkit-react-router, authkit-tanstack-start)
-# plus the Python `workos`, Go `github.com/workos/workos-go`, Ruby/PHP/Java/.NET SDKs.
-# "authkit" is kept for bare references (e.g. authkitMiddleware, cookie names) that omit "workos".
 grep -rni "workos\|authkit" \
   --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" \
   --include="*.mjs" --include="*.cjs" --include="*.py" --include="*.go" \
@@ -211,7 +213,7 @@ grep -rn "WORKOS_\|workos\." \
   . 2>/dev/null
 
 # Find WorkOS SDK surface + claim / token / org access patterns (things that may need a JWT Template or org→tenant remap)
-grep -rn "workos.userManagement\|workos.organizations\|workos.sso\|workos.directorySync\|workos.auditLogs\|workos.fga\|workos.widgets\|workos.events\|workos.webhooks\|workos.pipes\|workos.portal\|workos.organizationDomains\|workos.featureFlags\|workos.mfa\|workos.authorization\|workos.vault\|organizationId\|organization_id\|orgId\|connectionId\|connection_id\|directoryId\|directory_id\|roleSlug\|permission" \
+grep -rn "workos.userManagement\|workos.organizations\|workos.sso\|workos.directorySync\|workos.auditLogs\|workos.fga\|workos.widgets\|workos.events\|workos.webhooks\|workos.pipes\|workos.portal\|workos.organizationDomains\|workos.featureFlags\|workos.types\|workos.mfa\|workos.authorization\|workos.vault\|organizationId\|organization_id\|orgId\|connectionId\|connection_id\|directoryId\|directory_id\|roleSlug\|permission" \
   --include="*.ts" --include="*.tsx" --include="*.js" --include="*.py" --include="*.go" \
   --exclude-dir=node_modules --exclude-dir=.next \
   . 2>/dev/null
@@ -234,6 +236,7 @@ find . -maxdepth 3 \( -name "package.json" -o -name "go.mod" -o -name "requireme
 ```
 
 For each hit, record:
+
 - **File path and line** — where the change happens
 - **What it does** — import, route protection, claim access, org/tenant read, SSO/SCIM config, webhook handler, logout handler, etc.
 - **Complexity** — Low (drop-in replacement), Medium (logic rewrite), High (no equivalent)
@@ -267,14 +270,16 @@ sessions, organizations, and existing accounts are preserved.
 
 Include a **Migration at a Glance** table:
 
-| | |
-|---|---|
-| **Approach** | Full native migration / OIDC compatibility layer |
-| **Files changing** | N source files across N areas |
-| **Console setup** | N configuration steps before launch |
-| **User impact** | No re-login required / Users will need to log in once after cutover |
-| **Estimated engineering effort** | N–N hours |
-| **Biggest risk** | One sentence naming the highest-complexity item |
+
+|                                  |                                                                     |
+| -------------------------------- | ------------------------------------------------------------------- |
+| **Approach**                     | Full native migration / OIDC compatibility layer                    |
+| **Files changing**               | N source files across N areas                                       |
+| **Console setup**                | N configuration steps before launch                                 |
+| **User impact**                  | No re-login required / Users will need to log in once after cutover |
+| **Estimated engineering effort** | N–N hours                                                           |
+| **Biggest risk**                 | One sentence naming the highest-complexity item                     |
+
 
 ---
 
@@ -304,17 +309,21 @@ Each group gets a sentence on what it does and what changes.
 **Session handling (3 files)** — These files read and validate the current user's login
 state. They'll be updated to use the Descope session SDK instead of WorkOS AuthKit.
 
-| File | What it does today | What changes |
-|---|---|---|
-| `lib/auth.ts:34` | Returns WorkOS session via `withAuth()` with `user`, `organizationId`, `role` | Rewritten to return Descope `AuthenticationInfo`; a thin adapter layer preserves the shape callers expect |
-| `middleware.ts:12` | `authkitMiddleware()` blocks unauthenticated requests app-wide | Updated to call Descope session validation; logic is identical, SDK call changes |
+
+| File               | What it does today                                                            | What changes                                                                                              |
+| ------------------ | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `lib/auth.ts:34`   | Returns WorkOS session via `withAuth()` with `user`, `organizationId`, `role` | Rewritten to return Descope `AuthenticationInfo`; a thin adapter layer preserves the shape callers expect |
+| `middleware.ts:12` | `authkitMiddleware()` blocks unauthenticated requests app-wide                | Updated to call Descope session validation; logic is identical, SDK call changes                          |
+
 
 **Login / logout routes (2 files)** — These handle the AuthKit redirect-based login flow.
 Descope replaces this with an embedded UI component (or hosted Flow); the redirect cycle changes.
 
-| File | What it does today | What changes |
-|---|---|---|
+
+| File                    | What it does today             | What changes                                                                                                  |
+| ----------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
 | `app/callback/route.ts` | AuthKit OAuth callback handler | Deleted or rewritten — Descope handles this client-side; verify the replacement against the framework section |
+
 
 Cover all functional groupings. End with: "Total: N files. Estimated code-change effort: N–N hours."
 
@@ -350,25 +359,27 @@ it's needed, and roughly how long it takes. Group into "Required before any test
 "Required before production":
 
 **Required before any testing:**
-- [ ] **Create a Descope project** — Takes 2 minutes. Produces a Project ID that replaces
-  all WorkOS credentials in the app's environment variables.
-- [ ] **Create an authentication flow** — Descope uses a visual "flow" to define the login
-  experience (what methods are offered, in what order). The built-in `sign-up-or-in` flow
-  works for most apps and requires no customization to start.
-- [ ] **Configure a user profile token template** — By default, Descope session tokens don't
-  include the user's name, email, or profile photo. This template needs to be configured so
-  the app can display user profile information. Without it, any part of the UI that shows the
-  user's name or email will show nothing after login. (~10 minutes)
+
+- **Create a Descope project** — Takes 2 minutes. Produces a Project ID that replaces
+all WorkOS credentials in the app's environment variables.
+- **Create an authentication flow** — Descope uses a visual "flow" to define the login
+experience (what methods are offered, in what order). The built-in `sign-up-or-in` flow
+works for most apps and requires no customization to start.
+- **Configure a user profile token template** — By default, Descope session tokens don't
+include the user's name, email, or profile photo. This template needs to be configured so
+the app can display user profile information. Without it, any part of the UI that shows the
+user's name or email will show nothing after login. (~10 minutes)
 
 **Required before production:**
-- [ ] **Create tenants for each WorkOS Organization** — Descope Tenants must exist before
-  tenant-scoped code (SSO, roles, membership) will work.
-- [ ] **Create roles** (or whatever the codebase references) — Descope roles must exist in the
-  console before code that assigns them will work.
-- [ ] **Configure SSO connections per tenant** (or enable the SSO Setup Suite for self-serve) — SAML/OIDC connections need to be recreated.
-- [ ] **Configure social login providers** (Google, GitHub, etc.) — OAuth credentials for
-  each provider need to be entered in the console. (~15 minutes per provider)
-- [ ] (continue for each item found in analysis)
+
+- **Create tenants for each WorkOS Organization** — Descope Tenants must exist before
+tenant-scoped code (SSO, roles, membership) will work.
+- **Create roles** (or whatever the codebase references) — Descope roles must exist in the
+console before code that assigns them will work.
+- **Configure SSO connections per tenant** (or enable the SSO Setup Suite for self-serve) — SAML/OIDC connections need to be recreated.
+- **Configure social login providers** (Google, GitHub, etc.) — OAuth credentials for
+each provider need to be entered in the console. (~15 minutes per provider)
+- (continue for each item found in analysis)
 
 ---
 
@@ -376,15 +387,17 @@ it's needed, and roughly how long it takes. Group into "Required before any test
 
 Diff table with plain-English notes for each removal and addition:
 
-| Remove | Add | Why |
-|---|---|---|
-| `WORKOS_API_KEY` | — | WorkOS authenticates server-side calls with a secret API key. Descope uses a Project ID (+ optional Management Key) instead. |
-| `WORKOS_CLIENT_ID` | — | WorkOS identifies the AuthKit client. Descope uses a Project ID. |
-| `WORKOS_REDIRECT_URI` | — | AuthKit's OAuth callback URL. Descope's embedded Flow doesn't require a server redirect URI in the same way. |
-| `WORKOS_COOKIE_PASSWORD` | — | Used by AuthKit to encrypt/seal the session cookie. Descope issues a signed session JWT instead; no sealing password needed. |
-| — | `DESCOPE_PROJECT_ID` | The single identifier for the Descope project. Replaces all of the above. |
-| — | `NEXT_PUBLIC_DESCOPE_PROJECT_ID` | Same value, exposed to the browser for the login component (Next.js). |
-| — | `DESCOPE_MANAGEMENT_KEY` | Only needed if the app manages users, roles, tenants, or SSO/SCIM server-side. |
+
+| Remove                   | Add                              | Why                                                                                                                                 |
+| ------------------------ | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `WORKOS_API_KEY`         | —                                | WorkOS authenticates server-side calls with a secret API key. Descope uses a Project ID (+ optional Management Key) instead.        |
+| `WORKOS_CLIENT_ID`       | —                                | WorkOS identifies the AuthKit client. Descope uses a Project ID.                                                                    |
+| `WORKOS_REDIRECT_URI`    | —                                | AuthKit's OAuth callback URL, configured in console. Descope's embedded Flow doesn't require a server redirect URI in the same way. |
+| `WORKOS_COOKIE_PASSWORD` | —                                | Used by AuthKit to encrypt/seal the session cookie. Descope issues a signed session JWT instead; no sealing password needed.        |
+| —                        | `DESCOPE_PROJECT_ID`             | The single identifier for the Descope project. Replaces all of the above.                                                           |
+| —                        | `NEXT_PUBLIC_DESCOPE_PROJECT_ID` | Same value, exposed to the browser for the login component (Next.js only).                                                          |
+| —                        | `DESCOPE_MANAGEMENT_KEY`         | Only needed if the app manages users, roles, tenants, or SSO/SCIM server-side.                                                      |
+
 
 Follow with: "Net change: 4 variables removed, 1–3 added. No secrets need to be rotated
 on the WorkOS side — those credentials stop being used."
@@ -406,12 +419,13 @@ Prose strategy first, then steps. Start with: "X existing users across Y organiz
 > assume the Auth0 migration script (`descope/descope-migration`) supports WorkOS.
 
 End with a brief checklist of the migration steps at the level a PM can track:
-- [ ] Export users and organizations from WorkOS
-- [ ] Map each WorkOS Organization to a Descope Tenant
-- [ ] Re-point SCIM/Directory Sync at Descope (if Directory Sync is in use)
-- [ ] Do a dry run of the import against the Descope dev project
-- [ ] Review dry-run output for errors
-- [ ] Run live migration against staging, then production
+
+- Export users and organizations from WorkOS
+- Map each WorkOS Organization to a Descope Tenant
+- Re-point SCIM/Directory Sync at Descope (if Directory Sync is in use)
+- Do a dry run of the import against the Descope dev project
+- Review dry-run output for errors
+- Run live migration against staging, then production
 
 ---
 
@@ -461,40 +475,42 @@ Then labeled phases, each with a time estimate:
 **Phase 1 — Console Setup** (~30–60 minutes, no code required)
 Can be done by any team member with Descope console access, in parallel with other work.
 
-- [ ] Create Descope project, copy Project ID
-- [ ] Create authentication flow (use the built-in `sign-up-or-in` to start)
-- [ ] Configure user profile token template
-- [ ] Create tenants for each WorkOS Organization (list actual orgs found)
-- [ ] Create roles: (list actual roles found)
-- [ ] Configure SSO connections per tenant or enable the SSO Setup Suite (if SSO in use)
-- [ ] Configure social login providers: (list actual providers found)
+- Create Descope project, copy Project ID
+- Create authentication flow (use the built-in `sign-up-or-in` to start)
+- Configure user profile token template
+- Create tenants for each WorkOS Organization (list actual orgs found)
+- Create roles: (list actual roles found)
+- Configure SSO connections per tenant or enable the SSO Setup Suite (if SSO in use)
+- Configure social login providers: (list actual providers found)
 
 **Phase 2 — Code Changes** (~X–Y hours, 1 engineer)
 Work through files in the order listed. Run a compile check after each group.
 
-- [ ] Update environment variables in `.env.example` and CI config (15 min)
-- [ ] Rewrite session helper / `withAuth()` usage (30 min)
-- [ ] Swap AuthKit provider/middleware for Descope equivalents (15 min)
-- [ ] Update protected route files to use new session check (45 min)
-- [ ] Update org/tenant claim reads (`organizationId` → `token.dct`/`token.tenants`) (varies)
-- [ ] Update logout — two-step logout (15 min)
-- [ ] Compile check and fix any type errors before proceeding
+- Update environment variables in `.env.example` and CI config (15 min)
+- Rewrite session helper / `withAuth()` usage (30 min)
+- Swap AuthKit provider/middleware for Descope equivalents (15 min)
+- Update protected route files to use new session check (45 min)
+- Update org/tenant claim reads (`organizationId` → `token.dct`/`token.tenants`) (varies)
+- Update logout — two-step logout (15 min)
+- Compile check and fix any type errors before proceeding
 
 **Phase 3 — User & Organization Migration** (~1–2 hours, includes dry run)
 Run against dev/staging first. Do not run against production until Phase 4 passes.
 
-- [ ] (steps from user & organization migration section above)
+- (steps from user & organization migration section above)
 
 **Phase 4 — Testing** (~30–45 minutes)
-- [ ] Compile passes with zero errors
-- [ ] Server starts, no crashes on startup
-- [ ] Unauthenticated routes redirect to login correctly
-- [ ] Login flow completes, user profile data appears (confirms token template is working)
-- [ ] Tenant/SSO routing works for at least one organization
-- [ ] Logout invalidates session
+
+- Compile passes with zero errors
+- Server starts, no crashes on startup
+- Unauthenticated routes redirect to login correctly
+- Login flow completes, user profile data appears (confirms token template is working)
+- Tenant/SSO routing works for at least one organization
+- Logout invalidates session
 
 **Phase 5 — Production Cutover**
-- [ ] (cutover-specific steps based on their strategy — maintenance window, phased rollout, SCIM re-point, etc.)
+
+- (cutover-specific steps based on their strategy — maintenance window, phased rollout, SCIM re-point, etc.)
 
 ---
 
@@ -623,9 +639,11 @@ option objects, hook return shapes (`useDescope()` returns the SDK directly, not
 and subpath exports (`/client` vs root) differ just as often.
 
 **1a. After rewriting any module, grep for remaining imports of the removed package.**
+
 ```bash
 grep -r "from '@workos-inc/" --include="*.ts" --include="*.tsx" .
 ```
+
 Add remaining hits to the work list.
 
 **2. Derive wrapper types from the actual return type.**
@@ -644,10 +662,12 @@ span 10–20 files.
 **5. Verify published package versions before writing to `package.json` or running `npm install`.**
 Don't reuse WorkOS's version number or rely on training data for versions. Before writing any
 install command:
+
 ```bash
 npm view @descope/node-sdk version
 npm view @descope/nextjs-sdk version
 ```
+
 If npm is unavailable, leave the version as `"latest"` and flag it.
 
 ---
@@ -661,58 +681,72 @@ Use `AskUserQuestion` to ask whether they already have a Project ID and working 
 yes, skip to verifying items 5–7 — these are easy to miss even for existing projects.
 
 ### 1. Create a project and get your Project ID
+
 - Sign in at [console.descope.com](https://console.descope.com)
 - Your **Project ID** appears in the top-left project selector and under **Project → Settings**. It starts with `P` (e.g. `P2abc123...`).
 - For Next.js client-side code, this becomes `NEXT_PUBLIC_DESCOPE_PROJECT_ID`. For all server-side SDKs, it's `DESCOPE_PROJECT_ID`.
 
 ### 2. Get a Management Key (if needed)
+
 Required for: user management API, role/permission management, tenant operations, SSO/SCIM
 configuration, ReBAC (FGA), Outbound Apps. If the app does any server-side user, tenant, SSO,
 or SCIM management, they need this.
+
 - Console → **Company → Management Keys → Generate Key**
 - Store as `DESCOPE_MANAGEMENT_KEY`. Treat like a secret — never expose client-side.
 
 ### 3. Choose or create a Flow
+
 A Flow is the auth UI sequence. Reference it by Flow ID in the web component.
 
 - Console → **Authentication → Flows**
 - The built-in **"sign-up-or-in"** flow handles email/password, OTP, and social login.
-  Use it for most migrations.
+Use it for most migrations.
 - To customise: duplicate "sign-up-or-in", rename it, then edit in the visual builder.
 - The Flow ID is in the URL when editing and in the flow list.
 - There are 100+ Flow templates in the library — check for an existing template before building a custom flow. See `references/flows-and-widgets.md` → Flows.
 - MFA: add an MFA step to the Flow or embed MFA as a subflow. Descope manages MFA enrollment through Flows. For factor-deletion SDK support by type, see `references/implementation-nuances.md` → MFA section.
 
 ### 4. Configure authentication methods
+
 - Console → **Authentication** → select methods (Email OTP, Magic Link, Social, SSO, Passkeys, etc.)
 - For social providers (Google, GitHub, etc.): configure OAuth credentials here, then add
-  the provider step to your Flow.
+the provider step to your Flow.
 - For enterprise SSO (SAML/OIDC): Console → **SSO** → configure per tenant, or enable the SSO Setup Suite for tenant-admin self-serve. For correct SSO callback and ACS URLs (social OAuth, SAML ACS, what NOT to use), see `references/implementation-nuances.md` → Social login / SSO section.
 
 ### 5. Configure a JWT Template (almost always needed)
+
 WorkOS AuthKit tokens may include profile fields; Descope tokens do not by default.
+
 - Console → **Authorization → JWT Templates → New Template**
 - Add claims: `{"email": "{{user.email}}", "name": "{{user.name}}", "picture": "{{user.picture}}"}`
 - Apply the template to your project. Without this step, any code reading `token.email`
-  will get `undefined` after migration.
+will get `undefined` after migration.
 
 ### 6. Create roles in the Console (if using RBAC)
+
 Descope roles are referenced by **name**, not by ID. They must be created manually in the
 Console before the code that assigns them will work.
+
 - Console → **Authorization → RBAC → + Role**
 - Create each role the app references (e.g. `admin`, `member`)
 
 ### 7. Define custom attributes (if using tenant/user metadata)
+
 WorkOS Organization `metadata` and User metadata map to Descope `customAttributes`.
 Pre-define them in the Console schema before setting them via the SDK.
+
 - Console → **Project → Custom Attributes**
 
 ### 8. Env var summary
-| Variable | Where to get it | Used by |
-|---|---|---|
-| `DESCOPE_PROJECT_ID` | Console → Project Settings | All server-side SDKs |
-| `NEXT_PUBLIC_DESCOPE_PROJECT_ID` | Same value as above | Next.js `AuthProvider` (client-side) |
-| `DESCOPE_MANAGEMENT_KEY` | Console → Company → Management Keys | Management SDK, SSO/SCIM, Outbound Apps API |
+
+
+| Variable                         | Where to get it                     | Used by                                     |
+| -------------------------------- | ----------------------------------- | ------------------------------------------- |
+| `DESCOPE_PROJECT_ID`             | Console → Project Settings          | All server-side SDKs                        |
+| `NEXT_PUBLIC_DESCOPE_PROJECT_ID` | Same value as above                 | Next.js `AuthProvider` (client-side)        |
+| `DESCOPE_MANAGEMENT_KEY`         | Console → Company → Management Keys | Management SDK, SSO/SCIM, Outbound Apps API |
+
 
 ### 9. Consider Widgets for management UI
 
@@ -728,11 +762,14 @@ to the first code change step.
 
 ## Step 2: Framework-Specific Migration
 
-> **TODO (verify against WorkOS SDK + Descope docs before writing code):** The framework
-> recipes below are stubs listing the WorkOS idioms that need mapping. Confirm exact WorkOS SDK
-> surface (`@workos-inc/node`, `@workos-inc/authkit-nextjs`, `@workos-inc/authkit-react`) and the
-> matching Descope SDK calls via the Docs MCP or local type declarations before generating any
-> code. Do not ship code from these stubs without verification.
+WorkOS publishes exactly two SDK families (per the [WorkOS SDKs page](https://workos.com/docs/sdks)):
+
+- **Backend SDKs** (one per language): `workos-node`, `workos-go`, `workos-ruby`, `workos-rust`, `workos-python`, `workos-php`, `workos-php-laravel`, `workos-kotlin` (Java), `workos-dotnet` (.NET). These call the WorkOS API and hold server-side session helpers.
+- **AuthKit SDKs** (one per JS framework): `authkit-js`, `authkit-react`, `authkit-nextjs`, `authkit-remix`, `authkit-react-router`, `authkit-tanstack-start`. These handle the login UI + session.
+
+The recipes below cover exactly these SDKs — one section each — annotated with the matching Descope target. Do not infer other frameworks (e.g. Express, Flask, FastAPI); a WorkOS app using those is using the underlying language Backend SDK (`workos-node`, `workos-python`, etc.), so map it via that SDK's section.
+
+> The framework recipes below are stubs listing the WorkOS idioms that need mapping. Confirm the exact WorkOS SDK surface for the user's stack and the matching Descope SDK calls via the Docs MCP or local type declarations before generating any code. Do not ship code from these stubs without verification.
 
 Read `references/implementation-nuances.md` in two passes before writing any code:
 
@@ -742,14 +779,122 @@ Read `references/implementation-nuances.md` in two passes before writing any cod
 When a new framework is added to the file, add it to this list.
 
 ### Common WorkOS idioms to map (all frameworks)
+
+These idioms are **AuthKit-JS-specific**. Backend-SDK apps (Python, Go, Ruby, PHP, Java, .NET) don't
+have these helpers — they instead call the SDK directly (e.g. `workos.userManagement.authenticateWithCode(...)`
+for the code exchange and `workos.userManagement.loadSealedSession(...)` for session access), which map
+to Descope session validation + the hosted/embedded Flow the same way.
+
 - `withAuth()` / `getUser()` (AuthKit session access) → Descope session validation + an adapter returning the shape callers expect
 - `authkitMiddleware()` → Descope session-validation middleware
 - AuthKit sealed-session cookie (`WORKOS_COOKIE_PASSWORD`) → Descope signed session JWT in `DS`/`DSR` cookies
 - `getSignInUrl()` / hosted AuthKit redirect → embedded Descope Flow component (or hosted Flow), wiring `onSuccess`
 - WorkOS callback route (code exchange) → removed/rewritten; Descope handles auth client-side
 
-### Next.js  — TODO (verify)
-- `@workos-inc/authkit-nextjs` → `@descope/nextjs-sdk` + `@descope/node-sdk`
+### Backend SDKs
+
+#### Node.js
+
+*WorkOS SDK: `workos-node` (`@workos-inc/node`) → Descope `@descope/node-sdk`*
+
+- Remove `@workos-inc/node` auth/session usage; add `@descope/node-sdk`
+- Validate the `DS` session token via custom middleware calling `descopeClient.validateSession()` (parse the cookie yourself)
+- Login UI → `<descope-wc>` web component; logout: `descopeClient.logout(refreshToken)` + clear `DS`/`DSR` cookies
+
+#### Go
+
+#### *WorkOS SDK: `workos-go` → Descope `github.com/descope/go-sdk`*
+
+- Remove the WorkOS Go SDK; add `descope/go-sdk`
+- Session validation: `descopeClient.Auth.ValidateSessionWithToken(ctx, token)` returns `(bool, *descope.Token, error)`
+- WorkOS `organizationId` → Descope `Token.Claims` (`dct` / `tenants`)
+
+#### Ruby
+
+*WorkOS SDK: `workos-ruby` → Descope Ruby SDK*
+
+- Remove the WorkOS Ruby SDK; add the Descope Ruby SDK
+- Validate the `DS` session token via the Descope Ruby SDK in your request lifecycle
+- Login UI → `<descope-wc>` web component; logout: Descope SDK logout + clear `DS`/`DSR` cookies
+- No dedicated recipe in `implementation-nuances.md` yet — follow the Node.js / Python backend patterns and verify against the [Descope Ruby SDK](https://github.com/descope/ruby-sdk).
+
+#### Rust
+
+*WorkOS SDK: `workos-rust` → **No Descope Rust SDK**; validate via Descope JWKS + Management REST API*
+
+- There is no official Descope Rust SDK. Validate the `DS` session JWT directly against Descope's JWKS endpoint (`https://api.descope.com/v2/keys/<project_id>`) using a standard JWT library.
+- Management operations (users, tenants, roles, SSO) → call the Descope Management REST API directly.
+- Login UI → `<descope-wc>` web component; logout clears `DS`/`DSR` cookies.
+
+#### Python
+
+*WorkOS SDK: `workos-python` → Descope `descope` Python SDK*
+
+- Remove the WorkOS Python SDK auth/session usage; add the `descope` Python SDK
+- Validate the `DS` session token with `descope_client.validate_session(session_token)` (or validate against Descope's JWKS for a custom authorizer)
+- Login UI → `<descope-wc>` web component; logout: `descope_client.logout(refresh_token)` + delete cookies
+
+#### PHP
+
+*WorkOS SDK: `workos-php` → Descope PHP SDK*
+
+- Remove the WorkOS PHP SDK; add the Descope PHP SDK
+- Validate the `DS` token via the Descope PHP SDK in your request lifecycle
+- Login UI → `<descope-wc>` web component; logout clears `DS`/`DSR` cookies
+- No dedicated recipe yet — follow the Node.js / Python backend patterns and verify against the Descope PHP SDK.
+
+#### Laravel
+
+*WorkOS SDK: `workos-php-laravel` → Descope PHP SDK (no Descope Laravel-specific SDK)*
+
+- Remove the WorkOS Laravel package; use the Descope PHP SDK
+- Validate the `DS` token in Laravel middleware
+- Login UI → `<descope-wc>` web component; logout clears `DS`/`DSR` cookies
+- No dedicated recipe yet — follow the PHP backend patterns and verify.
+
+#### Java
+
+*WorkOS SDK: `workos-kotlin` (Java/Kotlin) → Descope `descope-java`*
+
+- Remove the WorkOS Java/Kotlin SDK; add `descope-java`
+- Validate the `DS` token via a filter/interceptor
+- Login UI → `<descope-wc>` web component; logout clears `DS`/`DSR` cookies
+- No dedicated recipe yet — follow the backend patterns and verify against the [Descope Java SDK](https://github.com/descope/descope-java).
+
+#### .NET
+
+*WorkOS SDK: `workos-dotnet` → Descope `descope-dotnet`*
+
+- Remove the WorkOS .NET SDK; add `descope-dotnet`
+- Validate the `DS` token in middleware / a custom auth handler
+- Login UI → `<descope-wc>` web component; logout clears `DS`/`DSR` cookies
+- No dedicated recipe yet — follow the backend patterns and verify against the [Descope .NET SDK](https://github.com/descope/descope-dotnet).
+
+### AuthKit SDKs
+
+#### JavaScript
+
+*WorkOS SDK: `authkit-js` → Descope `@descope/web-js-sdk` + `@descope/web-component`*
+
+- `createClient()` / `authkit.getUser()` / `getAccessToken()` → `@descope/web-js-sdk` (`getSessionToken()`, `isJwtExpired()`, `refresh()`)
+- Login UI → `<descope-wc project-id flow-id>` web component, listening for `success` / `error` events
+- Logout: `sdk.logout()` + clear stored tokens/cookies
+
+#### React
+
+*WorkOS SDK: `authkit-react` → Descope `@descope/react-sdk`*
+
+- `<AuthKitProvider>` → Descope `<AuthProvider projectId>`
+- `useAuth()` (user/session/loading) → `useSession()` + `useUser()` hooks
+- `signIn()` / hosted redirect → embedded `<Descope flowId>` component, wiring `onSuccess`
+- Logout: `sdk.logout()` via `useDescope()` hook
+- No dedicated recipe yet — follow the Next.js client-side patterns and verify each method against docs.
+
+#### Next.js
+
+*WorkOS SDK: `authkit-nextjs` → Descope `@descope/nextjs-sdk` + `@descope/node-sdk`*
+
+- `authkit-nextjs` → `@descope/nextjs-sdk` + `@descope/node-sdk`
 - AuthKit `<AuthKitProvider>` → Descope `AuthProvider` (takes `projectId`; must use `NEXT_PUBLIC_` prefix)
 - `withAuth()` / `useAuth()` → `session()` (server) + `useSession()` / `useUser()` (client)
 - Remove the AuthKit callback route — verify Descope's client-side handling
@@ -757,42 +902,47 @@ When a new framework is added to the file, add it to this list.
 - Logout: `sdk.logout()` via `useDescope()` hook + clear cookies (two-step)
 - **Client vs. server session access** — `session()` from `@descope/nextjs-sdk/server` is server-only; `useSession()`/`useUser()` from `@descope/nextjs-sdk/client` are client-only. Using `session()` in a client component compiles but throws at runtime. Verify exact exports before writing imports.
 
-### Express.js — TODO (verify)
-- Remove `@workos-inc/node` AuthKit/session usage; add `@descope/node-sdk` + `cookie-parser`
-- Replace AuthKit middleware with ~20-line custom middleware reading the `DS` cookie and calling `descopeClient.validateSession()`
-- Add `/login` route rendering `<descope-wc>` web component
-- Logout: `descopeClient.logout(refreshToken)` + clear `DS`/`DSR` cookies
+#### Remix
 
-### Flask / Python — TODO (verify)
-- Remove the WorkOS Python SDK auth/session usage; add the `descope` Python SDK
-- Remove the WorkOS callback route — no code exchange needed
-- `/login` renders the Descope web component
-- Logout: `descope_client.logout(refresh_token)` + delete cookies
+*WorkOS SDK: `authkit-remix` → Descope `@descope/react-sdk` + `@descope/web-js-sdk` (no Descope Remix SDK)*
 
-### FastAPI / Python — TODO (verify)
-- Replace WorkOS session validation with a custom `TokenVerifier` class: reads `Authorization` header, validates against Descope JWKS, attaches claims as a FastAPI `Security()` dependency
+- `authkitLoader` / `authLoader()` loaders → custom Remix loaders that validate the session token (`@descope/web-js-sdk` / `@descope/node-sdk`) and gate routes
+- `getSignInUrl()` → embedded Descope component (`@descope/react-sdk`) or hosted Flow
+- Logout: clear `DS`/`DSR` cookies in an action + `sdk.logout()`
+- No dedicated recipe yet — follow the Next.js (server + client split) patterns and verify.
 
-### Go — TODO (verify)
-- Remove the WorkOS Go SDK; add `descope/go-sdk`
-- Session validation: `descopeClient.Auth.ValidateSessionWithToken(ctx, token)` returns `(bool, *descope.Token, error)`
-- WorkOS `organizationId` → Descope `Token.Claims` (`dct` / `tenants`)
+#### React Router
+
+*WorkOS SDK: `authkit-react-router` → Descope `@descope/react-sdk`*
+
+- Same shape as Remix (`authkit-react-router` is the React Router 7+ port): loader-based session checks → custom loaders + Descope session validation
+- Login via embedded Descope component; logout via `sdk.logout()` + cookie clear
+- No dedicated recipe yet — follow the React / Remix patterns and verify.
+
+#### TanStack Start
+
+*WorkOS SDK: `authkit-tanstack-start` → Descope `@descope/react-sdk` / `@descope/web-js-sdk` (no Descope TanStack SDK)*
+
+- Server-route session helpers → TanStack server functions validating the Descope session token
+- Login via embedded Descope component; logout via `sdk.logout()` + cookie clear
+- No dedicated recipe yet — follow the Next.js / React patterns and verify.
 
 ### Path A: OIDC Compatibility (lower risk, incremental)
 
 Descope exposes standard OIDC endpoints. If the app uses a **generic OIDC client library**
 pointed at WorkOS, it can point at Descope's OIDC issuer instead with minimal code changes.
 
-> **TODO (verify):** Many WorkOS apps use AuthKit's own SDK rather than a generic OIDC client,
-> in which case Path A may not apply cleanly. Confirm whether the app uses a standard OIDC client
-> before recommending this path. Verify the Descope OIDC endpoint table below against current docs.
+> Many WorkOS apps use AuthKit's own SDK rather than a generic OIDC client, in which case Path A may not apply cleanly. Confirm whether the app uses a standard OIDC client before recommending this path. Verify the Descope OIDC endpoint table below against current docs.
 
-| Endpoint | Descope |
-|---|---|
-| Issuer | `https://api.descope.com` |
-| Authorization | `https://api.descope.com/oauth2/v1/authorize` |
-| Token | `https://api.descope.com/oauth2/v1/token` |
-| UserInfo | `https://api.descope.com/oauth2/v1/userinfo` |
-| JWKS | `https://api.descope.com/__ProjectID__/.well-known/jwks.json` |
+
+| Endpoint      | Descope                                                       |
+| ------------- | ------------------------------------------------------------- |
+| Issuer        | `https://api.descope.com`                                     |
+| Authorization | `https://api.descope.com/oauth2/v1/authorize`                 |
+| Token         | `https://api.descope.com/oauth2/v1/token`                     |
+| UserInfo      | `https://api.descope.com/oauth2/v1/userinfo`                  |
+| JWKS          | `https://api.descope.com/__ProjectID__/.well-known/jwks.json` |
+
 
 **Good for:** Teams that want to swap the IdP first, then refactor to Descope-native SDKs
 later. Preserves existing OIDC client code.
@@ -816,6 +966,7 @@ log any non-obvious decisions made (adapter types kept, async cascade scope, etc
 Scan for WorkOS references in non-code files after updating source files.
 
 ### `.env.example` / `.env.template` / `.env.sample`
+
 ```
 # REMOVE
 WORKOS_API_KEY=
@@ -828,18 +979,22 @@ DESCOPE_PROJECT_ID=             # Console → Project Settings
 NEXT_PUBLIC_DESCOPE_PROJECT_ID= # Next.js only — same value as above
 DESCOPE_MANAGEMENT_KEY=         # Console → Company → Management Keys (only if using management SDK)
 ```
+
 Run `grep -r "WORKOS"` to find all env var references — `.env.example`, Docker, CI, shell scripts.
 
 ### README / docs
+
 Search all `.md` files for WorkOS references. At minimum, update:
+
 - **Setup section** — replace "create a WorkOS app / AuthKit setup" instructions with Descope Console setup steps
 - **Environment variables section** — reflect the reduced env var set
 - **Run instructions** — replace WorkOS dashboard steps with Descope Console steps
 - **Auth flow diagrams or descriptions** — update to reflect Descope's cookie-based approach
 
 ### Docker / CI files
+
 Check `Dockerfile`, `docker-compose.yml`, `.github/workflows/`, and any CI config for
-`WORKOS_*` env var declarations. Update them to `DESCOPE_*`.
+`WORKOS_`* env var declarations. Update them to `DESCOPE_`*.
 
 ### Setup / bootstrap scripts
 
@@ -868,19 +1023,22 @@ WorkOS AuthKit handles login UI, authentication methods, users, sessions, and en
 routing. Descope splits these responsibilities across a Flow (UI + methods), session validation
 (SDK), Users/Tenants, and JWT Templates (profile claims).
 
-| WorkOS | Descope |
-|---|---|
-| Hosted AuthKit login UI | [Descope Flows](https://docs.descope.com/flows) |
-| `withAuth()` / `getUser()` session access | `validateSession()` + a thin adapter returning the shape callers expect |
-| AuthKit user object | Descope User (profile fields via JWT Template) |
-| Auth method config (password, social, passkeys, MFA, magic auth) | Methods toggled in Console + added as Flow steps |
+
+| WorkOS                                                           | Descope                                                          |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Hosted AuthKit login UI                                          | [Descope Flows](https://docs.descope.com/flows)                  |
+| `withAuth()` / `getUser()` session access                        | `validateSession()` + adapter returning the shape callers expect |
+| AuthKit user object                                              | Descope User (profile fields via JWT Template)                   |
+| Auth method config (password, social, passkeys, MFA, magic auth) | Methods toggled in Console + added as Flow steps                 |
+
 
 Use Flows for the user-facing journey whenever possible; write custom SDK calls only when Flows
 cannot express the requirement. Ask which auth methods are enabled before recommending details.
 **Effort: Low–Medium** (mostly SDK/UI/session swap; token differences matter).
 
 ### Organizations → Descope Tenants
-- WorkOS `externalId` → Descope `token.dct` (active tenant) or `token.tenants` (nested object: `{ [tenantId]: { roles, permissions } }`)
+
+- WorkOS `organizationId` (flat string) → Descope `token.dct` (active tenant) or `token.tenants` (nested object: `{ tenantId: { roles, permissions } }`)
 - WorkOS org-scoped login → Descope routes by email domain or tenant-specific URLs
 - Users are project-level in Descope; associated with tenants, not created per-tenant
 - Organization `metadata` → tenant `customAttributes` (pre-define in the Console schema)
@@ -903,11 +1061,13 @@ the SSO Setup Suite + Tenant Profile Widget may eliminate the SDK calls entirely
 
 **SDK path (when programmatic SSO is needed):**
 
-| WorkOS | Descope |
-|---|---|
-| SAML connection (`sso.*`) | `management.sso.configureSAMLByTenant(tenantId, settings)` |
-| OIDC connection | `management.sso.configureOIDCByTenant(tenantId, settings)` |
-| Per-Organization connection | Per-tenant SSO (Console → SSO or Management SDK) |
+
+| WorkOS                      | Descope                                           |
+| --------------------------- | ------------------------------------------------- |
+| SAML connection (`sso.`*)   | `management.ssoApplication.createSamlApplication` |
+| OIDC connection             | `management.ssoApplication.createOidcApplication` |
+| Per-Organization connection | Per-tenant SSO (Console → SSO or Management SDK)  |
+
 
 (Verify exact method names against the Docs MCP.) Ask whether SSO is configured by internal
 engineers or by customer admins. **Effort: Medium** — setup recreated per tenant.
@@ -919,12 +1079,14 @@ a one-time import** — enterprise directories keep pushing create/update/suspen
 cutover, so every directory must be re-pointed at Descope before cutover or provisioning silently
 breaks.
 
-| WorkOS Directory Sync | Descope |
-|---|---|
+
+| WorkOS Directory Sync                      | Descope                                  |
+| ------------------------------------------ | ---------------------------------------- |
 | SCIM endpoint + bearer token per directory | Descope SCIM endpoint + token per tenant |
-| Directory user create/update/deprovision | Tenant user provisioning lifecycle |
-| Directory groups | Group → role mapping in Descope |
-| `dsync.*` / directory webhooks | Descope provisioning events / connectors |
+| Directory user create/update/deprovision   | Tenant user provisioning lifecycle       |
+| Directory groups                           | Group → role mapping in Descope          |
+| `dsync.`* / directory webhooks             | Descope provisioning events / connectors |
+
 
 Identify every directory, whether groups are synced, and whether groups map to roles.
 **Effort: Medium–High** (lifecycle, groups, deprovisioning, and role mapping can be subtle).
@@ -943,12 +1105,14 @@ Ask which admin workflows are hosted by WorkOS today before choosing a replaceme
 
 ### RBAC → Descope RBAC
 
-| WorkOS | Descope |
-|---|---|
-| `role` / `permissions` claim in session | `token.roles` / `token.permissions` (built-in) |
-| Organization-scoped role | Tenant-scoped role under `token.tenants[tenantId].roles` |
-| `roleSlug` reference | Descope role **name** (not ID) |
-| IdP group → role mapping | Group-to-role mapping (Console / SCIM) |
+
+| WorkOS                                  | Descope                                                  |
+| --------------------------------------- | -------------------------------------------------------- |
+| `role` / `permissions` claim in session | `token.roles` / `token.permissions` (built-in)           |
+| Organization-scoped role                | Tenant-scoped role under `token.tenants[tenantId].roles` |
+| `roleSlug` reference                    | Descope role **name** (not ID)                           |
+| IdP group → role mapping                | Group-to-role mapping (Console / SCIM)                   |
+
 
 SDK: `descopeClient.management.role.create(name, description, permissionNames, tenantId)` (verify
 signature). Roles must exist in the Console before assignment. Check whether roles are global or
@@ -973,11 +1137,12 @@ type document
   permission can_view: owner or viewer
 ```
 
-| Operation | WorkOS FGA | Descope ReBAC |
-|---|---|---|
+
+| Operation      | WorkOS FGA                | Descope ReBAC                                         |
+| -------------- | ------------------------- | ----------------------------------------------------- |
 | Write relation | `fga.writeWarrant({...})` | `descopeClient.management.fga.createRelations([...])` |
-| Check | `fga.check({...})` | `descopeClient.management.fga.check([...])` |
-| List resources | `fga.query(...)` | `descopeClient.management.authz.whatCanTargetAccessWithRelation(...)` |
+| Check          | `fga.check({...})`        | `descopeClient.management.fga.check([...])`           |
+
 
 (Verify exact WorkOS and Descope shapes against current docs.) Identify resources,
 relationships/privileges, where checks run, and any hierarchical inheritance. **Effort: High** —
@@ -1004,11 +1169,13 @@ WorkOS Pipes (connected third-party accounts with OAuth token storage/refresh) m
 Outbound Apps.
 
 Users connect accounts client-side:
+
 ```
 sdk.outbound.connect(appId, { redirectURL, scopes })
 ```
 
 Fetch stored tokens server-side:
+
 ```
 POST https://api.descope.com/v1/mgmt/outbound/app/user/token
 Authorization: Bearer {projectId}:{managementKey}
@@ -1020,10 +1187,12 @@ whether users must reconnect accounts or tokens can be migrated. **Effort: Mediu
 
 ### Webhooks / Events → Descope Webhooks / Connectors / Events
 
-| WorkOS | Descope |
-|---|---|
-| Webhook endpoint + signing secret | Descope webhook/connector + signature validation |
-| `user.created` / `organization.*` / `dsync.*` events | Corresponding Descope events / connector triggers |
+
+| WorkOS                                               | Descope                                           |
+| ---------------------------------------------------- | ------------------------------------------------- |
+| Webhook endpoint + signing secret                    | Descope webhook/connector + signature validation  |
+| `user.created` / `organization.`* / `dsync.`* events | Corresponding Descope events / connector triggers |
+
 
 Search the codebase for webhook handlers; update event names, signature/validation logic, and
 payload handling. Identify which event types are business-critical. **Effort: Medium.**
@@ -1064,6 +1233,7 @@ out of scope.
 ## Step 4: Critical Gotchas (Always Cover These)
 
 ### JWT Claims Are Not the Same
+
 Descope session JWTs contain `sub`, `amr`, `drn`, `tenants`, `roles`, `permissions`, and `dct` by
 default. They do **not** contain `email`, `name`, or `picture`. WorkOS AuthKit tokens may expose
 some profile fields, so code that reads them directly will break after migration.
@@ -1078,37 +1248,44 @@ when you only need the tenant ID.
 `name`, and any other profile fields the app reads from the token.
 
 ### Sealed Sessions Become Signed JWTs
+
 WorkOS AuthKit uses an encrypted/sealed session cookie protected by `WORKOS_COOKIE_PASSWORD`.
 Descope issues a signed session JWT in the `DS` cookie (refresh in `DSR`). The sealing password is
 no longer needed, and code that unseals/inspects the WorkOS cookie must be replaced with Descope
 session validation (`validateSession()`), which returns decoded JWT claims.
 
 ### Logout Is Two Steps
+
 1. Call `descopeClient.logout(refreshToken)` to invalidate server-side
 2. Clear `DS` and `DSR` cookies
 
 Skipping either step leaves a broken state.
 
 ### Audience Validation Is Opt-In
+
 Descope session tokens have no `aud` claim by default. Apps that rely on audience-scoped API access
 must (1) configure a custom `aud` claim in JWT Templates and (2) pass `audience` to
 `validateSession()` on the backend.
 
 ### Organization Claim Shape Differs
+
 WorkOS exposes a flat `organizationId` (and `connectionId` / `directoryId`). Descope uses `dct`
 (active tenant) and the nested `tenants` object. Any code reading `organizationId` needs to be
 updated — this is mechanical but can span many files, so grep for all org-claim reads and update
 them in one pass.
 
 ### One Token, Not Provider-Specific Access Tokens
+
 Forward the Descope session JWT (`DS` cookie) as `Authorization: Bearer <DS>` to API servers. There
 is one session token; downstream services validate it with `validateSession()`.
 
 ### No Drop-In Middleware
+
 Descope has no `authkitMiddleware()` equivalent package. The middleware is ~20 lines of custom code
 that reads the `DS` cookie and calls `validateSession()`.
 
 ### `cookies()` and `headers()` Are Async in Next.js 15
+
 `cookies()` and `headers()` from `next/headers` return a `Promise` in Next.js 15+. Before
 generating any server-side helper that reads cookies:
 
@@ -1117,15 +1294,18 @@ generating any server-side helper that reads cookies:
 3. Trace upward — making a cookie-reading helper async cascades to every caller.
 
 ### Async Cascade: Trace All Callers Before Finishing
+
 When a shared utility becomes async, TypeScript accepts `await` on non-Promises without
 error — so callers that forget `await` silently return a Promise object. Always grep for
 all call sites of any utility you make async and update them in the same pass.
 
 ### SCIM Is a Lifecycle, Not a One-Time Import
+
 If Directory Sync is in use, re-point the SCIM pipeline at Descope before cutover. A one-time user
 import leaves provisioning broken the moment the directory pushes its next change.
 
 ### Env Var Reduction
+
 WorkOS: `WORKOS_API_KEY`, `WORKOS_CLIENT_ID`, `WORKOS_REDIRECT_URI`, `WORKOS_COOKIE_PASSWORD` (4+).
 Descope: `DESCOPE_PROJECT_ID` only (+ `DESCOPE_MANAGEMENT_KEY` for management ops).
 
@@ -1163,6 +1343,7 @@ dotnet build        # .NET
 **Do not proceed until compilation exits with zero errors.**
 
 **If compilation fails, diagnose by error message:**
+
 - `Cannot find module '@workos-inc/...'` → stale import; re-run Phase 0
 - `Property 'X' does not exist on type 'AuthenticationInfo'` → wrapper built against WorkOS shape; re-derive
 - `'await' expression is not allowed in synchronous contexts` → async cascade gap
@@ -1223,11 +1404,12 @@ Check that `email`, `name`, and any other expected claims (including `dct`/`tena
 ```
 
 **Do not proceed to Step 6 until ALL of the following are true:**
-- [ ] Phase 0 grep returns zero WorkOS references
-- [ ] Phase 1 compilation passes with zero errors
-- [ ] Phase 1 server starts and stays running
-- [ ] Phase 3 root path returns 2xx or 3xx (not 5xx)
-- [ ] Phase 3 protected routes return 302 or 401 (not 500)
+
+- Phase 0 grep returns zero WorkOS references
+- Phase 1 compilation passes with zero errors
+- Phase 1 server starts and stays running
+- Phase 3 root path returns 2xx or 3xx (not 5xx)
+- Phase 3 protected routes return 302 or 401 (not 500)
 
 ---
 
@@ -1239,13 +1421,11 @@ remaining, and behavioral differences that matter before production.
 ### MIGRATION-SUMMARY.md
 
 1. **What was migrated** — a table mapping each WorkOS concept to its Descope replacement
-
 2. **Behavioral differences and open questions** — numbered list of significant differences
-   between the WorkOS and Descope implementations. For each item: WorkOS behavior, Descope
+  between the WorkOS and Descope implementations. For each item: WorkOS behavior, Descope
    behavior, action required.
-
 3. **Pre-deploy checklist** — actionable checkbox items for everything that must happen
-   before the migrated app can run. Prominently include all Console setup tasks (project, Flow,
+  before the migrated app can run. Prominently include all Console setup tasks (project, Flow,
    JWT template, tenants, SSO/SCIM) and the SCIM re-point — these are the things easiest to
    forget because the code compiles without them.
 
@@ -1264,43 +1444,46 @@ explicitly with estimated complexity (Low/Medium/High) so the user can plan.
 ## Reference Files
 
 - `references/implementation-nuances.md` — Verified migration patterns, code-level diffs, and edge
-  cases for several frameworks.
-- Descope Docs: https://docs.descope.com
-- WorkOS Migration Guide: https://docs.descope.com/migrate  <!-- TODO (verify): confirm the exact WorkOS migration guide URL, if one exists -->
-- User Import (Custom): https://docs.descope.com/migrate/custom
-- Descope OIDC Endpoints: https://docs.descope.com/getting-started/oidc-endpoints
-- Descope Flows: https://docs.descope.com/flows
-- JWT Templates: https://docs.descope.com/management/jwt-templates
-- Access Keys (M2M): https://docs.descope.com/management/m2m-access-keys
-- Messaging Templates: https://docs.descope.com/management/messaging-templates
-- Audit Webhook: https://docs.descope.com/connectors/connector-configuration-guides/network/audit-webhook
-- Custom Domains: https://docs.descope.com/how-to-deploy-to-production/custom-domain
-- ReBAC: https://docs.descope.com/authorization/rebac
-- Outbound Apps: https://docs.descope.com/identity-federation/outbound-apps
+cases for several frameworks.
+- Descope Docs: [https://docs.descope.com](https://docs.descope.com)
+- WorkOS Migration Guide: [https://docs.descope.com/migrate](https://docs.descope.com/migrate)  
+- User Import (Custom): [https://docs.descope.com/migrate/custom](https://docs.descope.com/migrate/custom)
+- Descope OIDC Endpoints: [https://docs.descope.com/getting-started/oidc-endpoints](https://docs.descope.com/getting-started/oidc-endpoints)
+- Descope Flows: [https://docs.descope.com/flows](https://docs.descope.com/flows)
+- JWT Templates: [https://docs.descope.com/management/jwt-templates](https://docs.descope.com/management/jwt-templates)
+- Access Keys (M2M): [https://docs.descope.com/management/m2m-access-keys](https://docs.descope.com/management/m2m-access-keys)
+- Messaging Templates: [https://docs.descope.com/management/messaging-templates](https://docs.descope.com/management/messaging-templates)
+- Audit Webhook: [https://docs.descope.com/connectors/connector-configuration-guides/network/audit-webhook](https://docs.descope.com/connectors/connector-configuration-guides/network/audit-webhook)
+- Custom Domains: [https://docs.descope.com/how-to-deploy-to-production/custom-domain](https://docs.descope.com/how-to-deploy-to-production/custom-domain)
+- ReBAC: [https://docs.descope.com/authorization/rebac](https://docs.descope.com/authorization/rebac)
+- Outbound Apps: [https://docs.descope.com/identity-federation/outbound-apps](https://docs.descope.com/identity-federation/outbound-apps)
 
 ### Session Validation by Language
-- Node.js: https://docs.descope.com/getting-started/nodejs#implement-session-validation
-- Python: https://docs.descope.com/getting-started/python#implement-session-validation
-- Go: https://docs.descope.com/getting-started/golang#implement-session-validation
-- Ruby: https://docs.descope.com/getting-started/ruby#implement-session-validation
-- Java / Kotlin: https://docs.descope.com/getting-started/java#implement-session-validation
-- .NET / C#: https://docs.descope.com/getting-started/dotnet#implement-session-validation
-- Next.js: https://docs.descope.com/getting-started/nextjs#implement-session-validation
-- React: https://docs.descope.com/getting-started/react#implement-session-validation
-- Angular: https://docs.descope.com/getting-started/angular#implement-session-validation
-- Vue: https://docs.descope.com/getting-started/vue#implement-session-validation
-- Swift / iOS: https://docs.descope.com/getting-started/swift#implement-session-validation
-- Kotlin / Android: https://docs.descope.com/getting-started/android#implement-session-validation
-- Flutter: https://docs.descope.com/getting-started/flutter#implement-session-validation
+
+- Node.js: [https://docs.descope.com/getting-started/nodejs#implement-session-validation](https://docs.descope.com/getting-started/nodejs#implement-session-validation)
+- Python: [https://docs.descope.com/getting-started/python#implement-session-validation](https://docs.descope.com/getting-started/python#implement-session-validation)
+- Go: [https://docs.descope.com/getting-started/golang#implement-session-validation](https://docs.descope.com/getting-started/golang#implement-session-validation)
+- Ruby: [https://docs.descope.com/getting-started/ruby#implement-session-validation](https://docs.descope.com/getting-started/ruby#implement-session-validation)
+- Java / Kotlin: [https://docs.descope.com/getting-started/java#implement-session-validation](https://docs.descope.com/getting-started/java#implement-session-validation)
+- .NET / C#: [https://docs.descope.com/getting-started/dotnet#implement-session-validation](https://docs.descope.com/getting-started/dotnet#implement-session-validation)
+- Next.js: [https://docs.descope.com/getting-started/nextjs#implement-session-validation](https://docs.descope.com/getting-started/nextjs#implement-session-validation)
+- React: [https://docs.descope.com/getting-started/react#implement-session-validation](https://docs.descope.com/getting-started/react#implement-session-validation)
+- Angular: [https://docs.descope.com/getting-started/angular#implement-session-validation](https://docs.descope.com/getting-started/angular#implement-session-validation)
+- Vue: [https://docs.descope.com/getting-started/vue#implement-session-validation](https://docs.descope.com/getting-started/vue#implement-session-validation)
+- Swift / iOS: [https://docs.descope.com/getting-started/swift#implement-session-validation](https://docs.descope.com/getting-started/swift#implement-session-validation)
+- Kotlin / Android: [https://docs.descope.com/getting-started/android#implement-session-validation](https://docs.descope.com/getting-started/android#implement-session-validation)
+- Flutter: [https://docs.descope.com/getting-started/flutter#implement-session-validation](https://docs.descope.com/getting-started/flutter#implement-session-validation)
 
 ### SDKs (GitHub)
-- Node SDK: https://github.com/descope/node-sdk
-- Python SDK: https://github.com/descope/python-sdk
-- Go SDK: https://github.com/descope/go-sdk
-- Ruby SDK: https://github.com/descope/descope-ruby-sdk
-- Java SDK: https://github.com/descope/descope-java
-- .NET SDK: https://github.com/descope/descope-dotnet
-- Swift SDK: https://github.com/descope/swift-sdk
-- Kotlin SDK: https://github.com/descope/descope-kotlin
-- Flutter SDK: https://github.com/descope/descope-flutter
-- JS/TS monorepo (React, Angular, Vue, Next.js, Web Component, Web JS): https://github.com/descope/descope-js
+
+- Node SDK: [https://github.com/descope/node-sdk](https://github.com/descope/node-sdk)
+- Python SDK: [https://github.com/descope/python-sdk](https://github.com/descope/python-sdk)
+- Go SDK: [https://github.com/descope/go-sdk](https://github.com/descope/go-sdk)
+- Ruby SDK: [https://github.com/descope/descope-ruby-sdk](https://github.com/descope/descope-ruby-sdk)
+- Java SDK: [https://github.com/descope/descope-java](https://github.com/descope/descope-java)
+- .NET SDK: [https://github.com/descope/descope-dotnet](https://github.com/descope/descope-dotnet)
+- Swift SDK: [https://github.com/descope/swift-sdk](https://github.com/descope/swift-sdk)
+- Kotlin SDK: [https://github.com/descope/descope-kotlin](https://github.com/descope/descope-kotlin)
+- Flutter SDK: [https://github.com/descope/descope-flutter](https://github.com/descope/descope-flutter)
+- JS/TS monorepo (React, Angular, Vue, Next.js, Web Component, Web JS): [https://github.com/descope/descope-js](https://github.com/descope/descope-js)
+

--- a/skills/workos-to-descope/SKILL.md
+++ b/skills/workos-to-descope/SKILL.md
@@ -1,0 +1,1306 @@
+---
+name: workos-to-descope
+description: >
+  Use this skill whenever anyone asks about migrating from WorkOS to Descope — whether they're
+  a developer doing it themselves or a technical lead evaluating the move. Triggers on: "how
+  do I migrate from WorkOS", "replace WorkOS with Descope", "we're moving off WorkOS", "WorkOS to
+  Descope", "switch from WorkOS", "our app uses @workos-inc/node / @workos-inc/authkit-nextjs / AuthKit / WorkOS SSO / Directory Sync / SCIM and we want to use Descope instead",
+  or any question about WorkOS features (AuthKit, Organizations, Enterprise SSO, Directory Sync/SCIM,
+  Admin Portal, RBAC, FGA, Audit Logs, Radar, Pipes) in the context of Descope. Works for any
+  language or framework with a Descope SDK. Always use this skill before producing migration
+  guidance — do not rely on memory alone.
+---
+
+# WorkOS → Descope Migration Skill
+
+This skill guides self-service migrations from WorkOS to Descope. It runs in three parts:
+
+1. **MCP Check** — confirm whether the Descope Docs MCP is available and suggest installing it if not
+2. **Migration Plan** — gather context via triage questions, analyze the codebase's auth touchpoints, and produce a human-readable `MIGRATION-PLAN.md` for the user to review
+3. **Execution** — if the user confirms they want to proceed, execute the plan
+
+Do not collapse these parts or skip ahead. The plan must be reviewed before code changes begin.
+
+WorkOS is not only an authentication provider — it is a B2B/enterprise-readiness platform spanning
+authentication, organizations, enterprise SSO, SCIM/directory sync, RBAC, FGA, audit logs, connected
+accounts, admin setup flows, and security controls. A good migration first identifies which WorkOS
+features are in use, then maps each one to the closest Descope feature or migration pattern. Expect
+WorkOS migrations to be more B2B-enterprise heavy than a typical consumer-auth migration.
+
+**Primary references** (both in this skill's directory):
+- `references/implementation-nuances.md` — verified migration patterns for each framework, WorkOS feature-to-Descope mappings, and known gotchas
+- `references/flows-and-widgets.md` — Descope terminology/lingo, Flow structure and templates, Widgets, SSO Setup Suite, Console-vs-code decision guide
+
+---
+
+## Guiding Principles
+
+**Console-first.** Before recommending SDK code for any user-facing auth feature, check whether the Console, a Flow, a Widget, or the SSO Setup Suite covers the use case. Engineers integrate once (SDK setup + session validation). All subsequent auth evolution — new methods, MFA changes, UI updates, tenant SSO onboarding — should happen in the Console without code deployments. See `references/flows-and-widgets.md` → Console vs. Code.
+
+**Ask, don't assume.** At any design decision point — embed Flows vs. OIDC compatibility, Flow vs. custom code, Widget vs. custom page, MFA inline vs. separate enrollment, programmatic SSO vs. SSO Setup Suite, one-Organization-to-one-Tenant mapping — use `AskUserQuestion` rather than proceeding with an assumption. The cost of a wrong assumption compounds across 20+ files, and the WorkOS Organization → Descope Tenant mapping in particular ripples into SSO, SCIM, RBAC, and domain routing. Uncertainty about architecture or intent is always worth a question.
+
+**MCP over memory.** When the Docs MCP is available (confirmed in Part 1), use `ask-question-about-descope` to verify every SDK method name, option shape, and return type before writing it. Do not fall back to "verify the exact method name in the SDK type declarations" as a hedge — just verify it directly.
+
+---
+
+## Part 1: MCP Check (BLOCKING)
+
+Before doing anything else, check whether the Descope Docs MCP is available by calling
+`search-descope-docs` with a simple query (e.g., "session validation").
+
+**If the tool is available:** proceed to Part 2 immediately.
+
+**If the tool is not available**, show this message and use `AskUserQuestion` to ask whether
+they want to install it first:
+
+> **Descope Docs MCP is not installed.**
+>
+> This skill uses the Descope Docs MCP to look up current API signatures, SDK methods, and
+> feature availability during migration. Without it, guidance is based on static training data,
+> which may be stale and can produce SDK calls that don't exist.
+>
+> You can install it in a few minutes at **https://docs-mcp.descope.com/** (server URL:
+> `https://docs-mcp.descope.com/mcp`). It significantly improves the accuracy of the
+> migration output — especially for SDK lookups and flow-specific configuration.
+>
+> **Would you like to install the MCP before we continue, or proceed without it?**
+
+- If they choose to install: pause and wait. Once they confirm it's installed, re-check by calling `search-descope-docs` again before proceeding.
+- If they choose to proceed without it: continue, but flag any SDK-specific answers as "based on last known documentation — verify against the current SDK."
+
+Do not proceed to Part 2 until this step is resolved.
+
+---
+
+## Part 2: Migration Plan
+
+Part 2 has two sub-steps:
+
+1. **Triage** — ask the questions needed to understand scope (migration questions go here since answers shape the plan)
+2. **Codebase Analysis + Plan File** — scan the project, produce `MIGRATION-PLAN.md`, and pause for review
+
+### Step 0: Triage (BLOCKING — requires `AskUserQuestion`)
+
+**Use the `AskUserQuestion` tool to gather the information below. Do not infer answers
+from memory, prior conversations, or assumptions — even if you think you know.**
+The migration path differs based on these answers; getting them wrong wastes the user's
+time and produces incorrect guidance.
+
+Do not proceed to Step 0.5 until the user has answered.
+
+**First `AskUserQuestion` call (up to 4 questions):**
+
+1. **Backend language / framework** — Present the most likely options based on any cues
+   in the conversation (e.g., Next.js, Express, Flask/FastAPI, Go, Rails). The user can always
+   pick "Other."
+2. **Migration goal** — Full cut-over, incremental/phased migration, or just evaluating.
+3. **Existing users and organizations** — Are they migrating an app with active users and
+   organizations in WorkOS, staging/dev only, or starting fresh? This determines whether user
+   and organization migration planning is needed (user export, org-to-tenant mapping, SCIM
+   continuity, phased vs. big-bang cutover, forced re-login on cutover).
+4. **Preferred migration style** — Do they want to embed Descope Flows/Widgets directly (full native migration), or preserve an existing OIDC client library and point it at Descope's OIDC endpoints (OIDC compatibility layer)? Note: B2B features (Organizations/SSO/SCIM management) have no OIDC-layer equivalent and require native SDK calls regardless of path.
+
+**Second `AskUserQuestion` call — WorkOS feature usage (use `multiSelect: true`):**
+
+5. **Which WorkOS features are in use?** Present the highest-impact categories:
+   - AuthKit / User Management (core auth replacement)
+   - Organizations (multi-tenancy / B2B)
+   - Enterprise SSO (SAML / OIDC connections)
+   - Directory Sync / SCIM (directory provisioning)
+   - Admin Portal (hosted self-serve admin setup)
+   - Domain Verification / Custom Domains
+   - RBAC / roles / permissions
+   - Fine-Grained Authorization / FGA
+   - Audit Logs
+   - Radar / bot or fraud protection
+   - Pipes / connected accounts
+   - Webhooks / Events
+   - Widgets
+   - MCP Auth / Connect
+   - Vault
+   - Feature Flags
+
+   The user can add others via "Other." Follow up on anything selected:
+   - **Organizations** — organization membership, organization switching, metadata, whether users can belong to multiple organizations.
+   - **Enterprise SSO** — connections SAML, OIDC, or both; whether setup is handled by internal engineers or by customer admins; whether domain-based SSO routing is used.
+   - **Directory Sync / SCIM** — which directories; group sync; group-to-role mapping; deprovisioning behavior; directory webhook handlers.
+   - **Admin Portal / Widgets** — which customer-admin workflows are hosted by WorkOS today; whether the app generates portal links; whether Descope Widgets or the SSO Setup Suite can replace them.
+   - **RBAC** — whether roles are global or organization-scoped; where permission checks happen in code; whether roles/permissions are in tokens; whether IdP groups map to roles.
+   - **FGA** — the authorization model (resources, relationships, privileges, hierarchy); where checks are performed. Flag as high complexity.
+   - **Audit Logs** — whether logs are written to WorkOS, read back from WorkOS, shown to customers, or required for compliance.
+   - **Radar** — whether it blocks, challenges, or only monitors suspicious auth attempts; custom rules.
+   - **Pipes** — which providers are connected; where connected-account tokens are used (AI agents, integrations, background jobs).
+   - **Vault / Feature Flags** — flag as potentially outside the core Descope identity migration unless used directly for auth or access control.
+   - **MCP Auth / Connect** — flag for deeper review before implementation.
+
+After both calls, summarize findings and flag high-complexity items (Directory Sync/SCIM, FGA,
+Pipes, MCP Auth/Connect, Vault) before proceeding to Step 0.5.
+
+---
+
+### Step 0.5: Engineer Review Checkpoint (BLOCKING — requires `AskUserQuestion`)
+
+These questions surface blockers the framework doesn't expose. Ask even the ones you think
+you know. Use `AskUserQuestion` before proceeding to codebase analysis.
+
+Batch into calls of up to 4 questions. Skip questions that are clearly inapplicable given
+Step 0 answers (e.g., skip user migration planning if they said they're starting fresh).
+
+**Access and credentials**
+- Do they have access to the Descope Console and a Project ID? (If not, see Step 1.5.)
+- Do they need a Management Key? (Required for user CRUD, role management, ReBAC, tenant/SSO/SCIM configuration, Outbound Apps.)
+
+**Codebase scope**
+- Are there places in the app that read claims directly from the session token (e.g. `user.email`, `claims.organization_id`, `role`/`permissions`)? These need a JWT Template configured before they'll work.
+- Does the app read WorkOS `organizationId`, `connectionId`, or `directoryId` in many places? The WorkOS Organization → Descope Tenant remap ripples through SSO, SCIM, RBAC, and membership checks — confirm the org model before writing code.
+- Are there multiple services or microservices validating WorkOS tokens/sessions? Each needs to be updated to validate Descope JWTs.
+
+**Deployment and risk**
+- Do they have multiple environments (dev / staging / prod)? Each needs its own Descope project and Project ID.
+- Is there a maintenance window, or does this need to be zero-downtime?
+
+**User and organization migration** (if they indicated existing users/orgs in Step 0)
+- How many users and organizations? This determines export approach and whether a phased cutover is warranted.
+- Do they use passwords in AuthKit? Plan how password credentials carry over (export/import vs. reset vs. passwordless). Verify the current WorkOS user-export capability and the Descope import path before committing to an approach.
+- Big-bang cutover or phased? Map each WorkOS Organization to a Descope Tenant first; user membership and tenant-scoped roles depend on it.
+- **SCIM is a lifecycle system, not a one-time import.** If Directory Sync is enabled, enterprise directories will keep pushing create/update/suspend/delete events after cutover. A single user import is not enough — every SCIM/directory workflow must be re-pointed at Descope before cutover, or provisioning silently breaks.
+- Are they aware that active WorkOS sessions will be invalidated on cutover unless a session-bridging approach is used? Plan for a forced re-login or phased rollout.
+
+**Gaps to flag immediately** (don't ask — flag these proactively based on Step 0 answers)
+- If they're using **Vault** or **Feature Flags**: these may have no direct Descope identity equivalent. Flag separately; do not pretend they are Descope SDK swaps. Ask whether they're in scope.
+- If they're using **MCP Auth / Connect**: flag for deeper review before any implementation — likely maps to Descope Inbound Apps / OAuth app patterns, but needs dedicated mapping.
+- If they're using **Audit Logs**: set up Descope's Audit Webhook Connector before cutover to avoid gaps in compliance/event logging. Missing this can break compliance visibility even though the app still runs.
+- If they're using **Pipes / connected accounts**: connected third-party tokens may power integrations or background jobs. Identify provider connections and whether users must reconnect accounts.
+
+**Console/Flow/Widget opportunities** (flag before codebase analysis, then ask):
+- If the app uses the **WorkOS Admin Portal** or generates portal links: ask whether the SSO Setup Suite + Tenant Profile Widget replaces that workflow instead of rebuilding it as custom code. Do not default to building custom admin setup screens.
+- If the app has a profile edit page or user management UI: ask whether a Descope Widget covers the use case.
+- If the app has a separate MFA enrollment page: ask whether MFA should be integrated into the main sign-in Flow as a step or subflow instead (almost always cleaner in Descope).
+- If any server-side code initiates SSO, generates emails, or runs logic during the auth journey: ask whether that logic can be a Flow step or Connector instead of server code.
+
+Summarize any blockers and Console/Flow opportunities before proceeding to codebase analysis.
+
+---
+
+### Step 1: Codebase Analysis
+
+Scan the codebase to map every auth touchpoint before writing the plan.
+
+**Run these searches (adapt file extensions to the user's language):**
+
+```bash
+# Find all WorkOS / AuthKit import sites.
+# Case-insensitive (-i) so it also catches the `WorkOS` class and `WORKOS_` env prefix.
+# "workos" already matches every @workos-inc/* package (Node, widgets, all authkit-* libs:
+# authkit-js, authkit-react, authkit-nextjs, authkit-remix, authkit-react-router, authkit-tanstack-start)
+# plus the Python `workos`, Go `github.com/workos/workos-go`, Ruby/PHP/Java/.NET SDKs.
+# "authkit" is kept for bare references (e.g. authkitMiddleware, cookie names) that omit "workos".
+grep -rni "workos\|authkit" \
+  --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" \
+  --include="*.mjs" --include="*.cjs" --include="*.py" --include="*.go" \
+  --include="*.rb" --include="*.php" --include="*.java" --include="*.kt" \
+  --include="*.cs" --include="*.ex" --include="*.exs" --include="*.rs" \
+  --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=dist --exclude-dir=venv \
+  . 2>/dev/null
+
+# Find all WorkOS env var references
+grep -rn "WORKOS_\|workos\." \
+  --include="*.ts" --include="*.tsx" --include="*.js" --include="*.py" --include="*.go" \
+  --include="*.env*" --include="*.yml" --include="*.yaml" --include="Dockerfile" \
+  --exclude-dir=node_modules --exclude-dir=.next \
+  . 2>/dev/null
+
+# Find WorkOS SDK surface + claim / token / org access patterns (things that may need a JWT Template or org→tenant remap)
+grep -rn "workos.userManagement\|workos.organizations\|workos.sso\|workos.directorySync\|workos.auditLogs\|workos.fga\|workos.widgets\|workos.events\|workos.webhooks\|workos.pipes\|workos.portal\|workos.organizationDomains\|workos.featureFlags\|workos.mfa\|workos.authorization\|workos.vault\|organizationId\|organization_id\|orgId\|connectionId\|connection_id\|directoryId\|directory_id\|roleSlug\|permission" \
+  --include="*.ts" --include="*.tsx" --include="*.js" --include="*.py" --include="*.go" \
+  --exclude-dir=node_modules --exclude-dir=.next \
+  . 2>/dev/null
+
+# Find protected route / session access declarations
+grep -rn "authkitMiddleware\|withAuth\|getUser\|ensureSignedIn\|getSignInUrl\|getSession\|isAuthenticated\|require_session\|@login_required\|authMiddleware" \
+  --include="*.ts" --include="*.tsx" --include="*.js" --include="*.py" --include="*.go" \
+  --exclude-dir=node_modules --exclude-dir=.next \
+  . 2>/dev/null
+
+# Find B2B / enterprise feature usage (SSO, SCIM, audit, admin portal, security)
+grep -rn "scim\|saml\|sso\|auditLog\|audit_log\|adminPortal\|portalLink\|radar\|pipes" \
+  --include="*.ts" --include="*.tsx" --include="*.js" --include="*.py" --include="*.go" \
+  --exclude-dir=node_modules --exclude-dir=.next \
+  . 2>/dev/null
+
+# Check package.json / go.mod / requirements.txt for WorkOS dependencies
+find . -maxdepth 3 \( -name "package.json" -o -name "go.mod" -o -name "requirements.txt" \) \
+  ! -path "*/node_modules/*" -exec grep -l "workos" {} \;
+```
+
+For each hit, record:
+- **File path and line** — where the change happens
+- **What it does** — import, route protection, claim access, org/tenant read, SSO/SCIM config, webhook handler, logout handler, etc.
+- **Complexity** — Low (drop-in replacement), Medium (logic rewrite), High (no equivalent)
+
+Read `package.json` (or equivalent) for the exact framework version — this affects async
+behavior (Next.js 15 vs 14) and SDK compatibility.
+
+If the Descope Docs MCP is available, use `search-descope-docs` or `ask-question-about-descope`
+to verify current SDK method names for anything you plan to reference in the plan.
+
+---
+
+### Step 2: Write MIGRATION-PLAN.md
+
+Write `MIGRATION-PLAN.md` to the working directory using the triage answers and codebase
+analysis.
+
+Two audiences: the engineer needs enough technical detail to execute; the PM or tech lead
+needs scope, risk, and timeline without decoding jargon. Use plain English. Explain
+technical terms on first use. Open each section with a sentence summarizing what it means
+before presenting tables or evidence. Say what breaks if a risk is missed, not just that it
+exists. Pair complexity labels with time estimates; skew toward the lower bound — SDK swaps and mechanical rewrites are usually faster than they look, and repetitive files in a group after the first go much faster. Group execution into phases so parallel vs. sequential work is clear.
+
+The plan must include these sections, in this order:
+
+#### Overview
+
+2–3 sentences: what's being replaced, what replaces it, and the recommended approach with a
+one-sentence rationale. Add one sentence on what doesn't change — user-facing login behavior,
+sessions, organizations, and existing accounts are preserved.
+
+Include a **Migration at a Glance** table:
+
+| | |
+|---|---|
+| **Approach** | Full native migration / OIDC compatibility layer |
+| **Files changing** | N source files across N areas |
+| **Console setup** | N configuration steps before launch |
+| **User impact** | No re-login required / Users will need to log in once after cutover |
+| **Estimated engineering effort** | N–N hours |
+| **Biggest risk** | One sentence naming the highest-complexity item |
+
+---
+
+#### What's Changing and Why
+
+Prose (not a table) describing what each part of the system does today and what it does
+after. Example:
+
+> Today, WorkOS handles everything related to login: AuthKit shows the login UI, issues tokens
+> and sealed sessions, validates them on every request, and routes enterprise users to the right
+> SSO connection. After this migration, Descope takes over all of those responsibilities. The
+> login UI becomes a Descope Flow embedded in the app. Session validation moves to the Descope
+> SDK. WorkOS Organizations become Descope Tenants. The WorkOS API key, client ID, redirect URI,
+> and cookie password are replaced by a single Descope Project ID.
+>
+> WorkOS features in use that need to carry over: [list in plain English, one clause each].
+
+Tailor to triage findings.
+
+---
+
+#### Auth Touchpoints: What the Code Analysis Found
+
+Open with the scope count (e.g., "11 files across 4 areas"). Group by area, not file path.
+Each group gets a sentence on what it does and what changes.
+
+**Session handling (3 files)** — These files read and validate the current user's login
+state. They'll be updated to use the Descope session SDK instead of WorkOS AuthKit.
+
+| File | What it does today | What changes |
+|---|---|---|
+| `lib/auth.ts:34` | Returns WorkOS session via `withAuth()` with `user`, `organizationId`, `role` | Rewritten to return Descope `AuthenticationInfo`; a thin adapter layer preserves the shape callers expect |
+| `middleware.ts:12` | `authkitMiddleware()` blocks unauthenticated requests app-wide | Updated to call Descope session validation; logic is identical, SDK call changes |
+
+**Login / logout routes (2 files)** — These handle the AuthKit redirect-based login flow.
+Descope replaces this with an embedded UI component (or hosted Flow); the redirect cycle changes.
+
+| File | What it does today | What changes |
+|---|---|---|
+| `app/callback/route.ts` | AuthKit OAuth callback handler | Deleted or rewritten — Descope handles this client-side; verify the replacement against the framework section |
+
+Cover all functional groupings. End with: "Total: N files. Estimated code-change effort: N–N hours."
+
+---
+
+#### Feature Migration: WorkOS → Descope
+
+For each WorkOS feature confirmed in triage, write a short paragraph: what it's trying to
+accomplish, the best Descope approach for that goal, what's different, and what action is
+required. The best approach may be a Flow, Widget, SSO Setup Suite, or Console configuration
+rather than a direct SDK equivalent — reason about the intent, not just the API surface. Only
+recommend SDK code when programmatic control is genuinely required. Example:
+
+> **Multi-tenancy (WorkOS Organizations → Descope Tenants)**
+> WorkOS Organizations group users by company and scope SSO, SCIM, roles, and domain policies.
+> Descope has the same concept, called Tenants. The main difference is how tenant membership
+> appears in the session token — WorkOS exposes a flat `organizationId`, while Descope uses a
+> nested `tenants` object that includes per-tenant roles (plus `dct` for the active tenant ID).
+> Any backend code that reads `organizationId` will need to be updated to read `token.dct` or
+> `token.tenants`. This is a predictable, mechanical change, but it ripples into SSO, SCIM, and
+> RBAC, so confirm the org→tenant mapping before starting.
+> **Effort: Medium (1–2 hours of code changes).** Confirm the data migration path for orgs first.
+
+Only include confirmed features.
+
+---
+
+#### Before the Code Can Run: Required Configuration
+
+Some Descope behavior is configured in the console, not in code. List every item that must
+be set up before the app works, as checkboxes with a plain description of what it is, why
+it's needed, and roughly how long it takes. Group into "Required before any testing" and
+"Required before production":
+
+**Required before any testing:**
+- [ ] **Create a Descope project** — Takes 2 minutes. Produces a Project ID that replaces
+  all WorkOS credentials in the app's environment variables.
+- [ ] **Create an authentication flow** — Descope uses a visual "flow" to define the login
+  experience (what methods are offered, in what order). The built-in `sign-up-or-in` flow
+  works for most apps and requires no customization to start.
+- [ ] **Configure a user profile token template** — By default, Descope session tokens don't
+  include the user's name, email, or profile photo. This template needs to be configured so
+  the app can display user profile information. Without it, any part of the UI that shows the
+  user's name or email will show nothing after login. (~10 minutes)
+
+**Required before production:**
+- [ ] **Create tenants for each WorkOS Organization** — Descope Tenants must exist before
+  tenant-scoped code (SSO, roles, membership) will work.
+- [ ] **Create roles** (or whatever the codebase references) — Descope roles must exist in the
+  console before code that assigns them will work.
+- [ ] **Configure SSO connections per tenant** (or enable the SSO Setup Suite for self-serve) — SAML/OIDC connections need to be recreated.
+- [ ] **Configure social login providers** (Google, GitHub, etc.) — OAuth credentials for
+  each provider need to be entered in the console. (~15 minutes per provider)
+- [ ] (continue for each item found in analysis)
+
+---
+
+#### Environment Variables
+
+Diff table with plain-English notes for each removal and addition:
+
+| Remove | Add | Why |
+|---|---|---|
+| `WORKOS_API_KEY` | — | WorkOS authenticates server-side calls with a secret API key. Descope uses a Project ID (+ optional Management Key) instead. |
+| `WORKOS_CLIENT_ID` | — | WorkOS identifies the AuthKit client. Descope uses a Project ID. |
+| `WORKOS_REDIRECT_URI` | — | AuthKit's OAuth callback URL. Descope's embedded Flow doesn't require a server redirect URI in the same way. |
+| `WORKOS_COOKIE_PASSWORD` | — | Used by AuthKit to encrypt/seal the session cookie. Descope issues a signed session JWT instead; no sealing password needed. |
+| — | `DESCOPE_PROJECT_ID` | The single identifier for the Descope project. Replaces all of the above. |
+| — | `NEXT_PUBLIC_DESCOPE_PROJECT_ID` | Same value, exposed to the browser for the login component (Next.js). |
+| — | `DESCOPE_MANAGEMENT_KEY` | Only needed if the app manages users, roles, tenants, or SSO/SCIM server-side. |
+
+Follow with: "Net change: 4 variables removed, 1–3 added. No secrets need to be rotated
+on the WorkOS side — those credentials stop being used."
+
+---
+
+#### User & Organization Migration (only if existing users/orgs need to be migrated)
+
+Prose strategy first, then steps. Start with: "X existing users across Y organizations need to be in Descope before cutover." Describe:
+
+- **The plan**: whether this is big-bang (all users/orgs moved before cutover) or phased, and why
+- **Org→tenant mapping**: each WorkOS Organization becomes a Descope Tenant; membership and tenant-scoped roles depend on this mapping being correct first
+- **What users will experience**: will they need to log in again? Will anything look different?
+- **The biggest dependency**: how password credentials carry over, and whether SCIM directories must be re-pointed at Descope (a continuing pipeline, not a one-time import)
+
+> **TODO (verify):** Confirm the current WorkOS user/organization export capability and whether
+> Descope offers a dedicated WorkOS importer. If no dedicated importer exists, use the custom
+> import path (`https://docs.descope.com/migrate/custom`) with the Descope Management SDK. Do not
+> assume the Auth0 migration script (`descope/descope-migration`) supports WorkOS.
+
+End with a brief checklist of the migration steps at the level a PM can track:
+- [ ] Export users and organizations from WorkOS
+- [ ] Map each WorkOS Organization to a Descope Tenant
+- [ ] Re-point SCIM/Directory Sync at Descope (if Directory Sync is in use)
+- [ ] Do a dry run of the import against the Descope dev project
+- [ ] Review dry-run output for errors
+- [ ] Run live migration against staging, then production
+
+---
+
+#### Risks and Things to Decide
+
+Things that could affect timeline, user experience, or scope. Write each in plain English
+with three parts: **what it is**, **what breaks if it's ignored**, and **what to do**.
+Format each as a named callout:
+
+> **Risk: Organization-to-tenant mapping affects almost every B2B feature**
+> WorkOS Organizations should usually map to Descope Tenants. If this mapping is wrong, SSO, SCIM,
+> roles, permissions, domain routing, and user membership checks may all break.
+> **Action:** Confirm the organization model before writing migration code.
+
+> **Risk: SCIM is a lifecycle system, not just a user import**
+> Directory Sync may create, update, suspend, and delete users or group memberships continuously.
+> A one-time import is not enough if enterprise directories keep syncing after cutover.
+> **Action:** Identify every SCIM/directory workflow and re-point it at Descope before cutover.
+
+> **Risk: Admin Portal workflows should not automatically become custom code**
+> If the app uses the WorkOS Admin Portal, the Descope equivalent may be the SSO Setup Suite or a
+> Widget rather than a custom settings page.
+> **Action:** Ask whether tenant admins currently self-configure SSO/SCIM/domain verification.
+
+> **Risk: Audit logs can silently disappear**
+> The app may keep working after migration even if audit logging is broken — creating compliance
+> and enterprise-customer issues.
+> **Action:** Set up Descope audit/event forwarding before production cutover.
+
+> **Risk: User profile data won't appear after login until a token template is configured**
+> Descope session tokens don't include name, email, or profile photo by default. Any UI that
+> displays user information will show blank values after migration until the token template is set
+> up in the Descope console. This is a one-time configuration step, not a code change.
+> **Action:** Configure the token template before running any tests. Estimated time: 10 minutes.
+
+Include only applicable risks.
+
+---
+
+#### Execution Plan
+
+Open with one sentence: phases run in sequence; steps within a phase can run in parallel.
+Then labeled phases, each with a time estimate:
+
+---
+
+**Phase 1 — Console Setup** (~30–60 minutes, no code required)
+Can be done by any team member with Descope console access, in parallel with other work.
+
+- [ ] Create Descope project, copy Project ID
+- [ ] Create authentication flow (use the built-in `sign-up-or-in` to start)
+- [ ] Configure user profile token template
+- [ ] Create tenants for each WorkOS Organization (list actual orgs found)
+- [ ] Create roles: (list actual roles found)
+- [ ] Configure SSO connections per tenant or enable the SSO Setup Suite (if SSO in use)
+- [ ] Configure social login providers: (list actual providers found)
+
+**Phase 2 — Code Changes** (~X–Y hours, 1 engineer)
+Work through files in the order listed. Run a compile check after each group.
+
+- [ ] Update environment variables in `.env.example` and CI config (15 min)
+- [ ] Rewrite session helper / `withAuth()` usage (30 min)
+- [ ] Swap AuthKit provider/middleware for Descope equivalents (15 min)
+- [ ] Update protected route files to use new session check (45 min)
+- [ ] Update org/tenant claim reads (`organizationId` → `token.dct`/`token.tenants`) (varies)
+- [ ] Update logout — two-step logout (15 min)
+- [ ] Compile check and fix any type errors before proceeding
+
+**Phase 3 — User & Organization Migration** (~1–2 hours, includes dry run)
+Run against dev/staging first. Do not run against production until Phase 4 passes.
+
+- [ ] (steps from user & organization migration section above)
+
+**Phase 4 — Testing** (~30–45 minutes)
+- [ ] Compile passes with zero errors
+- [ ] Server starts, no crashes on startup
+- [ ] Unauthenticated routes redirect to login correctly
+- [ ] Login flow completes, user profile data appears (confirms token template is working)
+- [ ] Tenant/SSO routing works for at least one organization
+- [ ] Logout invalidates session
+
+**Phase 5 — Production Cutover**
+- [ ] (cutover-specific steps based on their strategy — maintenance window, phased rollout, SCIM re-point, etc.)
+
+---
+
+Total estimated engineering effort: **N–N hours** across N engineers.
+Blocking dependencies: (list anything on the critical path — console access, SCIM re-point, etc.)
+
+---
+
+After writing `MIGRATION-PLAN.md`, **stop and tell the user:**
+
+> `MIGRATION-PLAN.md` has been written to your working directory. It maps every auth
+> touchpoint found, lists what needs Console setup before the first test, and calls out
+> risks that could affect the timeline.
+>
+> Take a look before we start making changes. When you're ready to proceed, say so.
+
+Do not proceed to Part 3 unless the user confirms.
+
+---
+
+## Part 3: Execution
+
+Execute the plan in `MIGRATION-PLAN.md` Execution Plan order. Follow the detailed guidance below
+for each step.
+
+---
+
+### Context Continuity Protocol
+
+Context can be lost between turns. These rules keep the migration coherent.
+
+**Step 3.0 — Create `MIGRATION-STATE.md` before touching any code.**
+
+Write `MIGRATION-STATE.md` to the working directory from the template below. It's the
+source of truth for migration state — keep it current throughout execution.
+
+```markdown
+# Migration State
+
+_Last updated: [timestamp of last completed step]_
+
+## Project Context
+- Framework: [e.g., Next.js 14, Express + React]
+- Language: [TypeScript / Python / Go]
+- Package manager: [npm / yarn / pnpm / pip / etc.]
+- Migration path: [Path A: OIDC compat / Path B: Full native]
+- Migration goal: [Full cutover / Phased / Evaluating]
+
+## Triage Answers
+- Existing users: [Yes — N users / No — greenfield]
+- Existing organizations: [Yes — N orgs → tenants / No]
+- Password migration needed: [Yes / No]
+- WorkOS features in use: [comma-separated list]
+- Multiple environments: [Yes: dev/staging/prod / No]
+- Zero-downtime required: [Yes / No]
+
+## Files Inventory
+_All files that need to change. Update status after each step._
+
+| File | Change | Status |
+|---|---|---|
+| `app/callback/route.ts` | Delete/rewrite | ⬜ Pending |
+| `lib/auth.ts` | Rewrite session helper | ⬜ Pending |
+| `middleware.ts` | Update session check | ⬜ Pending |
+
+## Console Setup Checklist
+- [ ] Descope project created — Project ID: (fill in when done)
+- [ ] JWT template configured
+- [ ] Tenants created for each WorkOS Organization: (list)
+- [ ] Roles created: (list roles)
+- [ ] SSO connections / SSO Setup Suite configured: (list)
+- [ ] Social providers configured: (list providers)
+
+## Decisions Log
+_Non-obvious decisions made during migration — preserves rationale if context is lost._
+
+_(none yet)_
+
+## Current Phase
+Phase 1 — Console Setup (not started)
+
+## Next Action
+Complete console setup per MIGRATION-PLAN.md before making any code changes.
+
+## Blockers
+_(none)_
+```
+
+---
+
+**Rule 1 — Re-read before every turn.**
+
+At the start of every execution turn, re-read `MIGRATION-PLAN.md` and `MIGRATION-STATE.md`
+before writing any code or making any decision.
+
+**Rule 2 — Verify context before every code change.**
+
+If the framework, migration path, triage answers, or next step aren't clear from the
+conversation, re-read both files before proceeding. Then output a context line:
+
+> `Migration context: Next.js 14 · Path B · Phase 2, step 3/8 · Next: rewrite lib/auth.ts`
+
+If this line can't be filled in accurately, re-read the files first.
+
+**Rule 3 — Update `MIGRATION-STATE.md` immediately after each step.**
+
+Mark the file done in the Files Inventory, update "Current Phase" and "Next Action", and
+append any non-obvious decision to the Decisions Log. Do this before the next step.
+
+---
+
+## Pre-Generation Protocol (apply before writing any code)
+
+Run before generating any import, wrapper type, or helper. Skipping produces code that
+compiles but fails at runtime.
+
+**1. Verify SDK exports before writing any import.**
+When the Docs MCP is available, use `ask-question-about-descope` to confirm the exact method name, option shape, and return type before writing any SDK call. This is faster and more reliable than reading type declarations. Do not write a method name and add a hedge like "verify the exact name" — just verify it.
+
+When the Docs MCP is unavailable: resolve the package's type declarations (`node_modules/<pkg>/dist/types/` or its `package.json` `types` field) and confirm the exact exported name and signature. For Go, run `go doc`. For Python, check the SDK stubs.
+
+**Prefer local `node_modules/` over GitHub** when reading type declarations. Installed packages reflect the exact version in use. If the Descope package isn't installed yet, install it first, then read local type declarations. Only fall back to GitHub if the package can't be installed in the current environment.
+
+This applies to **every SDK call you write**, not just the first import. Field names on
+option objects, hook return shapes (`useDescope()` returns the SDK directly, not `{ sdk }`),
+and subpath exports (`/client` vs root) differ just as often.
+
+**1a. After rewriting any module, grep for remaining imports of the removed package.**
+```bash
+grep -r "from '@workos-inc/" --include="*.ts" --include="*.tsx" .
+```
+Add remaining hits to the work list.
+
+**2. Derive wrapper types from the actual return type.**
+Read the function's declared return type and build the wrapper to match. WorkOS's field
+names, nesting, and flags differ — don't infer from them.
+
+**3. Check dependency versions before generating framework-specific code.**
+For Next.js: `cookies()` and `headers()` from `next/headers` are synchronous in v14 and
+async in v15. Read `package.json` (or `go.mod`, `requirements.txt`) first.
+
+**4. When making a helper async, propagate to all callers immediately.**
+In TypeScript, `async` on a shared utility silently breaks callers that omit `await`. Grep
+for all call sites of the changed function and update them in the same pass. The cascade can
+span 10–20 files.
+
+**5. Verify published package versions before writing to `package.json` or running `npm install`.**
+Don't reuse WorkOS's version number or rely on training data for versions. Before writing any
+install command:
+```bash
+npm view @descope/node-sdk version
+npm view @descope/nextjs-sdk version
+```
+If npm is unavailable, leave the version as `"latest"` and flag it.
+
+---
+
+## Step 1.5: Descope Project Setup & Console Configuration
+
+Several steps require Descope Console setup that can't be done in code. The app compiles
+without them but won't work at runtime.
+
+Use `AskUserQuestion` to ask whether they already have a Project ID and working Flow. If
+yes, skip to verifying items 5–7 — these are easy to miss even for existing projects.
+
+### 1. Create a project and get your Project ID
+- Sign in at [console.descope.com](https://console.descope.com)
+- Your **Project ID** appears in the top-left project selector and under **Project → Settings**. It starts with `P` (e.g. `P2abc123...`).
+- For Next.js client-side code, this becomes `NEXT_PUBLIC_DESCOPE_PROJECT_ID`. For all server-side SDKs, it's `DESCOPE_PROJECT_ID`.
+
+### 2. Get a Management Key (if needed)
+Required for: user management API, role/permission management, tenant operations, SSO/SCIM
+configuration, ReBAC (FGA), Outbound Apps. If the app does any server-side user, tenant, SSO,
+or SCIM management, they need this.
+- Console → **Company → Management Keys → Generate Key**
+- Store as `DESCOPE_MANAGEMENT_KEY`. Treat like a secret — never expose client-side.
+
+### 3. Choose or create a Flow
+A Flow is the auth UI sequence. Reference it by Flow ID in the web component.
+
+- Console → **Authentication → Flows**
+- The built-in **"sign-up-or-in"** flow handles email/password, OTP, and social login.
+  Use it for most migrations.
+- To customise: duplicate "sign-up-or-in", rename it, then edit in the visual builder.
+- The Flow ID is in the URL when editing and in the flow list.
+- There are 100+ Flow templates in the library — check for an existing template before building a custom flow. See `references/flows-and-widgets.md` → Flows.
+- MFA: add an MFA step to the Flow or embed MFA as a subflow. Descope manages MFA enrollment through Flows. For factor-deletion SDK support by type, see `references/implementation-nuances.md` → MFA section.
+
+### 4. Configure authentication methods
+- Console → **Authentication** → select methods (Email OTP, Magic Link, Social, SSO, Passkeys, etc.)
+- For social providers (Google, GitHub, etc.): configure OAuth credentials here, then add
+  the provider step to your Flow.
+- For enterprise SSO (SAML/OIDC): Console → **SSO** → configure per tenant, or enable the SSO Setup Suite for tenant-admin self-serve. For correct SSO callback and ACS URLs (social OAuth, SAML ACS, what NOT to use), see `references/implementation-nuances.md` → Social login / SSO section.
+
+### 5. Configure a JWT Template (almost always needed)
+WorkOS AuthKit tokens may include profile fields; Descope tokens do not by default.
+- Console → **Authorization → JWT Templates → New Template**
+- Add claims: `{"email": "{{user.email}}", "name": "{{user.name}}", "picture": "{{user.picture}}"}`
+- Apply the template to your project. Without this step, any code reading `token.email`
+  will get `undefined` after migration.
+
+### 6. Create roles in the Console (if using RBAC)
+Descope roles are referenced by **name**, not by ID. They must be created manually in the
+Console before the code that assigns them will work.
+- Console → **Authorization → RBAC → + Role**
+- Create each role the app references (e.g. `admin`, `member`)
+
+### 7. Define custom attributes (if using tenant/user metadata)
+WorkOS Organization `metadata` and User metadata map to Descope `customAttributes`.
+Pre-define them in the Console schema before setting them via the SDK.
+- Console → **Project → Custom Attributes**
+
+### 8. Env var summary
+| Variable | Where to get it | Used by |
+|---|---|---|
+| `DESCOPE_PROJECT_ID` | Console → Project Settings | All server-side SDKs |
+| `NEXT_PUBLIC_DESCOPE_PROJECT_ID` | Same value as above | Next.js `AuthProvider` (client-side) |
+| `DESCOPE_MANAGEMENT_KEY` | Console → Company → Management Keys | Management SDK, SSO/SCIM, Outbound Apps API |
+
+### 9. Consider Widgets for management UI
+
+Before migrating custom profile pages, user management pages, role assignment UI, or admin
+SSO/SCIM setup pages, ask whether a Descope Widget or the SSO Setup Suite covers the use case.
+See `references/flows-and-widgets.md` → Widgets.
+
+**After completing console setup:** Update `MIGRATION-STATE.md` — check off each completed
+item in the Console Setup Checklist, record the Project ID in the file, and set Next Action
+to the first code change step.
+
+---
+
+## Step 2: Framework-Specific Migration
+
+> **TODO (verify against WorkOS SDK + Descope docs before writing code):** The framework
+> recipes below are stubs listing the WorkOS idioms that need mapping. Confirm exact WorkOS SDK
+> surface (`@workos-inc/node`, `@workos-inc/authkit-nextjs`, `@workos-inc/authkit-react`) and the
+> matching Descope SDK calls via the Docs MCP or local type declarations before generating any
+> code. Do not ship code from these stubs without verification.
+
+Read `references/implementation-nuances.md` in two passes before writing any code:
+
+1. **General Insights** (always) — covers architecture, feature mapping, and common gotchas that apply to every migration regardless of framework.
+2. **Framework section** (use the file's ToC and `offset` to jump directly) — read only the section matching the user's stack.
+
+When a new framework is added to the file, add it to this list.
+
+### Common WorkOS idioms to map (all frameworks)
+- `withAuth()` / `getUser()` (AuthKit session access) → Descope session validation + an adapter returning the shape callers expect
+- `authkitMiddleware()` → Descope session-validation middleware
+- AuthKit sealed-session cookie (`WORKOS_COOKIE_PASSWORD`) → Descope signed session JWT in `DS`/`DSR` cookies
+- `getSignInUrl()` / hosted AuthKit redirect → embedded Descope Flow component (or hosted Flow), wiring `onSuccess`
+- WorkOS callback route (code exchange) → removed/rewritten; Descope handles auth client-side
+
+### Next.js  — TODO (verify)
+- `@workos-inc/authkit-nextjs` → `@descope/nextjs-sdk` + `@descope/node-sdk`
+- AuthKit `<AuthKitProvider>` → Descope `AuthProvider` (takes `projectId`; must use `NEXT_PUBLIC_` prefix)
+- `withAuth()` / `useAuth()` → `session()` (server) + `useSession()` / `useUser()` (client)
+- Remove the AuthKit callback route — verify Descope's client-side handling
+- `authkitMiddleware()` → Descope `authMiddleware(options)`
+- Logout: `sdk.logout()` via `useDescope()` hook + clear cookies (two-step)
+- **Client vs. server session access** — `session()` from `@descope/nextjs-sdk/server` is server-only; `useSession()`/`useUser()` from `@descope/nextjs-sdk/client` are client-only. Using `session()` in a client component compiles but throws at runtime. Verify exact exports before writing imports.
+
+### Express.js — TODO (verify)
+- Remove `@workos-inc/node` AuthKit/session usage; add `@descope/node-sdk` + `cookie-parser`
+- Replace AuthKit middleware with ~20-line custom middleware reading the `DS` cookie and calling `descopeClient.validateSession()`
+- Add `/login` route rendering `<descope-wc>` web component
+- Logout: `descopeClient.logout(refreshToken)` + clear `DS`/`DSR` cookies
+
+### Flask / Python — TODO (verify)
+- Remove the WorkOS Python SDK auth/session usage; add the `descope` Python SDK
+- Remove the WorkOS callback route — no code exchange needed
+- `/login` renders the Descope web component
+- Logout: `descope_client.logout(refresh_token)` + delete cookies
+
+### FastAPI / Python — TODO (verify)
+- Replace WorkOS session validation with a custom `TokenVerifier` class: reads `Authorization` header, validates against Descope JWKS, attaches claims as a FastAPI `Security()` dependency
+
+### Go — TODO (verify)
+- Remove the WorkOS Go SDK; add `descope/go-sdk`
+- Session validation: `descopeClient.Auth.ValidateSessionWithToken(ctx, token)` returns `(bool, *descope.Token, error)`
+- WorkOS `organizationId` → Descope `Token.Claims` (`dct` / `tenants`)
+
+### Path A: OIDC Compatibility (lower risk, incremental)
+
+Descope exposes standard OIDC endpoints. If the app uses a **generic OIDC client library**
+pointed at WorkOS, it can point at Descope's OIDC issuer instead with minimal code changes.
+
+> **TODO (verify):** Many WorkOS apps use AuthKit's own SDK rather than a generic OIDC client,
+> in which case Path A may not apply cleanly. Confirm whether the app uses a standard OIDC client
+> before recommending this path. Verify the Descope OIDC endpoint table below against current docs.
+
+| Endpoint | Descope |
+|---|---|
+| Issuer | `https://api.descope.com` |
+| Authorization | `https://api.descope.com/oauth2/v1/authorize` |
+| Token | `https://api.descope.com/oauth2/v1/token` |
+| UserInfo | `https://api.descope.com/oauth2/v1/userinfo` |
+| JWKS | `https://api.descope.com/__ProjectID__/.well-known/jwks.json` |
+
+**Good for:** Teams that want to swap the IdP first, then refactor to Descope-native SDKs
+later. Preserves existing OIDC client code.
+
+**Caveats:** Claim shapes differ, token lifetimes may differ, and WorkOS organization-scoped
+login / SSO must be rebuilt in Descope regardless of path.
+
+> **For B2B apps using WorkOS Organizations:** Path A preserves only a fraction of the work;
+> the management SDK, org/tenant-scoped login, SSO/SCIM setup, and claim mapping require full
+> migration regardless. **Path A savings are minimal for B2B workloads** — account for this
+> when estimating effort.
+
+**After completing framework code changes:** Update `MIGRATION-STATE.md` — mark each
+modified file as Done in the Files Inventory, update Current Phase and Next Action, and
+log any non-obvious decisions made (adapter types kept, async cascade scope, etc.).
+
+---
+
+## Step 2.5: Non-Code File Updates
+
+Scan for WorkOS references in non-code files after updating source files.
+
+### `.env.example` / `.env.template` / `.env.sample`
+```
+# REMOVE
+WORKOS_API_KEY=
+WORKOS_CLIENT_ID=
+WORKOS_REDIRECT_URI=
+WORKOS_COOKIE_PASSWORD=
+
+# ADD
+DESCOPE_PROJECT_ID=             # Console → Project Settings
+NEXT_PUBLIC_DESCOPE_PROJECT_ID= # Next.js only — same value as above
+DESCOPE_MANAGEMENT_KEY=         # Console → Company → Management Keys (only if using management SDK)
+```
+Run `grep -r "WORKOS"` to find all env var references — `.env.example`, Docker, CI, shell scripts.
+
+### README / docs
+Search all `.md` files for WorkOS references. At minimum, update:
+- **Setup section** — replace "create a WorkOS app / AuthKit setup" instructions with Descope Console setup steps
+- **Environment variables section** — reflect the reduced env var set
+- **Run instructions** — replace WorkOS dashboard steps with Descope Console steps
+- **Auth flow diagrams or descriptions** — update to reflect Descope's cookie-based approach
+
+### Docker / CI files
+Check `Dockerfile`, `docker-compose.yml`, `.github/workflows/`, and any CI config for
+`WORKOS_*` env var declarations. Update them to `DESCOPE_*`.
+
+### Setup / bootstrap scripts
+
+When the migration includes a setup or seed script (e.g., `scripts/bootstrap.mjs`, `scripts/seed.ts`), split it into two parts:
+
+1. **Console setup** (cannot be scripted): Flows, email templates, MFA configuration, branding/Styles, SSO Setup Suite — configure these in the Descope Console. Represent them as a Phase 1 checklist in `MIGRATION-PLAN.md`.
+2. **SDK automation** (can be scripted): role creation (`management.role.create()`), tenant creation, access key provisioning, SSO/SCIM config. Preserve these as a Node.js/Python script using the Descope Management SDK.
+
+**After completing non-code file updates:** Update `MIGRATION-STATE.md` — mark env files,
+README, and CI config done in the Files Inventory, and advance Next Action.
+
+---
+
+## Step 3: Feature Migration Mapping
+
+For each WorkOS feature confirmed in triage, write a short paragraph: what it accomplishes, the
+best Descope approach for that goal, what's different, and what action is required. Reason about
+intent, not just the API surface — the best approach may be a Flow, Widget, SSO Setup Suite, or
+Console configuration rather than a direct SDK equivalent. Only recommend SDK/API code when
+programmatic control is genuinely required, and verify every method name against the Docs MCP
+before writing it. Include only confirmed features.
+
+### AuthKit / User Management → Descope Flows + JWT Templates
+
+WorkOS AuthKit handles login UI, authentication methods, users, sessions, and enterprise login
+routing. Descope splits these responsibilities across a Flow (UI + methods), session validation
+(SDK), Users/Tenants, and JWT Templates (profile claims).
+
+| WorkOS | Descope |
+|---|---|
+| Hosted AuthKit login UI | [Descope Flows](https://docs.descope.com/flows) |
+| `withAuth()` / `getUser()` session access | `validateSession()` + a thin adapter returning the shape callers expect |
+| AuthKit user object | Descope User (profile fields via JWT Template) |
+| Auth method config (password, social, passkeys, MFA, magic auth) | Methods toggled in Console + added as Flow steps |
+
+Use Flows for the user-facing journey whenever possible; write custom SDK calls only when Flows
+cannot express the requirement. Ask which auth methods are enabled before recommending details.
+**Effort: Low–Medium** (mostly SDK/UI/session swap; token differences matter).
+
+### Organizations → Descope Tenants
+- WorkOS `externalId` → Descope `token.dct` (active tenant) or `token.tenants` (nested object: `{ [tenantId]: { roles, permissions } }`)
+- WorkOS org-scoped login → Descope routes by email domain or tenant-specific URLs
+- Users are project-level in Descope; associated with tenants, not created per-tenant
+- Organization `metadata` → tenant `customAttributes` (pre-define in the Console schema)
+
+Confirm the one-Organization-to-one-Tenant mapping before writing code — it ripples into SSO, SCIM,
+RBAC, and domain routing. **Effort: Medium** (clean conceptually; org-claim reads may be spread
+across many files).
+
+### Enterprise SSO → Descope Tenant SSO
+
+**Preferred approach — SSO Setup Suite:** before migrating any management-SDK SSO calls, ask whether
+the no-code SSO Setup Suite removes the need for that code. It guides tenant admins through per-tenant
+SAML/OIDC setup with IdP-specific instructions (Okta, Azure AD, Google Workspace, etc.) — no
+engineering involvement for new tenant onboarding.
+
+Use `AskUserQuestion` to ask: does the app need **programmatic** SSO configuration (CI/CD
+provisioning, API-driven onboarding), or do tenant admins configure SSO themselves? If the latter,
+the SSO Setup Suite + Tenant Profile Widget may eliminate the SDK calls entirely. See
+`references/flows-and-widgets.md` → SSO Setup Suite.
+
+**SDK path (when programmatic SSO is needed):**
+
+| WorkOS | Descope |
+|---|---|
+| SAML connection (`sso.*`) | `management.sso.configureSAMLByTenant(tenantId, settings)` |
+| OIDC connection | `management.sso.configureOIDCByTenant(tenantId, settings)` |
+| Per-Organization connection | Per-tenant SSO (Console → SSO or Management SDK) |
+
+(Verify exact method names against the Docs MCP.) Ask whether SSO is configured by internal
+engineers or by customer admins. **Effort: Medium** — setup recreated per tenant.
+
+### Directory Sync / SCIM → Descope SCIM / Tenant Provisioning
+
+WorkOS Directory Sync maps to Descope SCIM provisioning. **Treat this as a continuing pipeline, not
+a one-time import** — enterprise directories keep pushing create/update/suspend/delete events after
+cutover, so every directory must be re-pointed at Descope before cutover or provisioning silently
+breaks.
+
+| WorkOS Directory Sync | Descope |
+|---|---|
+| SCIM endpoint + bearer token per directory | Descope SCIM endpoint + token per tenant |
+| Directory user create/update/deprovision | Tenant user provisioning lifecycle |
+| Directory groups | Group → role mapping in Descope |
+| `dsync.*` / directory webhooks | Descope provisioning events / connectors |
+
+Identify every directory, whether groups are synced, and whether groups map to roles.
+**Effort: Medium–High** (lifecycle, groups, deprovisioning, and role mapping can be subtle).
+
+### Admin Portal → Descope SSO Setup Suite / Widgets
+
+WorkOS Admin Portal is a hosted self-serve UI where customer IT admins configure SSO, Directory Sync,
+and domain verification. Do not default to rebuilding it as custom code.
+
+- Generated portal links (`portal.generateLink(...)`) → SSO Setup Suite hosted/embedded flow or Tenant Profile Widget
+- SSO setup screens → SSO Setup Suite
+- Directory Sync / domain setup → corresponding Widgets
+
+Ask which admin workflows are hosted by WorkOS today before choosing a replacement. **Effort: Medium**
+— may remove custom code, but portal-link workflows need replacement.
+
+### RBAC → Descope RBAC
+
+| WorkOS | Descope |
+|---|---|
+| `role` / `permissions` claim in session | `token.roles` / `token.permissions` (built-in) |
+| Organization-scoped role | Tenant-scoped role under `token.tenants[tenantId].roles` |
+| `roleSlug` reference | Descope role **name** (not ID) |
+| IdP group → role mapping | Group-to-role mapping (Console / SCIM) |
+
+SDK: `descopeClient.management.role.create(name, description, permissionNames, tenantId)` (verify
+signature). Roles must exist in the Console before assignment. Check whether roles are global or
+org-scoped and where checks happen (middleware, API routes, DB queries, frontend). **Effort: Medium.**
+
+### Fine-Grained Authorization (FGA) → Descope ReBAC / AuthZ
+
+Not a mechanical swap — the authorization model must be translated and validated. Schema translation
+example:
+
+```
+# WorkOS FGA
+type document
+  relation owner [user]
+  relation viewer [user]
+  inherit can_view if: owner or viewer
+
+# Descope ReBAC DSL
+type document
+  relation owner: user
+  relation viewer: user
+  permission can_view: owner or viewer
+```
+
+| Operation | WorkOS FGA | Descope ReBAC |
+|---|---|---|
+| Write relation | `fga.writeWarrant({...})` | `descopeClient.management.fga.createRelations([...])` |
+| Check | `fga.check({...})` | `descopeClient.management.fga.check([...])` |
+| List resources | `fga.query(...)` | `descopeClient.management.authz.whatCanTargetAccessWithRelation(...)` |
+
+(Verify exact WorkOS and Descope shapes against current docs.) Identify resources,
+relationships/privileges, where checks run, and any hierarchical inheritance. **Effort: High** —
+require a dedicated model review.
+
+### Audit Logs → Descope Audit Webhook / Events
+
+WorkOS Audit Logs map to Descope audit events, the Audit Webhook Connector, or other connectors
+depending on the use case. Determine whether the app writes events to WorkOS, reads them back, shows
+them to customer admins, or requires them for compliance. **Configure this before cutover** — the app
+may keep working while audit logging is silently broken, creating compliance gaps. **Effort: Medium.**
+
+### Radar → Descope Flow Security Connectors
+
+WorkOS Radar (bot/fraud/abuse protection) maps to Descope Flow security steps and connectors: bot
+detection, CAPTCHA, abuse/risk checks, and risk-based Flow branching. These are composable (add
+detection steps to Flows) and usually configured in the Console/Flow builder rather than app code.
+Ask whether Radar blocks, challenges, or only monitors, and whether app logic depends on its
+decisions. **Effort: Medium** (usually config, not code).
+
+### Pipes → Descope Outbound Apps
+
+WorkOS Pipes (connected third-party accounts with OAuth token storage/refresh) maps to Descope
+Outbound Apps.
+
+Users connect accounts client-side:
+```
+sdk.outbound.connect(appId, { redirectURL, scopes })
+```
+
+Fetch stored tokens server-side:
+```
+POST https://api.descope.com/v1/mgmt/outbound/app/user/token
+Authorization: Bearer {projectId}:{managementKey}
+Body: { "appId": "google-calendar", "userId": "U2abc...", "scopes": [...] }
+```
+
+Ask which providers are connected, where tokens are used (including AI agents / background jobs), and
+whether users must reconnect accounts or tokens can be migrated. **Effort: Medium.**
+
+### Webhooks / Events → Descope Webhooks / Connectors / Events
+
+| WorkOS | Descope |
+|---|---|
+| Webhook endpoint + signing secret | Descope webhook/connector + signature validation |
+| `user.created` / `organization.*` / `dsync.*` events | Corresponding Descope events / connector triggers |
+
+Search the codebase for webhook handlers; update event names, signature/validation logic, and
+payload handling. Identify which event types are business-critical. **Effort: Medium.**
+
+### Domain Verification / Custom Domains → Descope Custom Domains and Tenant Routing
+
+WorkOS domain verification and custom domains map to Descope custom domains and tenant/domain routing
+— especially important for enterprise SSO discovery (routing a user to the right tenant's SSO
+connection by email domain). CNAME setup + verify in Console, then pass `baseUrl` to the SDK if using
+a custom auth domain. **Effort: Low–Medium.**
+
+### Widgets → Descope Widgets
+
+WorkOS Widgets (org switching, Directory Sync setup, SSO setup, domain verification, audit log
+streaming, API keys) should be evaluated against Descope Widgets. If a Descope Widget covers the
+workflow, prefer it over custom migration code. See `references/flows-and-widgets.md` → Widgets.
+
+### MCP Auth / Connect → Deeper Review Required
+
+May map to Descope Inbound Apps, OAuth app patterns, or custom MCP authorization. **Do not generate
+implementation code until the exact WorkOS usage is understood.** Determine whether WorkOS is acting
+as an OAuth provider, an OAuth client, or both. **Effort: Medium–High — flag for dedicated review.**
+
+### Vault → Possibly Out of Scope
+
+WorkOS Vault (encrypting/storing/controlling access to sensitive data) may have no direct Descope
+identity equivalent. Flag it separately and ask whether it is part of the identity migration or a
+separate secrets/data-security effort. **Do not present it as an SDK swap.**
+
+### Feature Flags → Usually Out of Scope
+
+WorkOS Feature Flags are usually not part of an auth migration. If they are used for access control,
+some behavior may map to Descope roles/permissions, but general feature flagging should be treated as
+out of scope.
+
+---
+
+## Step 4: Critical Gotchas (Always Cover These)
+
+### JWT Claims Are Not the Same
+Descope session JWTs contain `sub`, `amr`, `drn`, `tenants`, `roles`, `permissions`, and `dct` by
+default. They do **not** contain `email`, `name`, or `picture`. WorkOS AuthKit tokens may expose
+some profile fields, so code that reads them directly will break after migration.
+
+`dct` (Descope Current Tenant) is a flat string holding the active tenant ID — the direct equivalent
+of WorkOS's `organizationId`. For apps where a user is always in a single tenant context, `token.dct`
+is simpler to read than iterating `token.tenants`. Use `token.tenants` when you need per-tenant roles
+or permissions (it is a keyed object: `{ [tenantId]: { roles, permissions } }`); use `token.dct`
+when you only need the tenant ID.
+
+**Action required:** Configure a JWT Template in the Descope Console to add `email`,
+`name`, and any other profile fields the app reads from the token.
+
+### Sealed Sessions Become Signed JWTs
+WorkOS AuthKit uses an encrypted/sealed session cookie protected by `WORKOS_COOKIE_PASSWORD`.
+Descope issues a signed session JWT in the `DS` cookie (refresh in `DSR`). The sealing password is
+no longer needed, and code that unseals/inspects the WorkOS cookie must be replaced with Descope
+session validation (`validateSession()`), which returns decoded JWT claims.
+
+### Logout Is Two Steps
+1. Call `descopeClient.logout(refreshToken)` to invalidate server-side
+2. Clear `DS` and `DSR` cookies
+
+Skipping either step leaves a broken state.
+
+### Audience Validation Is Opt-In
+Descope session tokens have no `aud` claim by default. Apps that rely on audience-scoped API access
+must (1) configure a custom `aud` claim in JWT Templates and (2) pass `audience` to
+`validateSession()` on the backend.
+
+### Organization Claim Shape Differs
+WorkOS exposes a flat `organizationId` (and `connectionId` / `directoryId`). Descope uses `dct`
+(active tenant) and the nested `tenants` object. Any code reading `organizationId` needs to be
+updated — this is mechanical but can span many files, so grep for all org-claim reads and update
+them in one pass.
+
+### One Token, Not Provider-Specific Access Tokens
+Forward the Descope session JWT (`DS` cookie) as `Authorization: Bearer <DS>` to API servers. There
+is one session token; downstream services validate it with `validateSession()`.
+
+### No Drop-In Middleware
+Descope has no `authkitMiddleware()` equivalent package. The middleware is ~20 lines of custom code
+that reads the `DS` cookie and calls `validateSession()`.
+
+### `cookies()` and `headers()` Are Async in Next.js 15
+`cookies()` and `headers()` from `next/headers` return a `Promise` in Next.js 15+. Before
+generating any server-side helper that reads cookies:
+
+1. Check the project's `package.json` for the Next.js version.
+2. If ≥ 15: write `await cookies()` and mark the containing function `async`.
+3. Trace upward — making a cookie-reading helper async cascades to every caller.
+
+### Async Cascade: Trace All Callers Before Finishing
+When a shared utility becomes async, TypeScript accepts `await` on non-Promises without
+error — so callers that forget `await` silently return a Promise object. Always grep for
+all call sites of any utility you make async and update them in the same pass.
+
+### SCIM Is a Lifecycle, Not a One-Time Import
+If Directory Sync is in use, re-point the SCIM pipeline at Descope before cutover. A one-time user
+import leaves provisioning broken the moment the directory pushes its next change.
+
+### Env Var Reduction
+WorkOS: `WORKOS_API_KEY`, `WORKOS_CLIENT_ID`, `WORKOS_REDIRECT_URI`, `WORKOS_COOKIE_PASSWORD` (4+).
+Descope: `DESCOPE_PROJECT_ID` only (+ `DESCOPE_MANAGEMENT_KEY` for management ops).
+
+---
+
+## Step 5: Automated Testing
+
+Run the app and verify it works — don't just hand over a checklist.
+
+### Phase 0: Final stale-import sweep (BLOCKING)
+
+```bash
+grep -r "@workos-inc\|workos\|authkit" \
+  --include="*.ts" --include="*.tsx" --include="*.js" --include="*.py" --include="*.go" \
+  --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=dist \
+  .
+```
+
+If this returns any results, **stop and fix them before proceeding**.
+
+### Phase 1: Install, compile, and start
+
+```bash
+npm install   # or: pip install -r requirements.txt / go mod tidy
+```
+
+```bash
+npx tsc --noEmit    # TypeScript
+go build ./...      # Go
+mvn compile -q      # Java/Maven
+./gradlew compileJava compileKotlin  # Java/Gradle
+dotnet build        # .NET
+```
+
+**Do not proceed until compilation exits with zero errors.**
+
+**If compilation fails, diagnose by error message:**
+- `Cannot find module '@workos-inc/...'` → stale import; re-run Phase 0
+- `Property 'X' does not exist on type 'AuthenticationInfo'` → wrapper built against WorkOS shape; re-derive
+- `'await' expression is not allowed in synchronous contexts` → async cascade gap
+- `Object is possibly 'undefined'` on session fields → add null check or early return
+
+```bash
+npm run dev   # or: python main.py / go run . / flask run / etc.
+```
+
+### Phase 2: Run existing tests
+
+```bash
+npm test   # or: pytest / go test ./... / etc.
+```
+
+Auth-related test failures usually mean: a mock or fixture still uses WorkOS shapes, or a
+test validates JWT claims that are now missing (e.g., `email` without a JWT Template), or a test
+reads `organizationId` instead of `token.dct`.
+
+### Phase 3: Smoke test the running app
+
+```bash
+# Root path
+curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/
+
+# Unauthenticated protected route (expect 302 or 401)
+curl -s -o /dev/null -w "%{http_code}" http://localhost:<port>/dashboard
+
+# Login page loads Descope component
+curl -s http://localhost:<port>/login | grep -i "descope"
+
+# Invalid token → 401
+curl -s -H "Cookie: DS=invalid_token" http://localhost:<port>/api/me
+```
+
+### Phase 4: Verify JWT claims (if JWT Template is configured)
+
+```bash
+echo "<DS_cookie_value>" | cut -d'.' -f2 | base64 -d 2>/dev/null | python3 -m json.tool
+```
+
+Check that `email`, `name`, and any other expected claims (including `dct`/`tenants` for B2B) are present.
+
+### Phase 5: Report results
+
+```
+## Test Results
+
+**Server startup:** ✅ Started successfully on port 3000
+**Existing tests:** ✅ 12 passed / ❌ 2 failed (list failures)
+**Unauthenticated /dashboard:** ✅ 302 → /login
+**Unauthenticated /api/protected:** ✅ 401
+**Login page loads Descope component:** ✅
+**JWT claims (email, name, dct):** ✅ Present / ❌ Missing — JWT Template not yet configured
+
+**Blockers before going live:**
+- [ ] (list anything that failed or needs manual action)
+```
+
+**Do not proceed to Step 6 until ALL of the following are true:**
+- [ ] Phase 0 grep returns zero WorkOS references
+- [ ] Phase 1 compilation passes with zero errors
+- [ ] Phase 1 server starts and stays running
+- [ ] Phase 3 root path returns 2xx or 3xx (not 5xx)
+- [ ] Phase 3 protected routes return 302 or 401 (not 500)
+
+---
+
+## Step 6: Post-Migration Summary (Required)
+
+Every migration produces a `MIGRATION-SUMMARY.md` covering what was done, manual setup
+remaining, and behavioral differences that matter before production.
+
+### MIGRATION-SUMMARY.md
+
+1. **What was migrated** — a table mapping each WorkOS concept to its Descope replacement
+
+2. **Behavioral differences and open questions** — numbered list of significant differences
+   between the WorkOS and Descope implementations. For each item: WorkOS behavior, Descope
+   behavior, action required.
+
+3. **Pre-deploy checklist** — actionable checkbox items for everything that must happen
+   before the migrated app can run. Prominently include all Console setup tasks (project, Flow,
+   JWT template, tenants, SSO/SCIM) and the SCIM re-point — these are the things easiest to
+   forget because the code compiles without them.
+
+---
+
+## Step 7: Output Format
+
+Write a numbered migration guide in Markdown, scoped to the user's stack. Use code
+snippets and direct doc links. Always include the MIGRATION-SUMMARY.md deliverable (Step 6).
+
+For complex migrations (Directory Sync/SCIM, FGA, Pipes, MCP Auth), flag the high-effort items
+explicitly with estimated complexity (Low/Medium/High) so the user can plan.
+
+---
+
+## Reference Files
+
+- `references/implementation-nuances.md` — Verified migration patterns, code-level diffs, and edge
+  cases for several frameworks.
+- Descope Docs: https://docs.descope.com
+- WorkOS Migration Guide: https://docs.descope.com/migrate  <!-- TODO (verify): confirm the exact WorkOS migration guide URL, if one exists -->
+- User Import (Custom): https://docs.descope.com/migrate/custom
+- Descope OIDC Endpoints: https://docs.descope.com/getting-started/oidc-endpoints
+- Descope Flows: https://docs.descope.com/flows
+- JWT Templates: https://docs.descope.com/management/jwt-templates
+- Access Keys (M2M): https://docs.descope.com/management/m2m-access-keys
+- Messaging Templates: https://docs.descope.com/management/messaging-templates
+- Audit Webhook: https://docs.descope.com/connectors/connector-configuration-guides/network/audit-webhook
+- Custom Domains: https://docs.descope.com/how-to-deploy-to-production/custom-domain
+- ReBAC: https://docs.descope.com/authorization/rebac
+- Outbound Apps: https://docs.descope.com/identity-federation/outbound-apps
+
+### Session Validation by Language
+- Node.js: https://docs.descope.com/getting-started/nodejs#implement-session-validation
+- Python: https://docs.descope.com/getting-started/python#implement-session-validation
+- Go: https://docs.descope.com/getting-started/golang#implement-session-validation
+- Ruby: https://docs.descope.com/getting-started/ruby#implement-session-validation
+- Java / Kotlin: https://docs.descope.com/getting-started/java#implement-session-validation
+- .NET / C#: https://docs.descope.com/getting-started/dotnet#implement-session-validation
+- Next.js: https://docs.descope.com/getting-started/nextjs#implement-session-validation
+- React: https://docs.descope.com/getting-started/react#implement-session-validation
+- Angular: https://docs.descope.com/getting-started/angular#implement-session-validation
+- Vue: https://docs.descope.com/getting-started/vue#implement-session-validation
+- Swift / iOS: https://docs.descope.com/getting-started/swift#implement-session-validation
+- Kotlin / Android: https://docs.descope.com/getting-started/android#implement-session-validation
+- Flutter: https://docs.descope.com/getting-started/flutter#implement-session-validation
+
+### SDKs (GitHub)
+- Node SDK: https://github.com/descope/node-sdk
+- Python SDK: https://github.com/descope/python-sdk
+- Go SDK: https://github.com/descope/go-sdk
+- Ruby SDK: https://github.com/descope/descope-ruby-sdk
+- Java SDK: https://github.com/descope/descope-java
+- .NET SDK: https://github.com/descope/descope-dotnet
+- Swift SDK: https://github.com/descope/swift-sdk
+- Kotlin SDK: https://github.com/descope/descope-kotlin
+- Flutter SDK: https://github.com/descope/descope-flutter
+- JS/TS monorepo (React, Angular, Vue, Next.js, Web Component, Web JS): https://github.com/descope/descope-js

--- a/skills/workos-to-descope/SKILL.md
+++ b/skills/workos-to-descope/SKILL.md
@@ -1,7 +1,5 @@
 ---
-
-## name: workos-to-descope
-
+name: workos-to-descope
 description: >
   Use this skill whenever anyone asks about migrating from WorkOS to Descope — whether they're
   a developer doing it themselves or a technical lead evaluating the move. Triggers on: "how
@@ -99,40 +97,25 @@ Do not proceed to Step 0.5 until the user has answered.
 3. **Existing users and organizations** — Are they migrating an app with active users and
   organizations in WorkOS, staging/dev only, or starting fresh? This determines whether user
    and organization migration planning is needed (user export, org-to-tenant mapping, SCIM
-   continuity, phased vs. big-bang cutover, forced re-login on cutover).
+   continuity, phased vs. big-bang cutover, forced re-login on cutover). /////// is the 4th even necessary?
 4. **Preferred migration style** — Do they want to embed Descope Flows/Widgets directly (full native migration), or preserve an existing OIDC client library and point it at Descope's OIDC endpoints (OIDC compatibility layer)? Note: B2B features (Organizations/SSO/SCIM management) have no OIDC-layer equivalent and require native SDK calls regardless of path.
 
 **Second `AskUserQuestion` call — WorkOS feature usage (use `multiSelect: true`):**
 
 1. **Which WorkOS features are in use?** Present the highest-impact categories:
-  - AuthKit / User Management (core auth replacement)
-  - Organizations (multi-tenancy / B2B)
-  - Enterprise SSO (SAML / OIDC connections)
-  - Directory Sync / SCIM (directory provisioning)
-  - Admin Portal (hosted self-serve admin setup)
-  - Domain Verification / Custom Domains
-  - RBAC / roles / permissions
-  - Fine-Grained Authorization / FGA
-  - Audit Logs
-  - Radar / bot or fraud protection
-  - Pipes / connected accounts
-  - Webhooks / Events
-  - Widgets
-  - MCP Auth / Connect
-  - Vault
-  - Feature Flags
-   The user can add others via "Other." Follow up on anything selected:
+  - **AuthKit** 
   - **Organizations** — organization membership, organization switching, metadata, whether users can belong to multiple organizations.
   - **Enterprise SSO** — connections SAML, OIDC, or both; whether setup is handled by internal engineers or by customer admins; whether domain-based SSO routing is used.
   - **Directory Sync / SCIM** — which directories; group sync; group-to-role mapping; deprovisioning behavior; directory webhook handlers.
   - **Admin Portal / Widgets** — which customer-admin workflows are hosted by WorkOS today; whether the app generates portal links; whether Descope Widgets or the SSO Setup Suite can replace them.
-  - **RBAC** — whether roles are global or organization-scoped; where permission checks happen in code; whether roles/permissions are in tokens; whether IdP groups map to roles.
+  - **RBAC** — whether roles are global/environment or organization-scoped; where permission checks happen in code; whether roles/permissions are in tokens; whether IdP groups map to roles.
   - **FGA** — the authorization model (resources, relationships, privileges, hierarchy); where checks are performed. Flag as high complexity.
   - **Audit Logs** — whether logs are written to WorkOS, read back from WorkOS, shown to customers, or required for compliance.
   - **Radar** — whether it blocks, challenges, or only monitors suspicious auth attempts; custom rules.
   - **Pipes** — which providers are connected; where connected-account tokens are used (AI agents, integrations, background jobs).
   - **Vault / Feature Flags** — flag as potentially outside the core Descope identity migration unless used directly for auth or access control.
   - **MCP Auth / Connect** — flag for deeper review before implementation.
+  - The user can add others via "Other."
 
 After both calls, summarize findings and flag high-complexity items (Directory Sync/SCIM, FGA,
 Pipes, MCP Auth/Connect, Vault) before proceeding to Step 0.5.
@@ -301,6 +284,12 @@ Tailor to triage findings.
 
 ---
 
+---
+
+/// Very specific 1 to 1 comparison to using descope client and backend sdk's
+
+make sure 
+
 #### Auth Touchpoints: What the Code Analysis Found
 
 Open with the scope count (e.g., "11 files across 4 areas"). Group by area, not file path.
@@ -412,11 +401,6 @@ Prose strategy first, then steps. Start with: "X existing users across Y organiz
 - **Org→tenant mapping**: each WorkOS Organization becomes a Descope Tenant; membership and tenant-scoped roles depend on this mapping being correct first
 - **What users will experience**: will they need to log in again? Will anything look different?
 - **The biggest dependency**: how password credentials carry over, and whether SCIM directories must be re-pointed at Descope (a continuing pipeline, not a one-time import)
-
-> **TODO (verify):** Confirm the current WorkOS user/organization export capability and whether
-> Descope offers a dedicated WorkOS importer. If no dedicated importer exists, use the custom
-> import path (`https://docs.descope.com/migrate/custom`) with the Descope Management SDK. Do not
-> assume the Auth0 migration script (`descope/descope-migration`) supports WorkOS.
 
 End with a brief checklist of the migration steps at the level a PM can track:
 
@@ -718,7 +702,7 @@ the provider step to your Flow.
 
 WorkOS AuthKit tokens may include profile fields; Descope tokens do not by default.
 
-- Console → **Authorization → JWT Templates → New Template**
+- Console → **Project → JWT Templates**
 - Add claims: `{"email": "{{user.email}}", "name": "{{user.name}}", "picture": "{{user.picture}}"}`
 - Apply the template to your project. Without this step, any code reading `token.email`
 will get `undefined` after migration.
@@ -799,7 +783,6 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 - Remove `@workos-inc/node` auth/session usage; add `@descope/node-sdk`
 - Validate the `DS` session token via custom middleware calling `descopeClient.validateSession()` (parse the cookie yourself)
-- Login UI → `<descope-wc>` web component; logout: `descopeClient.logout(refreshToken)` + clear `DS`/`DSR` cookies
 
 #### Go
 
@@ -815,7 +798,6 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 - Remove the WorkOS Ruby SDK; add the Descope Ruby SDK
 - Validate the `DS` session token via the Descope Ruby SDK in your request lifecycle
-- Login UI → `<descope-wc>` web component; logout: Descope SDK logout + clear `DS`/`DSR` cookies
 - No dedicated recipe in `implementation-nuances.md` yet — follow the Node.js / Python backend patterns and verify against the [Descope Ruby SDK](https://github.com/descope/ruby-sdk).
 
 #### Rust
@@ -824,7 +806,6 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 - There is no official Descope Rust SDK. Validate the `DS` session JWT directly against Descope's JWKS endpoint (`https://api.descope.com/v2/keys/<project_id>`) using a standard JWT library.
 - Management operations (users, tenants, roles, SSO) → call the Descope Management REST API directly.
-- Login UI → `<descope-wc>` web component; logout clears `DS`/`DSR` cookies.
 
 #### Python
 
@@ -832,7 +813,6 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 - Remove the WorkOS Python SDK auth/session usage; add the `descope` Python SDK
 - Validate the `DS` session token with `descope_client.validate_session(session_token)` (or validate against Descope's JWKS for a custom authorizer)
-- Login UI → `<descope-wc>` web component; logout: `descope_client.logout(refresh_token)` + delete cookies
 
 #### PHP
 
@@ -840,7 +820,6 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 - Remove the WorkOS PHP SDK; add the Descope PHP SDK
 - Validate the `DS` token via the Descope PHP SDK in your request lifecycle
-- Login UI → `<descope-wc>` web component; logout clears `DS`/`DSR` cookies
 - No dedicated recipe yet — follow the Node.js / Python backend patterns and verify against the Descope PHP SDK.
 
 #### Laravel
@@ -849,7 +828,6 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 - Remove the WorkOS Laravel package; use the Descope PHP SDK
 - Validate the `DS` token in Laravel middleware
-- Login UI → `<descope-wc>` web component; logout clears `DS`/`DSR` cookies
 - No dedicated recipe yet — follow the PHP backend patterns and verify.
 
 #### Java
@@ -858,7 +836,6 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 - Remove the WorkOS Java/Kotlin SDK; add `descope-java`
 - Validate the `DS` token via a filter/interceptor
-- Login UI → `<descope-wc>` web component; logout clears `DS`/`DSR` cookies
 - No dedicated recipe yet — follow the backend patterns and verify against the [Descope Java SDK](https://github.com/descope/descope-java).
 
 #### .NET
@@ -867,7 +844,6 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 - Remove the WorkOS .NET SDK; add `descope-dotnet`
 - Validate the `DS` token in middleware / a custom auth handler
-- Login UI → `<descope-wc>` web component; logout clears `DS`/`DSR` cookies
 - No dedicated recipe yet — follow the backend patterns and verify against the [Descope .NET SDK](https://github.com/descope/descope-dotnet).
 
 ### AuthKit SDKs
@@ -921,13 +897,13 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 #### TanStack Start
 
-*WorkOS SDK: `authkit-tanstack-start` → Descope `@descope/react-sdk` / `@descope/web-js-sdk` (no Descope TanStack SDK)*
+*/// Note: Kevin will explain WorkOS SDK:* `authkit-tanstack-start` *→ Descope `@descope/react-sdk` / `@descope/web-js-sdk` (no Descope TanStack SDK)*
 
 - Server-route session helpers → TanStack server functions validating the Descope session token
 - Login via embedded Descope component; logout via `sdk.logout()` + cookie clear
 - No dedicated recipe yet — follow the Next.js / React patterns and verify.
 
-### Path A: OIDC Compatibility (lower risk, incremental)
+### /// not typically used : client sdk/backend sdk replacements most common Path A: OIDC Compatibility (lower risk, incremental)
 
 Descope exposes standard OIDC endpoints. If the app uses a **generic OIDC client library**
 pointed at WorkOS, it can point at Descope's OIDC issuer instead with minimal code changes.
@@ -982,6 +958,8 @@ DESCOPE_MANAGEMENT_KEY=         # Console → Company → Management Keys (only 
 
 Run `grep -r "WORKOS"` to find all env var references — `.env.example`, Docker, CI, shell scripts.
 
+//// api key is saame as our mgmt key
+
 ### README / docs
 
 Search all `.md` files for WorkOS references. At minimum, update:
@@ -1017,7 +995,7 @@ Console configuration rather than a direct SDK equivalent. Only recommend SDK/AP
 programmatic control is genuinely required, and verify every method name against the Docs MCP
 before writing it. Include only confirmed features.
 
-### AuthKit / User Management → Descope Flows + JWT Templates
+### AuthKit → Descope Flows + JWT Templates
 
 WorkOS AuthKit handles login UI, authentication methods, users, sessions, and enterprise login
 routing. Descope splits these responsibilities across a Flow (UI + methods), session validation
@@ -1038,8 +1016,8 @@ cannot express the requirement. Ask which auth methods are enabled before recomm
 
 ### Organizations → Descope Tenants
 
-- WorkOS `organizationId` (flat string) → Descope `token.dct` (active tenant) or `token.tenants` (nested object: `{ tenantId: { roles, permissions } }`)
-- WorkOS org-scoped login → Descope routes by email domain or tenant-specific URLs
+- WorkOS `organizationId` (flat string) → Descope /// internal tenant id (nested object: `{ tenantId: { roles, permissions } }`)
+- WorkOS org-scoped login → Descope routes by email domain or tenant name or tenant id
 - Users are project-level in Descope; associated with tenants, not created per-tenant
 - Organization `metadata` → tenant `customAttributes` (pre-define in the Console schema)
 
@@ -1054,10 +1032,21 @@ the no-code SSO Setup Suite removes the need for that code. It guides tenant adm
 SAML/OIDC setup with IdP-specific instructions (Okta, Azure AD, Google Workspace, etc.) — no
 engineering involvement for new tenant onboarding.
 
-Use `AskUserQuestion` to ask: does the app need **programmatic** SSO configuration (CI/CD
-provisioning, API-driven onboarding), or do tenant admins configure SSO themselves? If the latter,
-the SSO Setup Suite + Tenant Profile Widget may eliminate the SDK calls entirely. See
-`references/flows-and-widgets.md` → SSO Setup Suite.
+**Multiple SSO configurations per tenant.** Descope supports more than one SSO/IdP configuration on a
+single tenant: each tenant has a **Default SSO Configuration** plus optional **additional named SSO
+configurations** (Console or API/SDK). At login, Descope selects the right IdP by **domain-based
+routing** (e.g. `@acme.com` → Acme's Okta, `@globex.com` → Globex's Azure AD), a **tenant-specific
+login URL**, an explicit SSO configuration ID, or Flow logic. SCIM provisioning can be scoped per SSO
+configuration, and each configuration can have its own SSO Setup Suite link. See
+`references/flows-and-widgets.md` and [Descope Multi-SSO](https://docs.descope.com/sso/multi-sso).
+
+Use `AskUserQuestion` to ask **two** things here:
+1. Does any single customer use **multiple IdPs** (or did they create multiple WorkOS Organizations for
+   the same customer to handle different SSO connections/domains)? If yes, plan to consolidate into one
+   Descope Tenant with multiple SSO configurations rather than multiple tenants.
+2. Does the app need **programmatic** SSO configuration (CI/CD provisioning, API-driven onboarding), or
+   do tenant admins configure SSO themselves? If the latter, the SSO Setup Suite + Tenant Profile
+   Widget may eliminate the SDK calls entirely. See `references/flows-and-widgets.md` → SSO Setup Suite.
 
 **SDK path (when programmatic SSO is needed):**
 
@@ -1105,36 +1094,69 @@ Ask which admin workflows are hosted by WorkOS today before choosing a replaceme
 
 ### RBAC → Descope RBAC
 
+WorkOS roles come in two scopes, and they map to Descope's two scopes:
 
-| WorkOS                                  | Descope                                                  |
-| --------------------------------------- | -------------------------------------------------------- |
-| `role` / `permissions` claim in session | `token.roles` / `token.permissions` (built-in)           |
-| Organization-scoped role                | Tenant-scoped role under `token.tenants[tenantId].roles` |
-| `roleSlug` reference                    | Descope role **name** (not ID)                           |
-| IdP group → role mapping                | Group-to-role mapping (Console / SCIM)                   |
+- **Environment-level role** (defined on the WorkOS environment, available across all organizations) → **Descope project-level role** (applies across all tenants).
+- **Organization-scoped role** (a WorkOS "custom role", defined for a specific organization) → **Descope tenant-level role** (under `token.tenants[tenantId].roles`).
+
+
+| WorkOS                                                    | Descope                                          |
+| --------------------------------------------------------- | ------------------------------------------------ |
+| `role`                                                    | `role`                                           |
+| `permission`                                              | `permission`                                     |
+| Environment-level role (applies across all organizations) | Project-level role (applies across all tenants)  |
+| Organization-scoped role ("custom role")                  | Tenant-scoped role                               |
+| `roleSlug` reference                                      | Descope role **name** (not ID)                   |
+| IdP group → role mapping                                  | Group-to-role mapping (SSO Configuration / SCIM) |
 
 
 SDK: `descopeClient.management.role.create(name, description, permissionNames, tenantId)` (verify
-signature). Roles must exist in the Console before assignment. Check whether roles are global or
-org-scoped and where checks happen (middleware, API routes, DB queries, frontend). **Effort: Medium.**
+the exact function name depending on the language sdk). Pass `tenantId` to create a **tenant-level**
+role (the equivalent of a WorkOS organization-scoped/custom role); omit it for a **project-level**
+role (the equivalent of a WorkOS environment-level role). Roles must exist in the Console before
+assignment. Check whether each WorkOS role is environment- or organization-scoped and where checks
+happen (middleware, API routes, DB queries, frontend). **Effort: Medium.**
 
-### Fine-Grained Authorization (FGA) → Descope ReBAC / AuthZ
+### //// note: look into Fine-Grained Authorization (FGA) → Descope ReBAC / AuthZ
 
-Not a mechanical swap — the authorization model must be translated and validated. Schema translation
-example:
+Authorization model must be translated and validated. Schema translation example:
 
 ```
 # WorkOS FGA
-type document
-  relation owner [user]
-  relation viewer [user]
-  inherit can_view if: owner or viewer
+Resource type: project
+Parent: workspace
+
+Permissions:
+- project:view
+- project:edit
+- project:delete
+
+Roles:
+- project-viewer
+  - project:view
+
+- project-editor
+  - project:view
+  - project:edit
 
 # Descope ReBAC DSL
 type document
   relation owner: user
   relation viewer: user
-  permission can_view: owner or viewer
+  permission can_view: owner | viewer
+```
+
+**Descope ReBAC schema DSL** — use this syntax to author the Descope ReBAC schema:
+
+```
+Syntax                             Description          Example
+---------------------------------  -------------------  ----------------------------
+type <name>                        Define a type        type user
+relation <name>: <type>            Define a relation    relation owner: user
+|                                  Union (OR) operator  user | group
+#                                  Relation reference   Group#member
+.                                  Traverse relation    parent.owner
+permission <name>: <expression>    Define a permission  permission can_edit: owner
 ```
 
 
@@ -1152,16 +1174,40 @@ require a dedicated model review.
 
 WorkOS Audit Logs map to Descope audit events, the Audit Webhook Connector, or other connectors
 depending on the use case. Determine whether the app writes events to WorkOS, reads them back, shows
-them to customer admins, or requires them for compliance. **Configure this before cutover** — the app
-may keep working while audit logging is silently broken, creating compliance gaps. **Effort: Medium.**
+them to customer admins, or requires them for compliance. **Effort: Medium.**
 
-### Radar → Descope Flow Security Connectors
+### Radar → Descope Fingerprinting + Flow Security
 
-WorkOS Radar (bot/fraud/abuse protection) maps to Descope Flow security steps and connectors: bot
-detection, CAPTCHA, abuse/risk checks, and risk-based Flow branching. These are composable (add
-detection steps to Flows) and usually configured in the Console/Flow builder rather than app code.
-Ask whether Radar blocks, challenges, or only monitors, and whether app logic depends on its
-decisions. **Effort: Medium** (usually config, not code).
+**Mechanism difference (read this first):** WorkOS Radar is a dashboard toggle layered on top of
+AuthKit — it collects device-fingerprint signals and *automatically* blocks / challenges / notifies
+based on the actions you enable, with no app code. Descope has **no single equivalent toggle**.
+Instead you reproduce Radar's behavior by adding Descope's built-in fingerprinting/risk signals to
+your **Flow** and branching on them. So "configuring Radar" becomes "designing the Flow."
+
+Descope surfaces risk signals as `riskInfo` inside a Flow. `riskInfo.botDetected` and
+`riskInfo.riskScore` require adding a **Fingerprint / Assess** action immediately after the
+login/signup screen; `riskInfo.impossibleTravel` and `riskInfo.trustedDevice` do not. For stronger
+detection, layer in fraud/CAPTCHA connectors (reCAPTCHA Enterprise, Turnstile, Telesign,
+Fingerprint, Forter, Sardine).
+
+
+| Radar action  | What it does in WorkOS                                             | Descope equivalent                                                                                                                                                                  |
+| ------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Block**     | Auth fails even with valid credentials                             | Flow conditional after Fingerprint Assess: on high `riskInfo.riskScore` / `riskInfo.botDetected`, branch to a deny/failure screen and end the Flow without issuing a session        |
+| **Challenge** | Sends an email (or SMS) OTP step-up                                | Risk-based step-up in the Flow: branch the high-risk path into an OTP/MFA step or a CAPTCHA connector (reCAPTCHA / Turnstile) before continuing                                     |
+| **Notify**    | Sends an informational email to user/admin; sign-in still proceeds | Compose it: on the risk branch, fire an email/messaging connector or an outbound webhook (or rely on Descope audit events) to alert the user/admin, while letting the Flow continue |
+
+
+**Detection mapping** (verify current signal names against docs):
+
+- Bot detection → `riskInfo.botDetected` (needs Fingerprint Assess) + CAPTCHA connectors
+- Impossible travel → `riskInfo.impossibleTravel`
+- Unrecognized device → `riskInfo.trustedDevice` (invert: untrusted = unrecognized)
+- Brute force / repeat sign-up / stale accounts / managed lists (disposable email, sanctioned countries) / custom allow-deny restrictions → no single built-in signal; reproduce via `riskInfo.riskScore` thresholds, connectors, or custom Flow conditions. Flag any of these in use for dedicated design.
+
+Ask whether each Radar detection is set to **block, challenge, or notify**, and whether app logic
+depends on its decisions (vs. pure config). **Effort: Medium** — Console/Flow configuration rather
+than app code, but the decisioning must be *rebuilt* in the Flow, not simply toggled on.
 
 ### Pipes → Descope Outbound Apps
 

--- a/skills/workos-to-descope/SKILL.md
+++ b/skills/workos-to-descope/SKILL.md
@@ -691,7 +691,7 @@ yes, skip to verifying items 5–7 — these are easy to miss even for existing 
 ### 1. Create a project and get your Project ID
 
 - Sign in at [console.descope.com](https://console.descope.com)
-- Your **Project ID** appears in the top-left project selector and under **Project → Generak**. It starts with `P` (e.g. `P2abc123...`).
+- Your **Project ID** appears in the top-left project selector and under **Project → General**. It starts with `P` (e.g. `P2abc123...`).
 - For Next.js client-side code, this becomes `NEXT_PUBLIC_DESCOPE_PROJECT_ID`. For all server-side SDKs, it's `DESCOPE_PROJECT_ID`.
 
 ### 2. Get a Management Key (if needed)

--- a/skills/workos-to-descope/SKILL.md
+++ b/skills/workos-to-descope/SKILL.md
@@ -88,9 +88,6 @@ time and produces incorrect guidance.
 
 Do not proceed to Step 0.5 until the user has answered.
 
-
-////// comment down here ask kevin
-
 **First `AskUserQuestion` call (up to 4 questions):**
 
 1. **Backend language / framework** — Present the most likely options based on any cues
@@ -875,6 +872,16 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 ### AuthKit SDKs
 
+> **Read the session the framework-native way — never hand-parse the JWT on the client.** On
+> front-end pages and components, get auth state from the Descope hooks: `useSession()` for the
+> session token and auth status, `useUser()` for the user profile, and `useDescope()` for actions
+> like `logout()`. Do **not** manually decode the session token or pull claims out of it in client
+> code. Server-side session *validation* — `session()` in `@descope/nextjs-sdk/server`,
+> `validateSession()` in `@descope/node-sdk` (or the other backend SDKs) — belongs only in backend
+> routes, loaders, middleware, and API handlers, never in a rendered client component. This matters
+> most with the **React SDK**, where it's tempting to crack open the raw token in a component instead
+> of calling `useUser()` / `useSession()`.
+
 #### JavaScript
 
 *WorkOS SDK: `authkit-js` → Descope `@descope/web-js-sdk` + `@descope/web-component`*
@@ -889,6 +896,7 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 - `<AuthKitProvider>` → Descope `<AuthProvider projectId>`
 - `useAuth()` (user/session/loading) → `useSession()` + `useUser()` hooks
+- **Always read auth state through the hooks** — `useSession()` (token + `isAuthenticated`) and `useUser()` (profile), with `useDescope()` for actions. Never decode the session token by hand in a component, and never call backend `validateSession()` from client code; that runs only on the server.
 - `signIn()` / hosted redirect → embedded `<Descope flowId>` component, wiring `onSuccess`
 - Logout: `sdk.logout()` via `useDescope()` hook
 - No dedicated recipe yet — follow the Next.js client-side patterns and verify each method against docs.
@@ -930,10 +938,22 @@ to Descope session validation + the hosted/embedded Flow the same way.
 - Login via embedded Descope component; logout via `sdk.logout()` + cookie clear
 - No dedicated recipe yet — follow the Next.js / React patterns and verify.
 
-### /// not typically used : client sdk/backend sdk replacements most common Path A: OIDC Compatibility (lower risk, incremental)
+### Path A: OIDC Compatibility (lower risk, incremental)
 
 Descope exposes standard OIDC endpoints. If the app uses a **generic OIDC client library**
 pointed at WorkOS, it can point at Descope's OIDC issuer instead with minimal code changes.
+
+**First classify the current integration — the OIDC endpoints only matter for the hosted-page case.**
+Before considering Path A, determine how the app authenticates today:
+- **Hosted AuthKit page** (users are redirected to a WorkOS-hosted login URL through a generic
+  OIDC/OAuth client) → the Descope OIDC endpoints below are directly relevant; re-point the OIDC
+  client at Descope's issuer.
+- **Embedded AuthKit** (AuthKit's own SDK/components rendering login inside the app) **or custom code**
+  against the WorkOS SDK → the OIDC endpoints are largely irrelevant; this is a Descope-native SDK +
+  Flow migration (Path B), not an issuer swap.
+
+Don't recommend Path A until you've confirmed the app uses a standard OIDC/OAuth client against the
+hosted page.
 
 > Many WorkOS apps use AuthKit's own SDK rather than a generic OIDC client, in which case Path A may not apply cleanly. Confirm whether the app uses a standard OIDC client before recommending this path. Verify the Descope OIDC endpoint table below against current docs.
 
@@ -1088,6 +1108,27 @@ Use `AskUserQuestion` to ask **two** things here:
 (Verify exact method names against the Docs MCP.) Ask whether SSO is configured by internal
 engineers or by customer admins. **Effort: Medium** — setup recreated per tenant.
 
+**Runtime login calls — always use `sso.start` / `sso.exchange`, never the OAuth flow.** When code
+initiates an enterprise SSO login (the equivalent of WorkOS's `sso.getAuthorizationUrl()` +
+`sso.getProfileAndToken()`), call the Descope SDK's `sso.start(tenant, redirectUrl, ...)` to begin
+the flow and `sso.exchange(code)` to complete it. Use these **regardless of the IdP's underlying
+protocol** — even when the tenant's SSO is configured in Descope as OIDC/OAuth — because `sso.start`
+resolves the **tenant-level SSO configuration** (the correct IdP, domain-based routing, and
+connection settings) for you. Do **not** reach for the generic `oauth.start` / `oauth.exchange`
+functions for enterprise SSO: those drive project-level social/OAuth providers and will not apply a
+tenant's SSO config. Rule of thumb: tenant/enterprise SSO → `sso.*`; social or generic OAuth login →
+`oauth.*`.
+
+**Don't rebuild provider-specific SSO UI — let tenant config do the routing.** Especially when the
+app uses the **backend SDKs**, do not migrate or recreate any per-IdP login UI (separate "Sign in
+with Okta" / "Sign in with Azure AD" buttons, provider-picker screens, etc.), regardless of which
+SSO provider the WorkOS code names. In Descope the IdP is defined as **tenant SSO configuration**,
+and a single `sso.start` call resolves it automatically — either from the **user's email domain**
+(domain-based routing) or by passing the **tenant ID / slug** explicitly (e.g. hardcoded for a known
+tenant). So the login surface just collects an email (or targets a known tenant) and calls
+`sso.start`; Descope selects the correct IdP from config. Keep the UI generic and push all
+provider-specific details into Console/tenant configuration.
+
 ### Directory Sync / SCIM → Descope SCIM / Tenant Provisioning
 
 WorkOS Directory Sync maps to Descope SCIM provisioning. **Treat this as a continuing pipeline, not
@@ -1144,7 +1185,7 @@ role (the equivalent of a WorkOS environment-level role). Roles must exist in th
 assignment. Check whether each WorkOS role is environment- or organization-scoped and where checks
 happen (middleware, API routes, DB queries, frontend). **Effort: Medium.**
 
-### //// note: look into Fine-Grained Authorization (FGA) → Descope ReBAC / AuthZ
+### Fine-Grained Authorization (FGA) → Descope ReBAC / AuthZ
 
 Authorization model must be translated and validated. Schema translation example:
 

--- a/skills/workos-to-descope/SKILL.md
+++ b/skills/workos-to-descope/SKILL.md
@@ -823,7 +823,7 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 - Remove the WorkOS Ruby SDK; add the Descope Ruby SDK
 - Validate the `DS` session token via the Descope Ruby SDK in your request lifecycle
-- No dedicated recipe in `implementation-nuances.md` yet — follow the Node.js / Python backend patterns and verify against the [Descope Ruby SDK](https://github.com/descope/ruby-sdk).
+- No dedicated recipe in `implementation-nuances.md` yet — follow the Node.js / Python backend patterns and verify against the [Descope Ruby SDK](https://github.com/descope/descope-ruby-sdk).
 
 #### Rust
 

--- a/skills/workos-to-descope/SKILL.md
+++ b/skills/workos-to-descope/SKILL.md
@@ -933,7 +933,7 @@ to Descope session validation + the hosted/embedded Flow the same way.
 
 #### TanStack Start
 
-*/// Note: Kevin will explain WorkOS SDK:* `authkit-tanstack-start` *→ Descope `@descope/react-sdk` / `@descope/web-js-sdk` (no Descope TanStack SDK)*
+*WorkOS SDK: `authkit-tanstack-start` → Descope `@descope/react-sdk` / `@descope/web-js-sdk` (no Descope TanStack SDK)*
 
 - Server-route session helpers → TanStack server functions validating the Descope session token
 - Login via embedded Descope component; logout via `sdk.logout()` + cookie clear

--- a/skills/workos-to-descope/SKILL.md
+++ b/skills/workos-to-descope/SKILL.md
@@ -1006,8 +1006,6 @@ DESCOPE_MANAGEMENT_KEY=         # Console → Company → Management Keys (only 
 
 Run `grep -r "WORKOS"` to find all env var references — `.env.example`, Docker, CI, shell scripts.
 
-//// api key is saame as our mgmt key
-
 ### README / docs
 
 Search all `.md` files for WorkOS references. At minimum, update:

--- a/skills/workos-to-descope/references/flows-and-widgets.md
+++ b/skills/workos-to-descope/references/flows-and-widgets.md
@@ -1,0 +1,227 @@
+# Descope Flows, Widgets, and Console-First Reference
+
+This file covers Descope's no-code/low-code layer — Flows, Widgets, the SSO Setup Suite, and
+the Console-vs-code decision guide. Read it when the migration touches auth UI, MFA enrollment,
+user management pages, or SSO configuration. In all those areas, a Console/Flow/Widget approach
+is usually faster and safer than writing code.
+
+---
+
+## Contents
+
+- [Terminology: Auth0 → Descope Lingo](#terminology-auth0--descope-lingo)
+- [Flows: Structure and What They Replace](#flows-structure-and-what-they-replace)
+- [Widgets: Post-Login Management UI](#widgets-post-login-management-ui)
+- [SSO Setup Suite](#sso-setup-suite)
+- [Console vs. Code: The Decision Guide](#console-vs-code-the-decision-guide)
+
+---
+
+## Terminology: Auth0 → Descope Lingo
+
+### Critical naming inversion
+
+The most common migration mistake: Auth0 and Descope use the word "tenant" to mean different things.
+
+| Auth0 term | Descope term | Notes |
+|---|---|---|
+| **Tenant** (your Auth0 account) | **Project** | Top-level unit. Has auth methods, Flows, users, and settings. Multiple environments → multiple Projects. |
+| **Organization** (your B2B customer) | **Tenant** | "For B2B apps, a tenant is your customer." Direct equivalent of Auth0 Organization. |
+| Application | **Federated Application** (OIDC/SAML clients) or just **Project** (direct SDK integration) | Use Federated Application when you need OIDC/SAML; use Project directly for SDK-based integration. |
+| Action / Rule / Hook | **Flow + Scriptlet + Connector** | Flows replace the entire Auth0 pipeline. Actions become Flow steps; custom code becomes Scriptlets; external calls become Connectors. |
+| M2M Client / Client Credentials | **Access Key** | Presented to exchange for a short-lived JWT. Supports expiration, permitted IPs, tenant/role scoping. |
+| Universal Login Page | **Auth Hosting** (hosted) or embedded **`<descope-wc>` / `<Descope>` component** | Flows define the auth experience in both cases. |
+| Social Connection (Google, GitHub…) | **OAuth Provider** | Configured under Authentication Methods in Console. |
+| Enterprise Connection (SAML/OIDC per-org) | **Tenant SSO** | Per-tenant configuration. Use the SSO Setup Suite for self-service. |
+| Branding | **Styles** | Logo, colors, fonts in Console → Styles. Inherited by all Flow Screens. |
+| Auth0 Marketplace integration | **Connector** | Added as a step inside a Flow. Response available in flow context as `connectors.<contextKey>`. |
+| Roles / Permissions | **Roles / Permissions** | Same concepts. Project-level and tenant-level. Stored as strings in JWT. |
+| Management API (M2M token) | **Management SDK + Management Key** | Same capabilities, different auth (Management Key vs. M2M token). |
+
+### Other Descope-specific terms
+
+- **Project** — the top-level unit. Think Auth0 tenant.
+- **Flow** — visual auth pipeline. Replaces Auth0 Actions/Rules/Hooks + Universal Login.
+- **Screen** — one UI page within a Flow. Designed in Screen Builder.
+- **Scriptlet** — inline JS step in a Flow (Lodash + CryptoJS included). Escape hatch for custom logic.
+- **Connector** — HTTP call step in a Flow. Response stored in flow context.
+- **Subflow** — one Flow embedded inside another. Context passes through; does not terminate the parent.
+- **Descoper** — a person with Console access. Managed in Company Settings → Descopers with custom roles.
+- **Auth Hosting Application** — the hosted login UI (equivalent to Auth0 Universal Login domain).
+
+---
+
+## Flows: Structure and What They Replace
+
+A Descope Flow is a visual, no-code authentication pipeline built in the Console. It IS the
+authentication process — not a hook on top of it. Flows can be changed without redeploying
+the application.
+
+### What Flows replace from Auth0
+
+| Auth0 | Descope Flow equivalent |
+|---|---|
+| Actions / Rules / Hooks (post-login logic, claims, role assignment) | Flow steps (Actions, Scriptlets, Custom Claims) |
+| Universal Login page UI | Flow Screens |
+| Email verification sequence | Email verification Flow step |
+| Password reset sequence | Password reset Flow (template available) |
+| MFA enrollment (Guardian ticket URL redirect) | MFA step in main sign-in Flow, or MFA subflow |
+| Invitation emails | Invitation Flow (template available) |
+| Step-up authentication | Step-up Flow (template: `step-up`; adds `su` claim to JWT) |
+| Progressive profiling | Progressive profiling Flow (template available) |
+| Attack protection (bot detection, brute force) | Connector steps (Arkose, reCAPTCHA, Fingerprint, HaveIBeenPwned, AbuseIPDB) |
+
+### Building blocks
+
+1. **Screens** — UI forms. Designed in Screen Builder. Support conditional show/hide of components based on context values (`user.*`, `form.*`, `tenant.*`).
+2. **Actions** — single-task steps: authenticate, send OTP, verify magic link, create user, assign role, set custom claims, end the flow.
+3. **Conditions** — branch routing based on context values (`user.*`, `tenant.*`, `form.*`, `connectors.<key>`, `jwtClaims.*`, `cookies.<name>`).
+4. **Connectors** — HTTP calls to external services during the flow. Response stored as `connectors.<contextKey>` for use in later Conditions, Actions, or Custom Claims.
+
+**Advanced:**
+- **Scriptlets** — inline JavaScript. Useful for string manipulation, hashing, date math, or calling Lodash/CryptoJS utilities. Has a test/debug mode.
+- **Subflows** — embed one Flow inside another. The subflow End continues back to the parent instead of generating a JWT. Pass inputs via `{{subflowInput.key}}`. Good for MFA as a step inside a larger sign-in journey.
+
+### Flow templates (100+ in library)
+
+Access via Console → Flows → "Start from template". Search by method, use case, or connector.
+
+**Common templates:**
+- `sign-up-or-in` — default; combines email OTP, magic link, social, passkeys
+- `step-up` — step-up auth; adds `su` JWT claim on success
+- OTP variants (email, SMS, WhatsApp)
+- Magic link variants
+- Passkey / WebAuthn
+- Social login
+- TOTP / authenticator app
+- SSO / SAML / OIDC federation
+- MFA combinations (password + TOTP, social + OTP, passkeys + magic link)
+- Invitation, user impersonation, progressive profiling, account recovery
+
+**Before writing any custom Flow configuration:** check whether a template already covers the
+use case. Most common patterns are available out of the box.
+
+### MFA enrollment specifically
+
+Many Auth0 apps have a separate MFA enrollment page because Auth0 Guardian works via a server-generated redirect URL. That pattern has no Descope equivalent.
+
+**The Descope approach:**
+- Add an MFA step to the main sign-up/sign-in Flow — enrollment happens inline during the auth journey
+- Or embed MFA as a **subflow** — triggered by a condition (e.g., user is admin, or risk score is high)
+- Or use the **step-up** flow template to gate sensitive operations
+
+Before migrating a standalone MFA enrollment page, ask whether MFA can be integrated into the main Flow instead. This is almost always the cleaner approach in Descope.
+
+---
+
+## Widgets: Post-Login Management UI
+
+Widgets are embeddable management UI components for post-login operations. Each widget
+action runs a Flow under the hood. Customizable via Console → Widgets without code changes.
+
+### When to recommend a Widget
+
+Whenever the migration plan calls for building or migrating a custom:
+- Profile edit page → **User Profile Widget**
+- User management page (admin view) → **User Management Widget**
+- Role assignment UI → **Role Management Widget**
+- Tenant SSO setup page → **Tenant Profile Widget** (+ SSO Setup Suite)
+- Audit log view → **Audit Widget**
+
+Ask before writing code: *"Does a Widget cover this use case?"*
+
+### Widget types
+
+**User-facing (for end users):**
+
+| Widget | What it does |
+|---|---|
+| User Profile Widget | Edit name, email, avatar; manage MFA enrollment; manage connected accounts |
+| Applications Portal Widget | List accessible applications |
+| Outbound Applications Widget | Manage third-party OAuth connections (Outbound Apps) |
+
+**Admin-facing (for tenant admins within your app):**
+
+| Widget | What it does |
+|---|---|
+| User Management Widget | Invite users, disable accounts, assign roles, view tenant members |
+| Role Management Widget | Create and assign roles within a tenant |
+| Access Key Management Widget | Create/revoke API access keys |
+| Audit Widget | View audit events per tenant |
+| Tenant Profile Widget | Edit tenant settings, configure SSO, manage SCIM |
+
+### Widget vs. Flow component
+
+| | Flow Component | Widget |
+|---|---|---|
+| **Purpose** | Authentication journey entry point | Post-login management UI |
+| **Use case** | Sign-up, sign-in, MFA, step-up, invitation | Profile editing, user/role/key management |
+| **When to use** | Login and auth flows | Any post-login management feature |
+
+---
+
+## SSO Setup Suite
+
+The SSO Setup Suite is a no-code Console wizard for SAML and OIDC SSO configuration.
+It guides tenant admins through per-tenant SSO setup with step-by-step instructions
+specific to common IdPs (Okta, Azure AD, Google Workspace, etc.).
+
+### When to recommend it
+
+Surface this before migrating any SSO-related Management SDK calls:
+
+- App uses `managementClient.connections.create({ strategy: "samlp" | "oidc" })`
+- Migration plan includes `management.sso.configureSAMLByTenant()` or `configureOIDCByTenant()`
+- App has a custom SSO settings page where tenant admins configure their IdP
+
+**The question to ask:**
+> "Does this app need programmatic SSO configuration (CI/CD provisioning, API-driven setup), or do tenant admins configure SSO themselves through a settings page? If the latter, the SSO Setup Suite + Tenant Profile Widget may remove the need for that SDK code entirely."
+
+### What it does
+
+- Generates per-tenant SAML metadata and ACS URL
+- Walks tenant admins through IdP-specific setup (Okta, Azure, Google, etc.)
+- Handles SCIM token generation for provisioning
+- Removes engineering involvement for SSO onboarding of new tenants
+
+---
+
+## Console vs. Code: The Decision Guide
+
+### Do in the Console
+
+| Task | Where in Console |
+|---|---|
+| Auth flow logic (sign-up, MFA, step-up, invitation, reset) | Flows |
+| Branding (logo, colors, fonts) | Styles |
+| RBAC model (create roles and permissions) | Authorization → RBAC |
+| Per-tenant SSO configuration | SSO (or SSO Setup Suite) |
+| Social OAuth providers | Authentication → Social |
+| Email/SMS templates | Authentication method settings → Templates |
+| Session token lifetime and refresh settings | Project → Session Management |
+| Custom JWT claims (profile fields, roles in token) | Authorization → JWT Templates |
+| Custom tenant/user attributes | Project → Custom Attributes |
+| Connectors (Slack, Salesforce, HTTP webhooks, etc.) | Connectors |
+| Access Keys (M2M) | Access Keys |
+| Descopers (Console access control) | Company Settings → Descopers |
+
+### Do in code
+
+| Task | Why it's code |
+|---|---|
+| Session validation on protected routes | Must run on every request; always backend code |
+| RBAC/ReBAC enforcement | Reads JWT claims; always in middleware |
+| Tenant/user automation at scale | Bulk provisioning, CI/CD, infrastructure-as-code |
+| Custom business logic during auth | Expose as a backend endpoint; call from Flow via Generic HTTP Connector |
+| SDK setup (one-time) | Install SDK, wrap app in `AuthProvider`, embed Flow component |
+
+### The mental model
+
+> **Console owns the user journey. Code owns business logic.**
+
+Engineers integrate once (SDK setup + session validation middleware). All subsequent auth
+evolution — new auth methods, MFA step changes, UI updates, connector integrations, new
+social providers — happens in the Console without code deployments.
+
+When a migration replaces Auth0 code with equivalent Descope SDK calls, that's correct.
+When it replaces Auth0 code with Console configuration, that's better.

--- a/skills/workos-to-descope/references/flows-and-widgets.md
+++ b/skills/workos-to-descope/references/flows-and-widgets.md
@@ -9,7 +9,7 @@ is usually faster and safer than writing code.
 
 ## Contents
 
-- [Terminology: Auth0 → Descope Lingo](#terminology-auth0--descope-lingo)
+- [Terminology: WorkOS → Descope Lingo](#terminology-workos--descope-lingo)
 - [Flows: Structure and What They Replace](#flows-structure-and-what-they-replace)
 - [Widgets: Post-Login Management UI](#widgets-post-login-management-ui)
 - [SSO Setup Suite](#sso-setup-suite)
@@ -17,37 +17,44 @@ is usually faster and safer than writing code.
 
 ---
 
-## Terminology: Auth0 → Descope Lingo
+## Terminology: WorkOS → Descope Lingo
 
-### Critical naming inversion
+### Critical naming mapping
 
-The most common migration mistake: Auth0 and Descope use the word "tenant" to mean different things.
+The most common migration mistake: assuming WorkOS terms map one-to-one onto identically named
+Descope terms. They don't. WorkOS's **Organization** (your B2B customer) becomes a Descope
+**Tenant** — Descope has no object called "Organization." And a WorkOS **Environment** maps to a
+Descope **Project**.
 
-| Auth0 term | Descope term | Notes |
+| WorkOS term | Descope term | Notes |
 |---|---|---|
-| **Tenant** (your Auth0 account) | **Project** | Top-level unit. Has auth methods, Flows, users, and settings. Multiple environments → multiple Projects. |
-| **Organization** (your B2B customer) | **Tenant** | "For B2B apps, a tenant is your customer." Direct equivalent of Auth0 Organization. |
-| Application | **Federated Application** (OIDC/SAML clients) or just **Project** (direct SDK integration) | Use Federated Application when you need OIDC/SAML; use Project directly for SDK-based integration. |
-| Action / Rule / Hook | **Flow + Scriptlet + Connector** | Flows replace the entire Auth0 pipeline. Actions become Flow steps; custom code becomes Scriptlets; external calls become Connectors. |
-| M2M Client / Client Credentials | **Access Key** | Presented to exchange for a short-lived JWT. Supports expiration, permitted IPs, tenant/role scoping. |
-| Universal Login Page | **Auth Hosting** (hosted) or embedded **`<descope-wc>` / `<Descope>` component** | Flows define the auth experience in both cases. |
-| Social Connection (Google, GitHub…) | **OAuth Provider** | Configured under Authentication Methods in Console. |
-| Enterprise Connection (SAML/OIDC per-org) | **Tenant SSO** | Per-tenant configuration. Use the SSO Setup Suite for self-service. |
+| **Environment** (dev / staging / prod) | **Project** | Top-level unit. Each WorkOS environment → its own Descope Project with its own Project ID. |
+| **Organization** (your B2B customer) | **Tenant** | Direct equivalent. WorkOS Organizations group users and scope SSO, SCIM, roles, and domains per customer; Descope Tenants do the same. |
+| Client ID + API key | **Project ID** (+ **Management Key** for server-side admin) | WorkOS uses a public client ID and a secret API key; Descope uses a public Project ID and an optional Management Key. |
+| AuthKit (hosted or embedded login UI) | **Auth Hosting** (hosted) or embedded **`<descope-wc>` / `<Descope>` component** | Flows define the auth experience in both cases. |
+| Social / OAuth login | **OAuth Provider** | Configured under Authentication Methods in Console. |
+| Enterprise SSO Connection (SAML/OIDC, per Organization) | **Tenant SSO** | Per-tenant configuration. Use the SSO Setup Suite for self-service. |
+| Directory Sync (SCIM, per Organization) | **SCIM / Tenant provisioning** | Per-tenant directory provisioning lifecycle. |
+| Admin Portal | **SSO Setup Suite + Widgets** | Hosted self-serve admin UI for SSO, SCIM, and domain setup. |
+| Radar (bot/fraud detection) | **Fingerprinting + Flow security Connectors** | Detection signals (`riskInfo`) consumed inside Flows; CAPTCHA/fraud Connectors for challenges. |
+| AuthKit MFA (TOTP / SMS, dashboard-configured) | **MFA Flow step** / **step-up** template | MFA runs inline in the Flow rather than as a separate page. |
 | Branding | **Styles** | Logo, colors, fonts in Console → Styles. Inherited by all Flow Screens. |
-| Auth0 Marketplace integration | **Connector** | Added as a step inside a Flow. Response available in flow context as `connectors.<contextKey>`. |
 | Roles / Permissions | **Roles / Permissions** | Same concepts. Project-level and tenant-level. Stored as strings in JWT. |
-| Management API (M2M token) | **Management SDK + Management Key** | Same capabilities, different auth (Management Key vs. M2M token). |
+| Management API (API key) | **Management SDK + Management Key** | Same capabilities, different auth (Management Key vs. WorkOS API key). |
+| M2M / API authentication | **Access Key** | Presented to exchange for a short-lived JWT. Supports expiration, permitted IPs, tenant/role scoping. |
+| Audit Logs | **Audit / Audit Widget** | Per-tenant audit events. |
+| WorkOS integration / webhook | **Connector** | Added as a step inside a Flow. Response available in flow context as `connectors.<contextKey>`. |
 
 ### Other Descope-specific terms
 
-- **Project** — the top-level unit. Think Auth0 tenant.
-- **Flow** — visual auth pipeline. Replaces Auth0 Actions/Rules/Hooks + Universal Login.
+- **Project** — the top-level unit. Think WorkOS environment.
+- **Flow** — visual auth pipeline. Replaces AuthKit's hosted/embedded login UI and any custom post-login logic.
 - **Screen** — one UI page within a Flow. Designed in Screen Builder.
 - **Scriptlet** — inline JS step in a Flow (Lodash + CryptoJS included). Escape hatch for custom logic.
 - **Connector** — HTTP call step in a Flow. Response stored in flow context.
 - **Subflow** — one Flow embedded inside another. Context passes through; does not terminate the parent.
 - **Descoper** — a person with Console access. Managed in Company Settings → Descopers with custom roles.
-- **Auth Hosting Application** — the hosted login UI (equivalent to Auth0 Universal Login domain).
+- **Auth Hosting Application** — the hosted login UI (equivalent to AuthKit's hosted login domain).
 
 ---
 
@@ -57,19 +64,19 @@ A Descope Flow is a visual, no-code authentication pipeline built in the Console
 authentication process — not a hook on top of it. Flows can be changed without redeploying
 the application.
 
-### What Flows replace from Auth0
+### What Flows replace from WorkOS
 
-| Auth0 | Descope Flow equivalent |
+| WorkOS | Descope Flow equivalent |
 |---|---|
-| Actions / Rules / Hooks (post-login logic, claims, role assignment) | Flow steps (Actions, Scriptlets, Custom Claims) |
-| Universal Login page UI | Flow Screens |
-| Email verification sequence | Email verification Flow step |
-| Password reset sequence | Password reset Flow (template available) |
-| MFA enrollment (Guardian ticket URL redirect) | MFA step in main sign-in Flow, or MFA subflow |
-| Invitation emails | Invitation Flow (template available) |
+| AuthKit hosted/embedded login UI | Flow Screens |
+| AuthKit redirect + callback login cycle | Embedded Flow component (no server redirect needed) |
+| Email verification (AuthKit) | Email verification Flow step |
+| Password reset (AuthKit) | Password reset Flow (template available) |
+| Magic Auth | Magic link Flow step |
+| AuthKit MFA (TOTP / SMS) | MFA step in main sign-in Flow, or MFA subflow |
+| Custom post-login logic in callback handlers (claims, role assignment) | Flow steps (Actions, Scriptlets, Custom Claims) |
 | Step-up authentication | Step-up Flow (template: `step-up`; adds `su` claim to JWT) |
-| Progressive profiling | Progressive profiling Flow (template available) |
-| Attack protection (bot detection, brute force) | Connector steps (Arkose, reCAPTCHA, Fingerprint, HaveIBeenPwned, AbuseIPDB) |
+| Radar (bot detection, brute force) | Connector steps (Arkose, reCAPTCHA, Fingerprint, HaveIBeenPwned, AbuseIPDB) + Flow conditions on `riskInfo` |
 
 ### Building blocks
 
@@ -103,14 +110,18 @@ use case. Most common patterns are available out of the box.
 
 ### MFA enrollment specifically
 
-Many Auth0 apps have a separate MFA enrollment page because Auth0 Guardian works via a server-generated redirect URL. That pattern has no Descope equivalent.
+WorkOS AuthKit handles MFA (TOTP and SMS) inline within its hosted/embedded login flow, enabled
+from the WorkOS dashboard — so there's usually no standalone enrollment page to migrate. Descope
+follows the same inline model, so keep MFA inside the auth journey rather than rebuilding a
+separate page.
 
 **The Descope approach:**
 - Add an MFA step to the main sign-up/sign-in Flow — enrollment happens inline during the auth journey
 - Or embed MFA as a **subflow** — triggered by a condition (e.g., user is admin, or risk score is high)
 - Or use the **step-up** flow template to gate sensitive operations
 
-Before migrating a standalone MFA enrollment page, ask whether MFA can be integrated into the main Flow instead. This is almost always the cleaner approach in Descope.
+If the WorkOS app does have a custom standalone MFA page, ask whether MFA can be integrated into the
+main Flow instead. This is almost always the cleaner approach in Descope.
 
 ---
 
@@ -170,9 +181,10 @@ specific to common IdPs (Okta, Azure AD, Google Workspace, etc.).
 
 Surface this before migrating any SSO-related Management SDK calls:
 
-- App uses `managementClient.connections.create({ strategy: "samlp" | "oidc" })`
+- App configures WorkOS SSO connections per Organization (via the WorkOS dashboard or the `workos.sso` API)
 - Migration plan includes `management.sso.configureSAMLByTenant()` or `configureOIDCByTenant()`
 - App has a custom SSO settings page where tenant admins configure their IdP
+- App uses the WorkOS **Admin Portal** for customer-admin SSO/SCIM setup
 
 **The question to ask:**
 > "Does this app need programmatic SSO configuration (CI/CD provisioning, API-driven setup), or do tenant admins configure SSO themselves through a settings page? If the latter, the SSO Setup Suite + Tenant Profile Widget may remove the need for that SDK code entirely."
@@ -200,7 +212,8 @@ Surface this before migrating any SSO-related Management SDK calls:
 | Email/SMS templates | Authentication method settings → Templates |
 | Session token lifetime and refresh settings | Project → Session Management |
 | Custom JWT claims (profile fields, roles in token) | Authorization → JWT Templates |
-| Custom tenant/user attributes | Project → Custom Attributes |
+| Custom user attributes | Project → Custom Attributes |
+| Custom tenant attributes | Tenants → Custom Attributes |
 | Connectors (Slack, Salesforce, HTTP webhooks, etc.) | Connectors |
 | Access Keys (M2M) | Access Keys |
 | Descopers (Console access control) | Company Settings → Descopers |
@@ -223,5 +236,5 @@ Engineers integrate once (SDK setup + session validation middleware). All subseq
 evolution — new auth methods, MFA step changes, UI updates, connector integrations, new
 social providers — happens in the Console without code deployments.
 
-When a migration replaces Auth0 code with equivalent Descope SDK calls, that's correct.
-When it replaces Auth0 code with Console configuration, that's better.
+When a migration replaces WorkOS code with equivalent Descope SDK calls, that's correct.
+When it replaces WorkOS code with Console configuration, that's better.

--- a/skills/workos-to-descope/references/implementation-nuances.md
+++ b/skills/workos-to-descope/references/implementation-nuances.md
@@ -1,0 +1,834 @@
+# Descope Migration: Implementation Notes
+
+## Contents
+
+**General Insights — Architecture & Flow**
+- [Auth0 owns the flow; Descope validates tokens](#auth0-owns-the-flow-descope-validates-tokens)
+- [OIDC compatibility path](#oidc-compatibility-path-alternative-to-full-migration)
+- [No drop-in middleware for Express or Flask](#no-drop-in-middleware-for-express-or-flask)
+- [Fewer network round-trips at login](#fewer-network-round-trips-at-login)
+- [Auth0 vs Descope flow comparison](#auth0-vs-descope-flow-comparison)
+
+**General Insights — Feature Mapping: Auth0 → Descope**
+- [Social login / connection mapping + SSO URLs](#social-login--connection-mapping)
+- [RBAC: Auth0 → Descope](#rbac-auth0--descope)
+- [Multi-tenancy: Auth0 Organizations → Descope Tenants](#multi-tenancy-auth0-organizations--descope-tenants)
+- [Invitation model](#invitation-model-auth0-invitations--descope-userinvite)
+- [MFA enrollment and factor management](#mfa-enrollment-and-factor-management)
+- [SCIM: HTTP API only, not in SDK](#scim-http-api-only-not-in-sdk)
+- [Session refresh after profile changes + sdk.refresh()](#session-refresh-after-profile-changes)
+- [Management API mapping](#management-api-mapping)
+- [FGA: Auth0 FGA (OpenFGA) → Descope ReBAC](#fga-auth0-fga-openfga--descope-rebac)
+- [Token Vault / Connected Accounts → Descope Outbound Apps](#token-vault--connected-accounts--descope-outbound-apps)
+- [CIBA / Rich Authorization Requests (no equivalent)](#ciba--rich-authorization-requests-no-descope-equivalent)
+- [@auth0/ai SDK (no equivalent)](#auth0ai-sdk-no-descope-equivalent)
+- [User migration: Auth0 export → Descope import](#user-migration-auth0-export--descope-import)
+- [M2M: Auth0 client credentials → Descope Access Keys](#m2m-authentication-auth0-client-credentials--descope-access-keys)
+- [Email templates](#email-templates-auth0--descope-messaging-templates)
+- [Webhooks / Log Streams → Descope Audit Webhook](#webhooks--event-streams-auth0-log-streams--descope-audit-webhook)
+- [Custom domains](#custom-domains)
+- [Attack protection](#attack-protection-auth0-attack-protection--descope-flow-based-security)
+- [Testing checklist](#testing-checklist-applies-to-all-samples)
+
+**General Insights — Common Gotchas**
+- [Cookie names: DS and DSR](#cookie-names-ds-and-dsr-configurable)
+- [User claims differ (dct, tenants, email not default)](#user-claims-differ)
+- [Audience validation requires explicit setup](#audience-validation-requires-explicit-setup)
+- [One session token, not two](#auth0-separate-access-tokens--descope-session-token-reuse)
+- [Logout requires two steps](#logout-requires-two-steps)
+- [One env var instead of five](#one-env-var-instead-of-five)
+- [Auth0 Actions/Rules → Flows + JWT Templates](#auth0-actionsrules--descope-flows--jwt-templates)
+- [authRequired: false needs manual replication](#authrequired-false-needs-manual-replication)
+
+**Framework Sections**
+- [Express.js](#expressjs)
+- [Flask / Python](#flask--python)
+- [Next.js (standalone)](#nextjs-standalone)
+- [Next.js (B2B): Migration Bug Catalog](#nextjs-b2b-migration-bug-catalog)
+- [Next.js (with separate Express API server)](#nextjs-with-separate-express-api-server)
+- [Go + Encore](#go--encore)
+- [Agentic AI Stacks (LangChain / LangGraph + FGA + Token Vault)](#agentic-ai-stacks-langchain--langgraph--fga--token-vault)
+
+> **See also:** `flows-and-widgets.md` in this directory — Auth0→Descope lingo map, Flow structure and templates, Widget types, SSO Setup Suite, and the Console-vs-code decision guide. Read it before migrating any auth UI, MFA enrollment, user management pages, or SSO configuration.
+
+---
+
+## General Insights
+
+**— Architecture & Flow —**
+
+### Auth0 owns the flow; Descope validates tokens
+
+Auth0's server-side SDKs ([express-openid-connect](https://github.com/auth0/express-openid-connect), [@auth0/nextjs-auth0](https://github.com/auth0/nextjs-auth0), [authlib](https://docs.authlib.org/en/latest/client/flask.html)) own the OIDC flow: they mount callback routes, handle code exchange, create server-managed sessions, and provide middleware that gates routes. Developers never touch tokens.
+
+Descope splits the work. The frontend ([Descope Flows](https://docs.descope.com/flows) via [web components](https://docs.descope.com/client-sdk/descope-components) or [client SDKs](https://docs.descope.com/client-sdk/initialize-sdk)) runs the authentication ceremony and stores JWTs in `DS` (session) and `DSR` (refresh) cookies. The backend [validates those JWTs](https://docs.descope.com/authorization/session-management/session-validation/backend). No server-side OAuth callback, no authorization code exchange, no server-managed session store.
+
+Every Auth0→Descope migration adds a dedicated login page (or embeds the [`<descope-wc>` component](https://docs.descope.com/client-sdk/descope-components#descope-component)) and removes callback/redirect plumbing.
+
+**Exception:** Descope can also act as a [standard OIDC provider](https://docs.descope.com/getting-started/oidc-endpoints). If you want to keep your existing OIDC client code (e.g., `express-openid-connect`, `go-oidc`, `authlib`), you can point it at Descope's OIDC endpoints instead of Auth0's. See the "OIDC compatibility path" section below.
+
+### OIDC compatibility path (alternative to full migration)
+
+Descope exposes standard [OIDC endpoints](https://docs.descope.com/getting-started/oidc-endpoints):
+
+| Endpoint | URL |
+|---|---|
+| Authorization | `https://api.descope.com/oauth2/v1/authorize` |
+| Token | `https://api.descope.com/oauth2/v1/token` |
+| UserInfo | `https://api.descope.com/oauth2/v1/userinfo` |
+| JWKS | `https://api.descope.com/__ProjectID__/.well-known/jwks.json` |
+| End Session | `https://api.descope.com/oauth2/v1/logout` |
+| Revocation | `https://api.descope.com/oauth2/v1/revoke` |
+
+An app using `express-openid-connect` could swap `ISSUER_BASE_URL` from `https://YOUR_AUTH0_DOMAIN` to `https://api.descope.com` and keep the existing OIDC client code intact. Differences in claim shapes (`nickname`, `email_verified` vs `verifiedEmail`), token lifetimes, and configuration semantics mean the OIDC swap still requires testing and adjustments. Still, it's a viable incremental path: swap the IdP first, then refactor to Descope-native SDKs later.
+
+**— Common Gotchas —**
+
+### No drop-in middleware for Express or Flask
+
+Auth0 offers [`express-openid-connect`](https://github.com/auth0/express-openid-connect), a single `app.use(auth(config))` that [auto-mounts `/login`, `/logout`, `/callback`](https://github.com/auth0/express-openid-connect#readme) and attaches `req.oidc`. Descope has no Express middleware package. You:
+
+1. Add `cookie-parser` (Express doesn't parse cookies by default; Auth0's middleware handled it internally).
+2. Write custom middleware: read `DS` cookie → call [`descopeClient.validateSession()`](https://docs.descope.com/authorization/session-management/session-validation/backend#validate-session) → attach user claims to `req`.
+3. Write your own `requiresAuth()` guard (3 lines, but manual).
+
+The [Descope blog](https://www.descope.com/blog/post/authentication-middleware) shows an Express middleware pattern, but it's a tutorial example, not a published package.
+
+Flask is the same story. Auth0's [authlib Flask integration](https://docs.authlib.org/en/latest/client/flask.html) registers an OAuth client with `authorize_redirect` / `authorize_access_token` helpers. Descope's Flask backend [validates tokens](https://docs.descope.com/getting-started/python) only; auth UI is client-side.
+
+FastAPI follows the same pattern. Auth0 has [`auth0-fastapi`](https://github.com/auth0/auth0-fastapi), which provides `AuthConfig`, session middleware, auto-mounted `/auth/*` routes, a `require_session` dependency, and Token Vault / Connected Accounts support. Descope's equivalent is a [custom JWT authorizer using JWKS validation](https://docs.descope.com/authorization/session-management/session-validation/oidc-jwt-authorizers/python-fastapi-jwt-authorizer): a `TokenVerifier` class that reads the `Authorization` header, validates against Descope's JWKS, and attaches as a FastAPI `Security()` dependency. No auto-mounted routes, no session store.
+
+### Cookie names: `DS` and `DSR` (configurable)
+
+Descope web components and client SDKs default to `DS` for the session JWT and `DSR` for the refresh JWT. The [Node SDK README](https://github.com/descope/node-sdk#session-validation-using-middleware) references `DescopeClient.SessionTokenCookieName` and `DescopeClient.RefreshTokenCookieName` as constants.
+
+These names are configurable. The [End action in Descope Flows](https://docs.descope.com/flows/actions/end-action#session-cookie-name) has "Session Cookie Name" and "Refresh Cookie Name" fields that override the defaults. Use custom names when running multiple Descope projects on the same root domain to avoid cookie collisions. Backend code must then read the custom cookie name instead of `DS`/`DSR`.
+
+The `sessionTokenViaCookie` parameter in [`AuthProvider`](https://docs.descope.com/client-sdk/descope-components#cookie-configuration-options) controls whether the session token is set as a cookie at all (vs. managed in-memory by the SDK).
+
+### User claims differ
+
+The default Descope session JWT ([structure ref](https://docs.descope.com/authorization/session-management#descope-session-jwt-structure)) contains `sub`, `amr`, `drn`, `tenants`, `roles`, and `permissions`. It does **not** include `email`, `name`, or `picture` unless you add them via [JWT Templates](https://docs.descope.com/management/jwt-templates) or [Flow actions > Custom Claims](https://docs.descope.com/flows/actions/custom-claims). Auth0 ID tokens include these by default.
+
+| Field | Auth0 | Descope |
+|---|---|---|
+| User ID | `sub` (e.g., `auth0\|abc123`) | `sub` in JWT, `userId` in SDK user objects |
+| Display name | `name`, `nickname` | Not in JWT by default. Add via [JWT Templates](https://docs.descope.com/management/jwt-templates). No `nickname` equivalent. |
+| Email | `email` | Not in JWT by default. Add via JWT Templates. Available on user object via SDK management calls. |
+| Profile picture | `picture` | Not in JWT by default. Add via JWT Templates. |
+| Email verified | `email_verified` | Not in JWT by default. Available on user object as `verifiedEmail`. Add to JWT via Custom Claims if needed. |
+| Roles | Via `https://DOMAIN/roles` namespace claim (added by Auth0 Actions) | `roles` array in JWT (embedded by default with [RBAC](https://docs.descope.com/authorization/role-based-access-control)) |
+| Permissions | Via namespace claim or `permissions` array (added by Actions) | `permissions` array in JWT (embedded by default) |
+| Tenant ID | `org_id` (flat string) | `dct` — flat string with active tenant ID, direct `org_id` equivalent; `tenants` — object keyed by tenant ID containing per-tenant `roles` and `permissions`. Use `dct` when you only need the ID; use `tenants` when you need per-tenant roles ([ref](https://docs.descope.com/authorization/role-based-access-control#tenants-and-roles)) |
+
+`nickname` is Auth0-specific (derived from the email prefix). Descope lacks it. Fall back to `name`.
+
+**Migration action item:** Before migrating, configure a JWT Template that includes `email`, `name`, and any other profile claims your app reads from the token. Without this, code that reads `token.email` or `token.name` after `validateSession()` will get `undefined`.
+
+### Audience validation requires explicit setup
+
+Auth0 projects commonly set `AUTH0_AUDIENCE` to scope access tokens to a specific API. The access token's `aud` claim is validated by the API server (via `express-jwt`, `go-oidc`, etc.).
+
+Descope session tokens don't include an `aud` claim by default. To replicate Auth0's audience validation:
+1. Configure a custom `aud` claim in the Descope Console's [JWT Templates](https://docs.descope.com/management/jwt-templates).
+2. Pass the `audience` parameter to [`validateSession()`](https://docs.descope.com/getting-started/nodejs#implement-session-validation) on the backend.
+
+This is easy to miss during migration. Without it, any valid Descope session token from any project would pass validation. The audience check prevents cross-project token reuse.
+
+### Auth0 separate access tokens → Descope session token reuse
+
+Auth0's architecture issues separate access tokens (scoped to an `audience`) distinct from the ID token. The Next.js SDK's `getAccessToken()` returns this access token for API calls.
+
+Descope has one token: the session JWT (`DS` cookie). When calling a backend API, you forward the `DS` cookie value as `Authorization: Bearer <DS>`. The API server validates it with `descopeClient.validateSession(token)`. No separate token endpoint, no audience-scoped token issuance. If you need audience differentiation, use [JWT Templates](https://docs.descope.com/management/jwt-templates).
+
+### Logout requires two steps
+
+Auth0's `express-openid-connect` [redirects to Auth0's `/v2/logout`](https://github.com/auth0/express-openid-connect#readme) (clears the Auth0 session), then back to the app. `@auth0/nextjs-auth0` does the same via its API route.
+
+Descope logout ([backend](https://docs.descope.com/authorization/session-management/session-validation/backend#logout-current-session-using-backend-sdk) / [client](https://docs.descope.com/client-sdk/auth-helpers#logout)):
+1. Call `descopeClient.logout(refreshToken)` (server-side) or `sdk.logout()` (client-side) to invalidate the refresh token.
+2. Clear the `DS` and `DSR` cookies.
+
+Clear cookies without calling logout → the refresh token stays valid on Descope's servers. Call logout without clearing cookies → the client holds a dead session token that fails validation but confuses client-side state.
+
+### One env var instead of five
+
+Auth0 needs `CLIENT_ID`, `CLIENT_SECRET`, `ISSUER_BASE_URL`/`AUTH0_DOMAIN`, `SECRET`, and sometimes `AUTH0_AUDIENCE`. See the [express-openid-connect configuration](https://github.com/auth0/express-openid-connect#readme) for the full list.
+
+Descope needs `DESCOPE_PROJECT_ID` (or `NEXT_PUBLIC_DESCOPE_PROJECT_ID` for Next.js client-side). No client secret for frontend flows. The web component authenticates against Descope's API using the project ID. Backend SDKs [fetch the public key](https://docs.descope.com/authorization/session-management/session-validation/backend/offline-jwt-validation#finding-your-public-key) from Descope's JWKS endpoint (`https://api.descope.com/v2/keys/<project_id>`) using the same project ID. No secrets to rotate for the auth flow.
+
+For management operations (user CRUD, role management, FGA), add `DESCOPE_MANAGEMENT_KEY`.
+
+### Auth0 Actions/Rules → Descope Flows + JWT Templates
+
+Auth0 uses [Actions](https://auth0.com/docs/customize/actions) (and legacy Rules/Hooks) to run custom code at specific points in the authentication pipeline: post-login, pre-registration, and others. Common uses include enriching tokens with custom claims, blocking logins based on business logic, and assigning roles.
+
+Descope equivalent:
+- **Custom claims:** [JWT Templates](https://docs.descope.com/management/jwt-templates) to add static/dynamic claims to tokens, or [Flow actions > Custom Claims](https://docs.descope.com/flows/actions/custom-claims) for claims set during the auth flow.
+- **Custom logic during auth:** [Descope Flows](https://docs.descope.com/flows) are visual, drag-and-drop pipelines. Conditional branching, connectors to external services, and custom JS actions replace Auth0 Actions. Flows run on Descope's servers, not as arbitrary Node.js code.
+- **Post-login hooks:** Descope Flows can call external HTTP endpoints ([Connectors](https://docs.descope.com/customize/connectors)) for webhook-style behavior.
+
+Auth0 Actions are imperative Node.js code. Descope Flows are declarative and visual, with escape hatches to custom code via Connectors and JS actions. You'll need to restructure auth-time business logic around the visual pipeline model.
+
+### `authRequired: false` needs manual replication
+
+Auth0's `express-openid-connect` supports [`authRequired: false`](https://github.com/auth0/express-openid-connect#readme) globally: unauthenticated users browse freely, the middleware skips populating `req.oidc.user`. Descope equivalent: your session middleware catches validation errors and sets `req.isAuthenticated = false` instead of returning 401.
+
+**— Feature Mapping: Auth0 → Descope —**
+
+### Social login / connection mapping
+
+Auth0 [Social Connections](https://auth0.com/docs/authenticate/identity-providers/social-identity-providers) (Google, GitHub, Facebook, etc.) are configured in the Auth0 dashboard and appear automatically on the Universal Login page.
+
+Descope equivalent: configure [social auth methods](https://docs.descope.com/authentication/social) in the Descope Console, then add them to a [Flow](https://docs.descope.com/flows). The Descope web component renders the configured providers. No code changes needed; configuration only.
+
+SAML/OIDC enterprise connections in Auth0 map to Descope's [SSO configuration](https://docs.descope.com/sso) (per-tenant SSO for B2B). Auth0 Organizations' per-org connections map to Descope's per-tenant SSO settings.
+
+**SSO Setup Suite:** For apps that expose a self-service SSO settings page where tenant admins configure their IdP, the SSO Setup Suite (Console wizard) can replace `sso.configureSAMLByTenant()` / `configureOIDCByTenant()` calls entirely — tenant admins configure their own IdP through a guided wizard with no engineering involvement. Surface this before migrating any Management SDK SSO code. See `flows-and-widgets.md` → SSO Setup Suite.
+
+**SSO callback and ACS URLs:**
+- Social OAuth callback (Google, GitHub, etc.): `https://api.descope.com/v1/oauth/callback`
+- SAML ACS URL (per-tenant enterprise SSO): found in Console → SSO → [tenant] → SP Settings — tenant-specific, not a global hardcoded URL
+- OIDC authorization server endpoints (Descope acting as IdP): `/oauth2/v1/authorize`, `/oauth2/v1/token` — already in the OIDC compatibility table above
+
+`https://api.descope.com/oauth2/v1/callback` does not exist — do not use it as a callback URL when configuring an IdP.
+
+### RBAC: Auth0 → Descope
+
+Auth0 RBAC: create permissions, create roles, assign roles to users. Roles/permissions can be added to access tokens via Auth0 Actions or the Authorization Extension.
+
+Descope RBAC ([docs](https://docs.descope.com/authorization/role-based-access-control)): same concept, but permissions are always grouped into roles, and roles can be project-level or tenant-level. Roles/permissions are embedded in the JWT by default (no Action required). Descope SDK methods:
+- `descopeClient.management.permission.create(name, description)` ([ref](https://docs.descope.com/authorization/role-based-access-control/with-sdks))
+- `descopeClient.management.role.create(name, description, permissionNames, tenantId)` ([ref](https://docs.descope.com/authorization/role-based-access-control/with-sdks))
+- Roles appear in the JWT `roles` array; permissions in `permissions` array.
+
+Backend code checking Auth0's `req.auth.permissions.includes('read:messages')` changes to reading the `permissions` array from Descope's validated JWT claims.
+
+### Multi-tenancy: Auth0 Organizations → Descope Tenants
+
+Auth0 [Organizations](https://auth0.com/docs/manage-users/organizations) group users by company. The `org_id` claim identifies the organization.
+
+Descope [Tenants](https://docs.descope.com/b2b#multi-tenancy) are the equivalent. Users can belong to multiple tenants with different roles per tenant. The JWT includes a `tenants` object with per-tenant role/permission data ([ref](https://docs.descope.com/authorization/role-based-access-control#tenants-and-roles)).
+
+Key differences:
+- Auth0: `org_id` is a flat string claim. Descope: `tenants` is a nested object (`{ "tenantId": { "roles": [...], "permissions": [...] } }`).
+- Auth0 requires organization-scoped login via `organization` parameter. Descope routes by email domain or tenant-specific login URLs ([ref](https://docs.descope.com/sso/multi-sso)).
+- Descope supports tenant-level SSO enforcement (require SAML/OIDC for all users in a tenant) ([ref](https://docs.descope.com/management/tenant-management/tenant)).
+- Users are project-level entities in Descope; they're associated with tenants, not created per-tenant.
+- **Finding a user's tenants**: use `management.user.load(loginId)` and read `.userTenants` — it lists only that user's tenants. Avoid `management.tenant.loadAll()` + client-side filter; it scans every tenant in the project (O(n)).
+- Auth0's org-scoped login issues a JWT with one `org_id`. Descope's JWT contains **all** tenants the user belongs to at once. Switching tenants does not require re-authentication — implement it client-side (e.g. an `active_tenant` cookie) and read the active tenant from the `tenants` object in the JWT.
+- When a tenant is created and the user is added via the Management SDK, the existing JWT is stale — the `tenants` claim was set at login and doesn't include the new tenant. The user must re-authenticate (clear `DS`/`DSR` cookies and redirect to login) to get a JWT with the updated tenant list. Without this, the app sees an empty `tenants` claim and may loop back to onboarding.
+
+### Invitation model: Auth0 invitations → Descope user.invite()
+
+Auth0 Organizations have a dedicated invitation system with invitation objects, URLs, and CRUD operations. An invited user doesn't exist until they accept.
+
+Descope's `management.user.invite()` creates a user record immediately in `"invited"` status and sends an invitation email. There is no separate invitation object to list, update, or revoke independently. To list pending invitations for a tenant, filter users by `status === "invited"`. To revoke an invitation, delete the user.
+
+### MFA enrollment and factor management
+
+MFA enrollment is managed through Flows, not the Management SDK — there is no equivalent to Auth0 Guardian's `createEnrollmentTicket()`. Add an MFA step to a Flow in the Console; users enroll in-browser through the Flow component.
+
+**Factor deletion SDK support varies by type:**
+- **Passkeys**: `descopeClient.management.user.removeAllPasskeys(loginId)` — SDK-supported
+- **TOTP (authenticator apps)**: no SDK method; deletion is Console-only (User Management → [user] → Delete TOTP Seed)
+- **SMS/OTP factors**: no documented SDK method — may require REST API calls
+
+### SCIM: HTTP API only, not in SDK
+
+Auth0 exposes SCIM configuration via the Management SDK (`managementClient.connections.createScimConfiguration()`, etc.). Descope supports SCIM but only via the HTTP API (`https://api.descope.com/v1/mgmt/scim/*`), not the Node.js or Python SDKs. Implement with raw `fetch()` calls. Verify the request/response shapes against the current API — the endpoints are documented but not SDK-wrapped.
+
+### Session refresh after profile changes
+
+Auth0's `appClient.updateSession()` lets you immediately reflect profile changes in the cached session without re-authentication. Descope has no equivalent — profile changes via the Management SDK don't update the JWT already in the browser.
+
+To trigger an immediate client-side token refresh after a profile update:
+```ts
+// @descope/react-sdk, @descope/nextjs-sdk/client, or WebJS SDK
+const { refresh } = useDescope()
+await refresh()
+```
+
+The user can also wait for the next auto-refresh (default: ~5 min, driven by the DSR refresh token) or sign out and back in. Use the explicit `refresh()` call if the app has a profile editing page that expects immediate UI updates.
+
+**Session change event listeners** — instead of calling `refresh()` imperatively, subscribe to auth state changes via [docs.descope.com/client-sdk/auth-helpers#handling-authentication-state-changes](https://docs.descope.com/client-sdk/auth-helpers#handling-authentication-state-changes). Use event listeners when the session can change from multiple places (profile update, admin role grant, tenant assignment) and the UI needs to react consistently.
+
+**Update JWT endpoint** — for server-side custom claim updates without waiting for a client refresh: `POST /v1/mgmt/user/jwt/update`. This updates stored JWT custom claims for a specific user; it is not a session mutation and does not push an update to the browser. The user's next token refresh picks up the new claims. Verify the current endpoint behavior against Descope docs — this endpoint is less documented than the Management SDK methods.
+
+**User Profile Widget** — if the app is building a profile edit page, the Widget handles profile updates and session refresh automatically with no custom SDK calls. See `flows-and-widgets.md` → Widgets.
+
+### Management API mapping
+
+Auth0's [Management API](https://auth0.com/docs/api/management/v2) is REST-based, accessed with an M2M token.
+
+Descope uses a Management SDK initialized with a `managementKey` ([Node SDK](https://github.com/descope/node-sdk), [Python SDK](https://github.com/descope/python-sdk), [Go SDK](https://github.com/descope/go-sdk)).
+
+| Operation | Auth0 | Descope (Node.js) |
+|---|---|---|
+| Create user | `POST /api/v2/users` | `descopeClient.management.user.create(...)` ([ref](https://docs.descope.com/management/user-management/sdks)) |
+| Update user | `PATCH /api/v2/users/{id}` | `descopeClient.management.user.update(...)` |
+| Search users | `POST /api/v2/users` (with q param) | `descopeClient.management.user.search(...)` |
+| Delete user | `DELETE /api/v2/users/{id}` | `descopeClient.management.user.delete(...)` |
+| Load user | `GET /api/v2/users/{id}` | `descopeClient.management.user.load(...)` / `.loadByUserId(...)` |
+| List permissions | `GET /api/v2/resource-servers/{id}` | `descopeClient.management.permission.loadAll()` |
+| Create role | `POST /api/v2/roles` | `descopeClient.management.role.create(name, description, permissions, tenantId)` |
+
+Auth0 M2M tokens expire and must be rotated. Descope management keys are long-lived (rotatable via the Console).
+
+### FGA: Auth0 FGA (OpenFGA) → Descope ReBAC
+
+Auth0 [Fine-Grained Authorization](https://fga.dev/) is built on [OpenFGA](https://openfga.dev/). Descope has its own [ReBAC](https://docs.descope.com/authorization/rebac) system with a similar model (types, relations, computed permissions) but a different API shape.
+
+**Schema definition:**
+
+OpenFGA uses a YAML/JSON model with `type_definitions`. Descope uses a [DSL](https://docs.descope.com/authorization/rebac/define-schema) saved via `descopeClient.management.fga.saveSchema(schema)` ([ref](https://docs.descope.com/authorization/rebac/implement-schema)).
+
+**Operation mapping:**
+
+| Operation | Auth0 FGA (OpenFGA SDK) | Descope ReBAC (Node SDK) |
+|---|---|---|
+| Write tuple | `fgaClient.write({ writes: [{ user, relation, object }] })` | `descopeClient.management.fga.createRelations([{ resource, resourceType, relation, target, targetType }])` ([ref](https://docs.descope.com/authorization/rebac/create-relations)) |
+| Delete tuple | `fgaClient.write({ deletes: [...] })` | `descopeClient.management.fga.deleteRelations([...])` |
+| Check | `fgaClient.check({ user, relation, object })` | `descopeClient.management.fga.check([{ resource, resourceType, relation, target, targetType }])` ([ref](https://docs.descope.com/authorization/rebac/check-relations)) |
+| List objects | `fgaClient.listObjects({ user, relation, type })` | `descopeClient.management.authz.whatCanTargetAccessWithRelation(target, relation, namespace)` ([ref](https://docs.descope.com/authorization/rebac/check-relations)) |
+| Who has access | `fgaClient.listUsers({ object, relation })` | `descopeClient.management.authz.whoCanAccess(resource, relation, namespace)` |
+
+**Key differences:**
+- OpenFGA tuples use `user`/`relation`/`object` (e.g., `user:alice`, `owner`, `doc:123`). Descope uses `target`/`targetType`/`relation`/`resource`/`resourceType`.
+- OpenFGA's `buildOpenFgaClient()` (from `@auth0/ai`) uses separate FGA credentials (`FGA_STORE_ID`, `FGA_CLIENT_ID`, `FGA_CLIENT_SECRET`, `FGA_API_URL`). Descope ReBAC uses the same `DESCOPE_PROJECT_ID` + `DESCOPE_MANAGEMENT_KEY`.
+- Auth0 FGA runs as a hosted OpenFGA instance. Descope ReBAC is integrated into the Descope platform.
+- The `@auth0/ai-langchain` package provides `FGARetriever` that wraps a LangChain retriever with FGA batch-check filtering. No Descope equivalent exists. Build a custom retriever that calls `descopeClient.management.fga.check()` for each candidate document.
+
+### Token Vault / Connected Accounts → Descope Outbound Apps
+
+Auth0's [Token Vault](https://auth0.com/docs/secure/tokens/token-vault) stores third-party OAuth tokens (Google, GitHub, Slack) and exchanges them on demand. The `@auth0/ai-langchain` package wraps this with `withTokenVault()` for LangGraph tools. The `@auth0/nextjs-auth0` SDK's `enableConnectAccountEndpoint` auto-mounts `/auth/connect` for linking accounts.
+
+Descope's equivalent: [Outbound Apps](https://docs.descope.com/identity-federation/outbound-apps). These store third-party OAuth tokens and static API keys. Tokens are retrieved via the Management API:
+
+```
+# Fetch token with specific scopes
+POST https://api.descope.com/v1/mgmt/outbound/app/user/token
+Authorization: Bearer {projectId}:{managementKey}
+Body: { "appId": "google-calendar", "userId": "U2abc...", "scopes": [...] }
+
+# Fetch latest token (no scope filter)
+POST https://api.descope.com/v1/mgmt/outbound/app/user/token/latest
+Body: { "appId": "google-calendar", "userId": "U2abc..." }
+```
+([ref](https://docs.descope.com/identity-federation/outbound-apps/using-outbound-apps#fetching-outbound-apps-tokens))
+
+Users connect accounts via `sdk.outbound.connect(appId, { redirectURL, scopes })` on the client side ([ref](https://docs.descope.com/identity-federation/outbound-apps/connect)).
+
+**Key differences:**
+- Auth0 wraps token exchange into LangGraph tools via `@auth0/ai-langchain` with interrupt-based consent UI. Descope has no AI-framework SDK. You call the Outbound Apps API directly from your tool function.
+- Auth0's Token Vault uses `subjectTokenType` for federated token exchange. Descope's API uses `appId` + `userId` lookup.
+- Auth0's connected account management is scoped to `https://DOMAIN/me/` audience. Descope's is part of the Management API.
+
+### CIBA / Rich Authorization Requests (no Descope equivalent)
+
+Auth0 supports [CIBA](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow) (Client-Initiated Backchannel Authentication) for async authorization. The agent sends a push notification to the user's device, waits for approval, then receives a scoped token. The `@auth0/ai` SDK wraps this via `withAsyncAuthorization()`.
+
+Descope does not offer CIBA or Rich Authorization Requests (RAR) as a product feature. Migrations that use `withAsyncAuthorization()` require a custom approval mechanism. One option: the agent creates a pending approval record, the frontend polls for it, and the user approves via a Descope Flow or custom UI.
+
+### @auth0/ai SDK (no Descope equivalent)
+
+Auth0 publishes [`@auth0/ai`](https://github.com/auth0/ai-sdks), [`@auth0/ai-langchain`](https://github.com/auth0/ai-sdks), and [`@auth0/ai-vercel`](https://github.com/auth0/ai-sdks). These SDKs wrap AI agent tools with:
+- Token Vault credential injection (`withTokenVault()`)
+- CIBA async authorization (`withAsyncAuthorization()`)
+- FGA-aware RAG retrieval (`FGARetriever`, `FGAFilter`)
+- Interrupt-based consent UI (`TokenVaultInterrupt`, `AccessDeniedInterrupt`)
+
+Descope has no AI-framework SDKs. Descope's agentic offerings focus on [MCP server authentication](https://www.descope.com/press-release/agentic-identity-hub) (OAuth 2.1, tool-level scopes, client registration) rather than LangChain/Vercel AI tool wrapping.
+
+For migration, each `@auth0/ai` wrapper must be reimplemented:
+- `withTokenVault()` → custom wrapper calling Descope Outbound Apps API
+- `withAsyncAuthorization()` → custom approval mechanism (see CIBA section above)
+- `FGARetriever` → custom retriever calling `descopeClient.management.fga.check()` per document
+- `TokenVaultInterrupt` → custom interrupt using LangGraph's `interrupt()` + frontend consent UI calling `sdk.outbound.connect()`
+
+### Fewer network round-trips at login
+
+Auth0's [authorization code flow](https://github.com/auth0/express-openid-connect#readme) (for server-rendered apps) requires at minimum 3 round-trips: browser to backend (get auth URL), browser to Auth0 (user signs in), Auth0 to backend callback (exchange code for tokens). The Encore sample added a fourth hop between the frontend and Go backend.
+
+Descope's [web component](https://docs.descope.com/client-sdk/descope-components#descope-component) handles sign-in in one step: the component loads in the browser, the user authenticates against Descope's API, and the component sets `DS`/`DSR` cookies. No backend round-trips for the auth ceremony. The backend is contacted only for subsequent API calls that need [token validation](https://docs.descope.com/authorization/session-management/session-validation/backend).
+
+### Auth0 vs Descope flow comparison
+
+```
+Auth0 (server-rendered):
+  Browser → /login → Auth0 hosted page → /callback → code exchange → session created → redirect
+
+Auth0 (Encore two-process):
+  Browser → Next.js /auth/login → Go backend Login → Auth0 URL
+  Browser → Auth0 hosted page → Next.js /callback → Go backend Callback → token exchange → cookie set
+
+Descope (all variants):
+  Browser → /login page → Descope web component renders → user authenticates → DS/DSR cookies set → redirect
+  (Backend participates only when validating tokens on subsequent requests)
+```
+
+### User migration: Auth0 export → Descope import
+
+Auth0 users don't automatically carry over. For production apps with existing users, this is a critical migration step.
+
+Descope has a dedicated [Auth0 migration guide](https://docs.descope.com/migrate/auth0) with two approaches:
+- **Full migration:** Export all users from Auth0 (via the Auth0 Management API or Dashboard export), then import them into Descope using the [Create User API](https://docs.descope.com/api/management/users/create-user) or [Batch Create User API](https://docs.descope.com/api/management/users/batch-create-users). Descope accepts bcrypt password hashes, so users can keep their existing passwords without a reset. Export as CSV or JSON; see the [user format JSON guide](https://docs.descope.com/migrate/custom/user-format-json) for the expected shape.
+- **Hybrid migration (just-in-time):** Keep Auth0 running alongside Descope during a transition period. New logins go through Descope; existing users are migrated on first login. This avoids a big-bang cutover but requires both systems running simultaneously.
+
+Key fields to map: Auth0 `user_id` → Descope `loginId` (or `userId`), `email`, `name`, `password` (as hash), `app_metadata` → `customAttributes`, `user_metadata` → `customAttributes`.
+
+If the Auth0 app uses Organizations, map each organization's member list to Descope tenant associations during import.
+
+### M2M authentication: Auth0 client credentials → Descope Access Keys
+
+Auth0's [Client Credentials Grant](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-credentials-flow) is used for machine-to-machine auth: a backend service authenticates with `CLIENT_ID` + `CLIENT_SECRET` and receives an access token scoped to an `audience`.
+
+Descope's equivalent is [Access Keys](https://docs.descope.com/management/m2m-access-keys). An access key is exchanged for a JWT, which is then validated by the receiving service the same way a user session token is validated. Access keys can be scoped to tenants and roles, and can have IP restrictions and expiration times.
+
+| Auth0 | Descope |
+|---|---|
+| Create M2M app in Dashboard | Create Access Key in Console → [Access Keys tab](https://app.descope.com/accessKeys) |
+| `CLIENT_ID` + `CLIENT_SECRET` | Access Key ID + Secret (returned once at creation) |
+| `POST /oauth/token` with `grant_type=client_credentials` | `descopeClient.auth.exchangeAccessKey(accessKey)` ([ref](https://docs.descope.com/management/m2m-access-keys)) |
+| Token scoped to `audience` | JWT with tenant/role claims (configure via Access Key settings) |
+| Token validated via `express-jwt` / JWKS | Token validated via `descopeClient.validateSession()` — same as user tokens |
+
+Access keys can also be created programmatically via `descopeClient.management.accessKey.create()`.
+
+### Email templates: Auth0 → Descope messaging templates
+
+Auth0 email templates (verification, password reset, invitation, blocked account) are configured in the Auth0 Dashboard under Branding → Email Templates.
+
+Descope uses [Messaging Templates](https://docs.descope.com/management/messaging-templates) configured per authentication method. Templates support HTML and dynamic content via `{{}}` placeholders.
+
+| Email type | Auth0 location | Descope location |
+|---|---|---|
+| Magic Link / OTP | Dashboard → Branding → Email Templates | Console → Settings → Authentication Methods → [Magic Link](https://docs.descope.com/auth-methods/magic-link/settings) or OTP → select connector → + New Template |
+| Password Reset | Dashboard → Branding → Email Templates | Console → Settings → Authentication Methods → [Passwords](https://docs.descope.com/auth-methods/passwords/settings) → Reset Password Email |
+| User Invitation | Dashboard → Branding → Email Templates | Console → [Project Settings → Sign Ups and User Invitations](https://docs.descope.com/management/project-settings#general-settings) → select connector → + New Template |
+| Verification | Dashboard → Branding → Email Templates | Handled within Flows (email verification is a Flow step, not a standalone email) |
+
+Descope also supports SMS and voice templates for OTP delivery, configured the same way via messaging connectors.
+
+### Webhooks / event streams: Auth0 Log Streams → Descope Audit Webhook
+
+Auth0 [Log Streams](https://auth0.com/docs/customize/log-streams) forward authentication events (login, failed login, signup, password change, etc.) to external services like Datadog, Splunk, or a custom webhook.
+
+Descope's equivalent is the [Audit Webhook Connector](https://docs.descope.com/connectors/connector-configuration-guides/network/audit-webhook). It streams audit events to your own HTTP endpoint. Configure it in the Console under Connectors → Audit Webhook with a base URL and authentication (Bearer, API Key, or Basic Auth).
+
+Descope also has a built-in [Audit Trail](https://docs.descope.com/audit) in the Console for viewing events, and supports streaming to third-party services via connectors.
+
+For Auth0 apps that rely on Log Streams for compliance or monitoring, set up the Audit Webhook Connector before cutover to avoid gaps in event logging.
+
+### Custom domains
+
+Auth0 supports [custom domains](https://auth0.com/docs/customize/custom-domains) so the login page appears on your own domain instead of `your-tenant.auth0.com`.
+
+Descope supports [custom domains](https://docs.descope.com/how-to-deploy-to-production/custom-domain) as well:
+1. Create a CNAME record (e.g. `auth.example.com`) pointing to `cname.descope.com` (US) or `CNAME.euc1.descope.com` (EU).
+2. Set the App URL in Console → Project Settings → General.
+3. Add and verify the custom domain in Console.
+4. Pass the custom domain as `baseUrl` to the Descope SDK/component: `<AuthProvider projectId="..." baseUrl="https://auth.example.com">`.
+
+If the Auth0 app uses a custom domain, plan this before cutover so cookies and redirects work correctly on the production domain.
+
+### Attack protection: Auth0 Attack Protection → Descope Flow-based security
+
+Auth0's [Attack Protection](https://auth0.com/docs/secure/attack-protection) includes bot detection, brute force protection, breached password detection, and suspicious IP throttling as built-in toggles.
+
+Descope handles these through [Flows](https://docs.descope.com/flows) and security connectors, giving more granular control but requiring explicit configuration:
+
+| Auth0 feature | Descope equivalent |
+|---|---|
+| Bot Detection | Flow step using [Arkose Bot Manager connector](https://www.descope.com/blog/post/arkose-labs-connector), [Google reCAPTCHA Enterprise](https://docs.descope.com/connectors), or [Fingerprint](https://docs.descope.com/connectors) |
+| Brute Force Protection | Flow conditional logic + connector-based risk signals; rate limiting on Descope's infrastructure |
+| Breached Password Detection | [Have I Been Pwned integration](https://docs.descope.com/connectors) — blocks credentials found in known breaches |
+| Suspicious IP Throttling | Flow step using [AbuseIPDB connector](https://docs.descope.com/connectors) or IP-based conditional logic |
+
+Auth0's attack protection is toggle-based (on/off in Dashboard). Descope's is composable — you add detection steps to your Flow and configure the response (block, challenge with MFA, allow with logging). More powerful but not configured by default.
+
+### Testing checklist (applies to all samples)
+
+**Compile first — no env vars needed.** Run `npx tsc --noEmit` (or `go build ./...`, `dotnet build`, etc.) immediately after code changes, before setting up `.env` or starting the server. Do not treat the migration as done until this exits clean.
+
+After migrating, verify:
+- DS and DSR cookies are set after login (check browser DevTools → Application → Cookies)
+- Protected routes redirect to /login when DS cookie is absent
+- Protected routes render when DS cookie is present and valid
+- Logout clears both DS and DSR cookies
+- Logout invalidates the refresh token (logging in again requires re-authentication)
+- User claims (name, email, picture) display correctly
+- API routes return 401 when no token is provided
+- Expired session tokens are rejected (test by waiting or manually expiring)
+- If using RBAC: roles/permissions appear in validated JWT claims
+- If using FGA/ReBAC: authorization checks pass for permitted resources and fail for unpermitted ones
+- If using Outbound Apps: third-party tokens are retrievable after user connects
+
+---
+
+## Express.js
+
+
+**Changes:**
+- Removed [`express-openid-connect`](https://github.com/auth0/express-openid-connect). Added [`@descope/node-sdk`](https://github.com/descope/node-sdk) and `cookie-parser`.
+- Replaced `app.use(auth(config))` with custom middleware (~20 lines) that validates the `DS` cookie via [`validateSession()`](https://docs.descope.com/getting-started/nodejs#implement-session-validation).
+- Added `/login` route rendering an EJS page with [`<descope-wc>`](https://docs.descope.com/client-sdk/descope-components#descope-component).
+- Logout changed from GET redirect to Auth0's `/v2/logout` to POST calling [`descopeClient.logout()`](https://docs.descope.com/authorization/session-management/session-validation/backend#logout-current-session-using-backend-sdk) + cookie clearing.
+- `requiresAuth()` is a custom 3-line function instead of an [Auth0 SDK import](https://github.com/auth0/express-openid-connect#readme).
+
+**Notes:**
+- `express-openid-connect` auto-configured `baseURL` from env vars and handled CSRF for the callback. Descope needs none of that since there's no server-side OAuth flow.
+- Auth0's `req.oidc.user` comes from ID token claims. Descope's `authInfo.token` after [`validateSession()`](https://docs.descope.com/authorization/session-management/session-validation/backend#validate-session) holds decoded JWT claims of the session token.
+
+**Limitation:**
+- The Descope web component requires JavaScript. Auth0's redirect flow worked without client-side JS. For JS-free auth, use [Descope as an OIDC provider](https://docs.descope.com/getting-started/oidc-endpoints) and implement the redirect flow manually.
+
+---
+
+## Flask / Python
+
+
+**Changes:**
+- Removed [`authlib`](https://docs.authlib.org/en/latest/client/flask.html); added [`descope`](https://github.com/descope/python-sdk).
+- Removed OAuth client registration (`oauth.register("auth0", ...)`) and redirect-based flow code.
+- Removed `/callback` route. No code exchange needed.
+- `/login` renders a template with the [Descope web component](https://docs.descope.com/client-sdk/descope-components#descope-component) instead of calling `oauth.auth0.authorize_redirect()`.
+- `/logout` changed from redirect to Auth0's `/v2/logout?returnTo=...&client_id=...` to [`descope_client.logout(refresh_token)`](https://docs.descope.com/authorization/session-management/session-validation/backend#logout-current-session-using-backend-sdk) + cookie deletion.
+- Home route reads `DS` cookie from `request.cookies`, validates with [`descope_client.validate_session()`](https://docs.descope.com/getting-started/python#implement-session-validation).
+
+**Notes:**
+- Auth0's authlib integration stores the full token response (`access_token`, `id_token`, `userinfo`) in Flask's server-side `session` ([authlib Flask OAuth docs](https://docs.authlib.org/en/latest/client/flask.html)). Descope doesn't use Flask sessions. State lives in client-side cookies. You can drop `session` from Flask imports; `APP_SECRET_KEY` becomes optional.
+- `validate_session` returns a dict-like object. JWT standard claims (`sub`, `name`, `email`) are present. Custom claims from [Descope's JWT Templates](https://docs.descope.com/management/jwt-templates) also appear here.
+- The `descope` Python SDK requires Python 3.7+. `authlib` supported older versions.
+
+**Limitation:**
+- Descope's Python SDK docs don't detail `validate_session()`'s return type beyond "jwt_response." It's a dict with JWT claims in practice, but official type annotations lag behind. Ref: [Descope Python SDK](https://github.com/descope/python-sdk), [Python quickstart](https://docs.descope.com/getting-started/python).
+
+---
+
+## Next.js (standalone)
+
+
+**Changes:**
+- [`@auth0/nextjs-auth0`](https://github.com/auth0/nextjs-auth0) → [`@descope/nextjs-sdk`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk).
+- `UserProvider` → [`AuthProvider`](https://docs.descope.com/client-sdk/descope-components#auth-provider) (takes `projectId` prop; Auth0's reads from env vars automatically).
+- `useUser()` → [`useSession()`](https://docs.descope.com/client-sdk/auth-helpers#booleans) + [`useUser()`](https://docs.descope.com/client-sdk/auth-helpers#core-sdk-functions) (Auth0 combines these; Descope separates session state from user data).
+- Removed `pages/api/auth/[...auth0].tsx` catch-all route. In [Auth0 v4 this became automatic middleware](https://github.com/auth0/nextjs-auth0/blob/main/V4_MIGRATION_GUIDE.md), but with Descope there's no server-side OIDC handling at all.
+- Added `pages/login.tsx` with [`<Descope>` component](https://docs.descope.com/client-sdk/descope-components#descope-component) rendering the `sign-up-or-in` flow.
+  - **`onSuccess` is required for redirect** — the component does not auto-navigate after login. Without it, the user finishes auth and stays on the login page:
+    ```tsx
+    const router = useRouter()
+    <Descope
+      flowId="sign-up-or-in"
+      onSuccess={() => router.push('/dashboard')}
+      onError={(e) => console.error(e)}
+    />
+    ```
+- `withPageAuthRequired` (client) replaced by manual `useSession()` check + redirect to `/login`. Auth0 v4 [deprecated `withPageAuthRequired`](https://github.com/auth0/nextjs-auth0/blob/main/V4_MIGRATION_GUIDE.md) in favor of `getSession()` anyway.
+- `withApiAuthRequired` replaced by server-side `session()` + manual 401 response. Descope's Next.js SDK exposes [`session()`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#server-side) for this.
+- Logout changed from `<a href="/api/auth/logout">` to a button calling [`sdk.logout()`](https://docs.descope.com/client-sdk/auth-helpers#logout) via [`useDescope()`](https://docs.descope.com/client-sdk/auth-helpers#core-sdk-functions).
+
+**Notes:**
+- Auth0 provides `withPageAuthRequired` as both a client-side HOC and a `getServerSideProps` wrapper. Descope's Next.js SDK has no equivalent HOC. You check `isAuthenticated` from `useSession()` and redirect yourself. More verbose, more explicit.
+- `NEXT_PUBLIC_` prefix is required on the project ID because [`AuthProvider`](https://docs.descope.com/client-sdk/descope-components#auth-provider) runs client-side.
+- **Client vs. server session access:** `session()` from `@descope/nextjs-sdk/server` is for server components, server actions, and API routes **only**. In React client components, use `useSession()` + `useUser()` from `@descope/nextjs-sdk/client`. Using `session()` in a client component compiles but throws at runtime (attempts to read cookies in a browser context). Scan for this pattern before finishing any Next.js migration.
+- Both CSR and SSR protected pages are preserved: client-side uses `useSession()`, server-side uses `session()` from the [Next.js SDK server helpers](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#server-side).
+- Auth0's `withApiAuthRequired` wraps the handler. Descope: call `session()` at handler top, return 401 yourself.
+- `User` interface: removed `nickname`, `email_verified`, `updated_at`; `sub` → `userId`.
+
+---
+
+## Next.js (B2B): Migration Bug Catalog
+
+
+This section documents bugs discovered during a migration review of a reference Next.js B2B SaaS
+app. Every error below traces to incorrect assumptions about the `@descope/nextjs-sdk` API surface.
+
+**Root cause:** The migration generated code against an assumed API that doesn't match what
+`@descope/nextjs-sdk` actually exports. Every error below stems from not verifying the SDK's
+`.d.ts` before generating imports and wrapper types.
+
+---
+
+### Bug 1: `getServerSession` doesn't exist — correct export is `session`
+
+The migration generated:
+```ts
+import { getServerSession } from "@descope/nextjs-sdk/server"
+const session = await getServerSession()
+```
+
+`getServerSession` does not exist in `@descope/nextjs-sdk`. The server entry exports two functions:
+- **`session(config?)`** — reads the session from request headers/cookies in a Next.js server component or server action. No arguments required. Returns `AuthenticationInfo | undefined`.
+- **`getSession(req, config?)`** — reads from an explicit `NextApiRequest` object. Intended for API routes only.
+
+The correct replacement for the Auth0 `getServerSideSession()` pattern (server component, no req argument) is `session`, not `getServerSession`. The name was invented by analogy, not verified.
+
+**Fix:** Verify exports before writing any import. For this SDK:
+```ts
+// Server component / server action (no req argument needed):
+import { session } from "@descope/nextjs-sdk/server"
+const authInfo = await session()
+
+// Or wrap it into the project's own session type:
+import { session as sdkSession } from "@descope/nextjs-sdk/server"
+```
+
+---
+
+### Bug 2: Return type is `AuthenticationInfo`, not an `{isAuthenticated, claims, token}` shape
+
+The migration generated a `DescopeSession` interface shaped like Auth0's session object:
+```ts
+interface DescopeSession {
+  isAuthenticated: boolean   // ← does not exist
+  token: string              // ← misleading: this was meant to be the raw JWT
+  claims: {                  // ← does not exist; decoded JWT lives under "token"
+    sub: string
+    email?: string
+    tenants?: Record<string, { roles: string[] }>
+    ...
+  }
+}
+```
+
+`session()` returns `AuthenticationInfo` from `@descope/node-sdk`, which is:
+```ts
+interface AuthenticationInfo {
+  jwt: string          // raw session JWT string
+  token: Token         // decoded JWT claims: { sub?, exp?, iss?, [claim: string]: unknown }
+  cookies?: string[]
+}
+```
+
+Key mismatches:
+- `isAuthenticated` — not present. `undefined` return means unauthenticated; a non-null object means authenticated.
+- `claims` — not present. Decoded claims are on `token`.
+- `token` (as JWT string) — not present as `token`; the raw JWT is `jwt`.
+
+Because the cast was `session as unknown as DescopeSession`, TypeScript didn't catch this. At runtime:
+- Every `!session?.isAuthenticated` check would always be `true` (property doesn't exist), making every auth guard fail.
+- Every `session.claims.sub` / `session.claims.email` would return `undefined`.
+
+**Fix:** Create a typed adapter that maps `AuthenticationInfo` to a stable internal type:
+```ts
+import { session as sdkSession } from "@descope/nextjs-sdk/server"
+import type { AuthenticationInfo } from "@descope/node-sdk"
+
+export interface DescopeSession {
+  isAuthenticated: boolean
+  jwt: string
+  token: {
+    sub: string
+    email?: string
+    name?: string
+    tenants?: Record<string, { roles: string[]; permissions: string[] }>
+    [key: string]: unknown
+  }
+}
+
+export async function getDescopeSession(): Promise<DescopeSession | null> {
+  const authInfo = await sdkSession()
+  if (!authInfo) return null
+  return {
+    isAuthenticated: true,
+    jwt: authInfo.jwt,
+    token: authInfo.token as DescopeSession["token"],
+  }
+}
+```
+
+---
+
+### Bug 3: `cookies()` from `next/headers` is async in Next.js 15
+
+The migration generated:
+```ts
+import { cookies } from "next/headers"
+
+export function getActiveTenantId(session: DescopeSession): string | null {
+  const cookieStore = cookies()   // ← synchronous call; wrong in Next.js 15
+  ...
+}
+```
+
+In Next.js 15, `cookies()` is async and returns `Promise<ReadonlyRequestCookies>`. The synchronous call compiles (TypeScript doesn't catch it because `cookies()` appears to return `ReadonlyRequestCookies` directly in older types) but throws at runtime.
+
+**Fix:** Check the target project's Next.js version before generating cookie/header reads. For Next.js 15+:
+```ts
+export async function getActiveTenantId(session: DescopeSession): Promise<string | null> {
+  const cookieStore = await cookies()
+  ...
+}
+```
+
+---
+
+### Bug 4: Making a helper async cascades to all callers — trace the dependency chain
+
+When `getActiveTenantId` became async, the following chain all needed `async`/`await`:
+1. `getActiveTenantId` → async
+2. `getActiveTenantRoles` (calls `getActiveTenantId`) → async
+3. `getRole` in `lib/roles.ts` (calls `getActiveTenantRoles`) → async
+4. All call sites in server components and server actions → add `await`
+
+This affected 20+ call sites across the project. The migration generated none of them as async, so adding `await cookies()` would have broken the entire tenant-aware authorization layer silently (TypeScript accepts `await` on non-Promise values without error).
+
+**Practice:** When making any shared helper async, immediately grep all call sites and propagate `async`/`await` before finishing the edit.
+
+---
+
+### Summary: what to verify before generating Next.js + `@descope/nextjs-sdk` code
+
+1. **Export names:** Resolve `node_modules/@descope/nextjs-sdk/dist/types/server/*.d.ts` and confirm the exact function names before writing any import.
+2. **Return type:** `session()` returns `AuthenticationInfo | undefined` from `@descope/node-sdk`, not a boolean-flagged Auth0-style session object.
+3. **isAuthenticated:** Does not exist on `AuthenticationInfo`. Unauthenticated = `undefined`; authenticated = non-null object.
+4. **claims vs token:** Decoded JWT claims are under `.token` (a `Token` object), not `.claims`. Raw JWT string is under `.jwt`.
+5. **Next.js version:** Check `package.json` for Next.js ≥ 15. If so, `cookies()` and `headers()` from `next/headers` are async — all consumers must be async.
+6. **Async cascade:** Tracing async upward from `cookies()` may require updating 10+ files. Plan for it.
+
+---
+
+## Next.js (with separate Express API server)
+
+
+**Changes:**
+- [`@auth0/nextjs-auth0`](https://github.com/auth0/nextjs-auth0) v4 → [`@descope/nextjs-sdk`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk) + [`@descope/node-sdk`](https://github.com/descope/node-sdk) (two packages: client SDK for Next.js, node SDK for the API server).
+- `Auth0Client` from `@auth0/nextjs-auth0/server` → singleton `getDescopeClient()` using `@descope/node-sdk`.
+- Removed Auth0's catch-all middleware that [auto-handled `/auth/*` routes in v4](https://github.com/auth0/nextjs-auth0/blob/main/V4_MIGRATION_GUIDE.md). Replaced with Next.js middleware using Descope's [`authMiddleware()`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#middleware) to check the `DS` cookie and redirect unauthenticated users.
+- Express API server (`api-server.js`): replaced [`express-jwt`](https://github.com/auth0/express-jwt) + [`jwks-rsa`](https://github.com/auth0/node-jwks-rsa) with `@descope/node-sdk` [`validateSession()`](https://docs.descope.com/authorization/session-management/session-validation/backend#validate-session).
+- Added `/login` page with [`<Descope>` React component](https://docs.descope.com/client-sdk/descope-components#descope-component).
+
+**Access token proxying changes:**
+Auth0's `auth0.getAccessToken()` returns a separate access token (scoped to `AUTH0_AUDIENCE`) passed to the external API as a Bearer token. The API server validates it against Auth0's JWKS endpoint via [`express-jwt`](https://github.com/auth0/express-jwt).
+
+Descope has no separate access token. The session token (DS cookie) is the token you pass to the API server. The Next.js API route reads `DS` from cookies and forwards it as `Authorization: Bearer <DS>`. The API server validates it with `descopeClient.validateSession(token)`.
+
+`AUTH0_AUDIENCE` and `AUTH0_SCOPE` env vars disappear. For audience validation with Descope, configure a custom `aud` claim in the Descope Console's [JWT Templates](https://docs.descope.com/management/jwt-templates) and pass the `audience` parameter to [`validateSession()`](https://docs.descope.com/getting-started/nodejs#implement-session-validation).
+
+**Notes:**
+- Auth0 v4's `Auth0Client` manages OIDC discovery, token caching, and session cookies. Descope's `DescopeClient` validates JWTs against [cached public keys](https://docs.descope.com/authorization/session-management/session-validation/backend/offline-jwt-validation). The frontend ([Descope Flows](https://docs.descope.com/flows)) handles what `Auth0Client` used to do.
+- [`jwks-rsa`](https://github.com/auth0/node-jwks-rsa) fetches and caches JWKS from Auth0's `/.well-known/jwks.json`. Descope's Node SDK does the same from `https://api.descope.com/v2/keys/<project_id>` ([ref](https://docs.descope.com/authorization/session-management/session-validation/backend/offline-jwt-validation#finding-your-public-key)). No configuration needed.
+- Removing `express-jwt` + `jwks-rsa` cuts 2 dependencies and ~15 lines of JWKS config. The Descope replacement is ~15 lines of middleware calling `validateSession()`.
+
+**Limitation:**
+- The original API server validated the `audience` claim (ensuring the token targeted this API). Descope's `validateSession()` checks signature and expiry but skips audience by default. To replicate: (1) configure `aud` in [Descope's JWT Templates](https://docs.descope.com/management/jwt-templates), (2) pass `audience` to `validateSession()` ([Node SDK docs](https://docs.descope.com/getting-started/nodejs#implement-session-validation)). Easy to miss during migration.
+
+---
+
+## Go + Encore
+
+
+**Changes:**
+- Backend gutted: 4 auth endpoints (Login, Callback, Logout, AuthHandler) at ~150 lines of Go → 1 endpoint (AuthHandler, ~25 lines) validating DS session tokens with the [Descope Go SDK](https://github.com/descope/go-sdk).
+- Removed `backend/auth/authenticator.go` (OIDC provider setup via [`go-oidc`](https://github.com/coreos/go-oidc), OAuth2 config, code exchange). Not needed.
+- Frontend removed 3 API routes (`/auth/login`, `/auth/logout`, `/callback`). Replaced with `/login` page containing [`<Descope>` component](https://docs.descope.com/client-sdk/descope-components#descope-component) and client-side `LogoutButton` using [`useDescope().logout()`](https://docs.descope.com/client-sdk/auth-helpers#logout).
+- `getRequestClient.ts` reads `DS` cookie instead of custom `auth-token` cookie.
+- Generated Encore client (`client.ts`) simplified: auth service methods (Login, Logout, Callback) removed since those backend endpoints are gone.
+
+**Two-process architecture:**
+The original split auth between Go backend (OIDC/code exchange/token verification) and Next.js frontend (redirect orchestration). With Descope, auth is client-side. The Go backend validates tokens only. The split is cleaner: backend is a pure API, frontend owns auth UX.
+
+Cookie name changed from `auth-token` (custom, set by callback route) to `DS` (Descope standard). `getRequestClient.ts` extracts this and passes it as Bearer token in the `Authorization` header. Encore's [`//encore:authhandler`](https://encore.dev/docs/go/primitives/defining-apis#access-controls) intercepts it.
+
+**Notes:**
+- Go SDK constructor: `client.NewWithConfig(&client.Config{ProjectID: "..."})`. Session validation: [`descopeClient.Auth.ValidateSessionWithToken(ctx, token)`](https://docs.descope.com/getting-started/go#implement-session-validation) returns `(bool, *descope.Token, error)`. `Token.Claims` is `map[string]interface{}`. Ref: [Descope Go SDK](https://github.com/descope/go-sdk).
+- Encore's `//encore:authhandler` expects `(auth.UID, error)`. Descope's JWT `sub` claim maps to `auth.UID`. Same claim name as Auth0, different issuer.
+- `encore.cue` config: ClientID + ClientSecret + Domain + RedirectURL → ProjectID only.
+- `go.mod`: [`coreos/go-oidc/v3`](https://github.com/coreos/go-oidc) + `golang.org/x/oauth2` → [`descope/go-sdk`](https://github.com/descope/go-sdk). Fewer dependencies.
+
+**Limitation:**
+- The Go SDK's exported type names (`client.DescopeClient`, `descope.Token`) aren't documented in Descope's official docs. The [Go quickstart](https://docs.descope.com/getting-started/go) shows usage patterns, not Go type signatures. Types in this migration are inferred from [Go SDK README](https://github.com/descope/go-sdk#readme) examples; verify against `go doc` output.
+- Encore's `//encore:service` init pattern (`initService()`) creates the Descope client at service startup. If Encore's lifecycle skips `initService`, the client won't exist. Same risk the original had with the OIDC authenticator.
+
+---
+
+## Agentic AI Stacks (LangChain / LangGraph + FGA + Token Vault)
+
+
+Three sub-projects (`py-langchain`, `ts-langchain`, `ts-vercel-ai`) sharing the same architecture: a document RAG app with an AI agent that accesses third-party services (Google Calendar, Gmail, GitHub, Slack) and processes purchases.
+
+### Architecture overview
+
+| Layer | Auth0 component | Descope equivalent | Migration difficulty |
+|---|---|---|---|
+| Authentication (login/session) | `@auth0/nextjs-auth0` v4, `auth0-fastapi` | `@descope/nextjs-sdk`, Descope Python SDK + custom FastAPI JWT authorizer | Low: same patterns as the framework sections above |
+| Fine-grained authorization | Auth0 FGA (OpenFGA) via `@openfga/sdk` + `@auth0/ai` `FGARetriever` | Descope ReBAC via `management.fga.*` + custom retriever | Medium: API shape differs, no `FGARetriever` |
+| Third-party token storage | Auth0 Token Vault / Connected Accounts | Descope Outbound Apps | Medium: API differs, no AI-framework wrapper |
+| Async user approval | Auth0 CIBA via `@auth0/ai` `withAsyncAuthorization()` | No equivalent; custom implementation needed | High |
+| AI tool authorization wrappers | `@auth0/ai-langchain`, `@auth0/ai-vercel` | No equivalent; custom wrappers needed | High |
+
+### Auth0 integration points across sub-projects
+
+**py-langchain** (FastAPI + LangGraph Python):
+- `auth0-fastapi` provides `AuthConfig`, `AuthClient`, session middleware, `/api/auth/*` routes, `require_session` dependency
+- `auth0-ai` Python SDK provides `Auth0AI`, `with_token_vault()`, `with_async_authorization()`
+- `auth0-ai-langchain` provides `FGARetriever`, `get_access_token_from_token_vault()`
+- `openfga-sdk` for direct FGA tuple writes/deletes in document management
+- LangGraph receives credentials via `config["configurable"]["_credentials"]` (injected by FastAPI proxy route)
+- Frontend is a Vite React SPA; auth is cookie-based via `withCredentials: true` on axios
+
+**ts-langchain** (Next.js + LangGraph TS):
+- `@auth0/nextjs-auth0` v4 with `Auth0Client`, `enableConnectAccountEndpoint`, `getAccessToken()`, `getSession()`
+- `@auth0/ai-langchain` provides `Auth0AI`, `withTokenVault()`, `withAsyncAuthorization()`, `FGARetriever`, `getAccessTokenFromTokenVault()`
+- LangGraph custom auth handler (`auth.ts`) validates JWTs against Auth0 JWKS, attaches `getRawAccessToken()` to context
+- `langgraph-nextjs-api-passthrough` proxies requests with Auth0 access token + user object injected
+- Connected Accounts API uses `https://DOMAIN/me/v1/connected-accounts/accounts` with scoped tokens
+- Uses `AUTH0_CUSTOM_API_CLIENT_ID`/`SECRET` for Token Vault federated token exchange
+
+**ts-vercel-ai** (Next.js + Vercel AI SDK):
+- Same auth setup as ts-langchain but uses Vercel AI SDK instead of LangGraph
+- `@auth0/ai-vercel` replaces `@auth0/ai-langchain` for tool wrapping
+- Tool authorization patterns are identical; the runtime difference is Vercel AI SDK vs LangGraph
+
+### FGA schema (shared across all three)
+
+```
+type user
+type doc
+  relations
+    define owner: [user]
+    define viewer: [user, user:*]
+    define can_view: owner or viewer
+```
+
+Documents are created with `owner` relation. Sharing adds `viewer` relations. RAG retrieval filters via `can_view` check. Delete removes all relations.
+
+Descope ReBAC equivalent schema ([DSL format](https://docs.descope.com/authorization/rebac/define-schema)):
+```
+model AuthZ 1.0
+
+type user
+
+type doc
+  relation owner: user
+  relation viewer: user
+  permission can_view: owner or viewer
+```
+
+### Credential flow (all three sub-projects)
+
+```
+Frontend (browser)
+  → cookies sent with request
+    → Next.js/FastAPI middleware validates session
+      → extracts access_token + user from session
+        → injects into LangGraph config as _credentials
+          → tool reads _credentials to:
+            a) call Auth0 /userinfo (user_info tool)
+            b) exchange via Token Vault (google_calendar, gmail, github, slack tools)
+            c) get CIBA approval token (shop_online tool)
+            d) build FGA check query with user email (context_docs tool)
+```
+
+With Descope, step (a) changes to reading claims from the validated session token (no `/userinfo` call needed since claims are in the JWT). Steps (b-d) require custom implementations using Descope Outbound Apps API, a custom approval mechanism, and Descope ReBAC API respectively.
+
+### Migration strategy notes
+
+The authentication layer (login, session, middleware) follows the same patterns as the framework sections above. The complexity is in the four Auth0 product integrations layered on top.
+
+Recommended migration order:
+1. Swap auth layer first (auth0-fastapi/nextjs-auth0 to Descope SDKs). Low risk, proven patterns.
+2. Migrate FGA to Descope ReBAC. Moderate lift; the API shape changes but the capability is equivalent.
+3. Migrate Token Vault to Outbound Apps. Moderate lift; needs custom tool wrappers.
+4. Build custom CIBA replacement. Highest risk; no direct equivalent.

--- a/skills/workos-to-descope/references/implementation-nuances.md
+++ b/skills/workos-to-descope/references/implementation-nuances.md
@@ -3,42 +3,41 @@
 ## Contents
 
 **General Insights — Architecture & Flow**
-- [Auth0 owns the flow; Descope validates tokens](#auth0-owns-the-flow-descope-validates-tokens)
+- [AuthKit owns the flow; Descope validates tokens](#authkit-owns-the-flow-descope-validates-tokens)
 - [OIDC compatibility path](#oidc-compatibility-path-alternative-to-full-migration)
 - [No drop-in middleware for Express or Flask](#no-drop-in-middleware-for-express-or-flask)
 - [Fewer network round-trips at login](#fewer-network-round-trips-at-login)
-- [Auth0 vs Descope flow comparison](#auth0-vs-descope-flow-comparison)
+- [WorkOS vs Descope flow comparison](#workos-vs-descope-flow-comparison)
 
-**General Insights — Feature Mapping: Auth0 → Descope**
+**General Insights — Feature Mapping: WorkOS → Descope**
 - [Social login / connection mapping + SSO URLs](#social-login--connection-mapping)
-- [RBAC: Auth0 → Descope](#rbac-auth0--descope)
-- [Multi-tenancy: Auth0 Organizations → Descope Tenants](#multi-tenancy-auth0-organizations--descope-tenants)
-- [Invitation model](#invitation-model-auth0-invitations--descope-userinvite)
+- [RBAC: WorkOS → Descope](#rbac-workos--descope)
+- [Multi-tenancy: WorkOS Organizations → Descope Tenants](#multi-tenancy-workos-organizations--descope-tenants)
+- [Invitation model](#invitation-model-workos-invitations--descope-userinvite)
 - [MFA enrollment and factor management](#mfa-enrollment-and-factor-management)
-- [SCIM: HTTP API only, not in SDK](#scim-http-api-only-not-in-sdk)
+- [Directory Sync / SCIM: a lifecycle, not an import](#directory-sync--scim-a-lifecycle-not-an-import)
 - [Session refresh after profile changes + sdk.refresh()](#session-refresh-after-profile-changes)
 - [Management API mapping](#management-api-mapping)
-- [FGA: Auth0 FGA (OpenFGA) → Descope ReBAC](#fga-auth0-fga-openfga--descope-rebac)
-- [Token Vault / Connected Accounts → Descope Outbound Apps](#token-vault--connected-accounts--descope-outbound-apps)
-- [CIBA / Rich Authorization Requests (no equivalent)](#ciba--rich-authorization-requests-no-descope-equivalent)
-- [@auth0/ai SDK (no equivalent)](#auth0ai-sdk-no-descope-equivalent)
-- [User migration: Auth0 export → Descope import](#user-migration-auth0-export--descope-import)
-- [M2M: Auth0 client credentials → Descope Access Keys](#m2m-authentication-auth0-client-credentials--descope-access-keys)
-- [Email templates](#email-templates-auth0--descope-messaging-templates)
-- [Webhooks / Log Streams → Descope Audit Webhook](#webhooks--event-streams-auth0-log-streams--descope-audit-webhook)
+- [FGA: WorkOS FGA (warrants) → Descope ReBAC](#fga-workos-fga-warrants--descope-rebac)
+- [Pipes → Descope Outbound Apps](#pipes--descope-outbound-apps)
+- [User migration: WorkOS export → Descope import](#user-migration-workos-export--descope-import)
+- [M2M: WorkOS API keys → Descope Access Keys](#m2m-authentication-workos-api-keys--descope-access-keys)
+- [Email templates](#email-templates-workos--descope-messaging-templates)
+- [Webhooks / Audit Logs → Descope Audit Webhook](#webhooks--audit-logs-workos--descope-audit-webhook)
 - [Custom domains](#custom-domains)
-- [Attack protection](#attack-protection-auth0-attack-protection--descope-flow-based-security)
+- [Radar → Descope Flow-based security](#radar--descope-flow-based-security)
+- [Admin Portal → SSO Setup Suite / Widgets](#admin-portal--sso-setup-suite--widgets)
 - [Testing checklist](#testing-checklist-applies-to-all-samples)
 
 **General Insights — Common Gotchas**
 - [Cookie names: DS and DSR](#cookie-names-ds-and-dsr-configurable)
 - [User claims differ (dct, tenants, email not default)](#user-claims-differ)
 - [Audience validation requires explicit setup](#audience-validation-requires-explicit-setup)
-- [One session token, not two](#auth0-separate-access-tokens--descope-session-token-reuse)
+- [Sealed sessions become signed JWTs; one session token](#sealed-sessions-become-signed-jwts)
 - [Logout requires two steps](#logout-requires-two-steps)
-- [One env var instead of five](#one-env-var-instead-of-five)
-- [Auth0 Actions/Rules → Flows + JWT Templates](#auth0-actionsrules--descope-flows--jwt-templates)
-- [authRequired: false needs manual replication](#authrequired-false-needs-manual-replication)
+- [One env var instead of four](#one-env-var-instead-of-four)
+- [WorkOS has no imperative actions → Flows + JWT Templates](#workos-has-no-imperative-actions--descope-flows--jwt-templates)
+- [Public routes need manual replication](#public-routes-need-manual-replication)
 
 **Framework Sections**
 - [Express.js](#expressjs)
@@ -46,10 +45,9 @@
 - [Next.js (standalone)](#nextjs-standalone)
 - [Next.js (B2B): Migration Bug Catalog](#nextjs-b2b-migration-bug-catalog)
 - [Next.js (with separate Express API server)](#nextjs-with-separate-express-api-server)
-- [Go + Encore](#go--encore)
-- [Agentic AI Stacks (LangChain / LangGraph + FGA + Token Vault)](#agentic-ai-stacks-langchain--langgraph--fga--token-vault)
+- [Go](#go)
 
-> **See also:** `flows-and-widgets.md` in this directory — Auth0→Descope lingo map, Flow structure and templates, Widget types, SSO Setup Suite, and the Console-vs-code decision guide. Read it before migrating any auth UI, MFA enrollment, user management pages, or SSO configuration.
+> **See also:** `flows-and-widgets.md` in this directory — WorkOS→Descope lingo map, Flow structure and templates, Widget types, SSO Setup Suite, and the Console-vs-code decision guide. Read it before migrating any auth UI, MFA enrollment, user management pages, or SSO configuration.
 
 ---
 
@@ -57,15 +55,15 @@
 
 **— Architecture & Flow —**
 
-### Auth0 owns the flow; Descope validates tokens
+### AuthKit owns the flow; Descope validates tokens
 
-Auth0's server-side SDKs ([express-openid-connect](https://github.com/auth0/express-openid-connect), [@auth0/nextjs-auth0](https://github.com/auth0/nextjs-auth0), [authlib](https://docs.authlib.org/en/latest/client/flask.html)) own the OIDC flow: they mount callback routes, handle code exchange, create server-managed sessions, and provide middleware that gates routes. Developers never touch tokens.
+WorkOS [AuthKit](https://workos.com/docs/authkit) and its framework SDKs ([authkit-nextjs](https://github.com/workos/authkit-nextjs), [authkit-js](https://github.com/workos/authkit-js), [authkit-react](https://github.com/workos/authkit-react)) own the login flow: AuthKit hosts (or embeds) the login UI, handles the redirect/callback code exchange, seals a server-managed session into an encrypted cookie, and provides middleware (`authkitMiddleware()`) and helpers (`withAuth()` / `getUser()`) that gate routes. Backend-SDK apps do the same work explicitly via `workos.userManagement.authenticateWithCode(...)` and `workos.userManagement.loadSealedSession(...)`. Developers never validate tokens themselves; the sealed cookie is unsealed with `WORKOS_COOKIE_PASSWORD`.
 
-Descope splits the work. The frontend ([Descope Flows](https://docs.descope.com/flows) via [web components](https://docs.descope.com/client-sdk/descope-components) or [client SDKs](https://docs.descope.com/client-sdk/initialize-sdk)) runs the authentication ceremony and stores JWTs in `DS` (session) and `DSR` (refresh) cookies. The backend [validates those JWTs](https://docs.descope.com/authorization/session-management/session-validation/backend). No server-side OAuth callback, no authorization code exchange, no server-managed session store.
+Descope splits the work. The frontend ([Descope Flows](https://docs.descope.com/flows) via [web components](https://docs.descope.com/client-sdk/descope-components) or [client SDKs](https://docs.descope.com/client-sdk/initialize-sdk)) runs the authentication ceremony and stores JWTs in `DS` (session) and `DSR` (refresh) cookies. The backend [validates those JWTs](https://docs.descope.com/authorization/session-management/session-validation/backend). No server-side OAuth callback, no authorization code exchange, no sealed server-managed session.
 
-Every Auth0→Descope migration adds a dedicated login page (or embeds the [`<descope-wc>` component](https://docs.descope.com/client-sdk/descope-components#descope-component)) and removes callback/redirect plumbing.
+Every WorkOS→Descope migration adds a dedicated login page (or embeds the [`<descope-wc>` component](https://docs.descope.com/client-sdk/descope-components#descope-component)) and removes the AuthKit callback/redirect plumbing.
 
-**Exception:** Descope can also act as a [standard OIDC provider](https://docs.descope.com/getting-started/oidc-endpoints). If you want to keep your existing OIDC client code (e.g., `express-openid-connect`, `go-oidc`, `authlib`), you can point it at Descope's OIDC endpoints instead of Auth0's. See the "OIDC compatibility path" section below.
+**Exception:** Descope can also act as a [standard OIDC provider](https://docs.descope.com/getting-started/oidc-endpoints). If the app authenticates through a **generic OIDC client** pointed at WorkOS's hosted AuthKit page, you can point that client at Descope's OIDC endpoints instead. See the "OIDC compatibility path" section below.
 
 ### OIDC compatibility path (alternative to full migration)
 
@@ -80,23 +78,25 @@ Descope exposes standard [OIDC endpoints](https://docs.descope.com/getting-start
 | End Session | `https://api.descope.com/oauth2/v1/logout` |
 | Revocation | `https://api.descope.com/oauth2/v1/revoke` |
 
-An app using `express-openid-connect` could swap `ISSUER_BASE_URL` from `https://YOUR_AUTH0_DOMAIN` to `https://api.descope.com` and keep the existing OIDC client code intact. Differences in claim shapes (`nickname`, `email_verified` vs `verifiedEmail`), token lifetimes, and configuration semantics mean the OIDC swap still requires testing and adjustments. Still, it's a viable incremental path: swap the IdP first, then refactor to Descope-native SDKs later.
+**First classify the current integration — these endpoints only matter for the hosted-page case.** An app that uses a **generic OIDC/OAuth client library** redirected to a WorkOS-hosted AuthKit login URL can swap the issuer to `https://api.descope.com` and keep the existing client code largely intact. An app that uses **embedded AuthKit or the WorkOS SDKs directly** (`withAuth()`, AuthKit components, `userManagement.*`) cannot — that's a full migration to Descope-native SDKs + Flows.
+
+Even for the hosted-page case, differences in claim shapes (`email_verified` vs `verifiedEmail`), token lifetimes, and configuration semantics mean the OIDC swap still requires testing and adjustments — and organization-scoped login, SSO, and SCIM must be rebuilt regardless of path. Still, it's a viable incremental step for the generic-client case: swap the IdP first, then refactor to Descope-native SDKs later. For B2B apps the savings are minimal, because management calls, org/tenant-scoped login, SSO/SCIM, and claim mapping all require full migration anyway.
 
 **— Common Gotchas —**
 
 ### No drop-in middleware for Express or Flask
 
-Auth0 offers [`express-openid-connect`](https://github.com/auth0/express-openid-connect), a single `app.use(auth(config))` that [auto-mounts `/login`, `/logout`, `/callback`](https://github.com/auth0/express-openid-connect#readme) and attaches `req.oidc`. Descope has no Express middleware package. You:
+WorkOS's framework SDKs offer drop-in helpers — `authkit-nextjs` exposes `authkitMiddleware()`, and AuthKit-JS apps get `withAuth()` / `getUser()` that read and unseal the session cookie for you. Descope has no equivalent Express middleware package. You:
 
-1. Add `cookie-parser` (Express doesn't parse cookies by default; Auth0's middleware handled it internally).
+1. Add `cookie-parser` (Express doesn't parse cookies by default; AuthKit's helpers handled it internally).
 2. Write custom middleware: read `DS` cookie → call [`descopeClient.validateSession()`](https://docs.descope.com/authorization/session-management/session-validation/backend#validate-session) → attach user claims to `req`.
 3. Write your own `requiresAuth()` guard (3 lines, but manual).
 
 The [Descope blog](https://www.descope.com/blog/post/authentication-middleware) shows an Express middleware pattern, but it's a tutorial example, not a published package.
 
-Flask is the same story. Auth0's [authlib Flask integration](https://docs.authlib.org/en/latest/client/flask.html) registers an OAuth client with `authorize_redirect` / `authorize_access_token` helpers. Descope's Flask backend [validates tokens](https://docs.descope.com/getting-started/python) only; auth UI is client-side.
+Flask is the same story. WorkOS's [Python SDK](https://github.com/workos/workos-python) provides `userManagement` helpers for the code exchange and sealed-session access. Descope's Flask backend [validates tokens](https://docs.descope.com/getting-started/python) only; auth UI is client-side.
 
-FastAPI follows the same pattern. Auth0 has [`auth0-fastapi`](https://github.com/auth0/auth0-fastapi), which provides `AuthConfig`, session middleware, auto-mounted `/auth/*` routes, a `require_session` dependency, and Token Vault / Connected Accounts support. Descope's equivalent is a [custom JWT authorizer using JWKS validation](https://docs.descope.com/authorization/session-management/session-validation/oidc-jwt-authorizers/python-fastapi-jwt-authorizer): a `TokenVerifier` class that reads the `Authorization` header, validates against Descope's JWKS, and attaches as a FastAPI `Security()` dependency. No auto-mounted routes, no session store.
+FastAPI follows the same pattern. The Descope approach is a [custom JWT authorizer using JWKS validation](https://docs.descope.com/authorization/session-management/session-validation/oidc-jwt-authorizers/python-fastapi-jwt-authorizer): a `TokenVerifier` class that reads the `Authorization` header, validates against Descope's JWKS, and attaches as a FastAPI `Security()` dependency. No auto-mounted routes, no sealed session store.
 
 ### Cookie names: `DS` and `DSR` (configurable)
 
@@ -108,42 +108,40 @@ The `sessionTokenViaCookie` parameter in [`AuthProvider`](https://docs.descope.c
 
 ### User claims differ
 
-The default Descope session JWT ([structure ref](https://docs.descope.com/authorization/session-management#descope-session-jwt-structure)) contains `sub`, `amr`, `drn`, `tenants`, `roles`, and `permissions`. It does **not** include `email`, `name`, or `picture` unless you add them via [JWT Templates](https://docs.descope.com/management/jwt-templates) or [Flow actions > Custom Claims](https://docs.descope.com/flows/actions/custom-claims). Auth0 ID tokens include these by default.
+The default Descope session JWT ([structure ref](https://docs.descope.com/authorization/session-management#descope-session-jwt-structure)) contains `sub`, `amr`, `drn`, `tenants`, `roles`, `permissions`, and `dct`. It does **not** include `email`, `name`, or `picture` unless you add them via [JWT Templates](https://docs.descope.com/management/jwt-templates) or [Flow actions > Custom Claims](https://docs.descope.com/flows/actions/custom-claims). WorkOS AuthKit's session may expose some profile fields directly, so code that reads them from the session will break after migration.
 
-| Field | Auth0 | Descope |
+| Field | WorkOS | Descope |
 |---|---|---|
-| User ID | `sub` (e.g., `auth0\|abc123`) | `sub` in JWT, `userId` in SDK user objects |
-| Display name | `name`, `nickname` | Not in JWT by default. Add via [JWT Templates](https://docs.descope.com/management/jwt-templates). No `nickname` equivalent. |
-| Email | `email` | Not in JWT by default. Add via JWT Templates. Available on user object via SDK management calls. |
-| Profile picture | `picture` | Not in JWT by default. Add via JWT Templates. |
-| Email verified | `email_verified` | Not in JWT by default. Available on user object as `verifiedEmail`. Add to JWT via Custom Claims if needed. |
-| Roles | Via `https://DOMAIN/roles` namespace claim (added by Auth0 Actions) | `roles` array in JWT (embedded by default with [RBAC](https://docs.descope.com/authorization/role-based-access-control)) |
-| Permissions | Via namespace claim or `permissions` array (added by Actions) | `permissions` array in JWT (embedded by default) |
-| Tenant ID | `org_id` (flat string) | `dct` — flat string with active tenant ID, direct `org_id` equivalent; `tenants` — object keyed by tenant ID containing per-tenant `roles` and `permissions`. Use `dct` when you only need the ID; use `tenants` when you need per-tenant roles ([ref](https://docs.descope.com/authorization/role-based-access-control#tenants-and-roles)) |
-
-`nickname` is Auth0-specific (derived from the email prefix). Descope lacks it. Fall back to `name`.
+| User ID | `user.id` (e.g., `user_01H...`) | `sub` in JWT, `userId` in SDK user objects |
+| Display name | `user.firstName` / `user.lastName` | Not in JWT by default. Add via [JWT Templates](https://docs.descope.com/management/jwt-templates). |
+| Email | `user.email` (on the AuthKit session) | Not in JWT by default. Add via JWT Templates. Available on user object via SDK management calls. |
+| Profile picture | `user.profilePictureUrl` | Not in JWT by default. Add via JWT Templates. |
+| Email verified | `user.emailVerified` | Not in JWT by default. Available on user object as `verifiedEmail`. Add to JWT via Custom Claims if needed. |
+| Roles | `role` / `roleSlug` (organization membership role) | `roles` array in JWT (embedded by default with [RBAC](https://docs.descope.com/authorization/role-based-access-control)) |
+| Permissions | `permissions` array (RBAC) | `permissions` array in JWT (embedded by default) |
+| Tenant ID | `organizationId` (flat string, from `withAuth()`) | `dct` — flat string with active tenant ID, direct `organizationId` equivalent; `tenants` — object keyed by tenant ID containing per-tenant `roles` and `permissions`. Use `dct` when you only need the ID; use `tenants` when you need per-tenant roles ([ref](https://docs.descope.com/authorization/role-based-access-control#tenants-and-roles)) |
 
 **Migration action item:** Before migrating, configure a JWT Template that includes `email`, `name`, and any other profile claims your app reads from the token. Without this, code that reads `token.email` or `token.name` after `validateSession()` will get `undefined`.
 
 ### Audience validation requires explicit setup
 
-Auth0 projects commonly set `AUTH0_AUDIENCE` to scope access tokens to a specific API. The access token's `aud` claim is validated by the API server (via `express-jwt`, `go-oidc`, etc.).
+WorkOS access tokens carry the `aud`/client context tied to the AuthKit client. If the API server validates an audience today (via `express-jwt`, JWKS, etc.), you must replicate it.
 
-Descope session tokens don't include an `aud` claim by default. To replicate Auth0's audience validation:
+Descope session tokens don't include an `aud` claim by default. To add audience validation:
 1. Configure a custom `aud` claim in the Descope Console's [JWT Templates](https://docs.descope.com/management/jwt-templates).
 2. Pass the `audience` parameter to [`validateSession()`](https://docs.descope.com/getting-started/nodejs#implement-session-validation) on the backend.
 
 This is easy to miss during migration. Without it, any valid Descope session token from any project would pass validation. The audience check prevents cross-project token reuse.
 
-### Auth0 separate access tokens → Descope session token reuse
+### Sealed sessions become signed JWTs
 
-Auth0's architecture issues separate access tokens (scoped to an `audience`) distinct from the ID token. The Next.js SDK's `getAccessToken()` returns this access token for API calls.
+WorkOS AuthKit uses an **encrypted/sealed** session cookie protected by `WORKOS_COOKIE_PASSWORD`. Code unseals it (`loadSealedSession()`, `withAuth()`) to read the user, and the access token is distinct from the sealed session.
 
-Descope has one token: the session JWT (`DS` cookie). When calling a backend API, you forward the `DS` cookie value as `Authorization: Bearer <DS>`. The API server validates it with `descopeClient.validateSession(token)`. No separate token endpoint, no audience-scoped token issuance. If you need audience differentiation, use [JWT Templates](https://docs.descope.com/management/jwt-templates).
+Descope has one token: the signed session JWT (`DS` cookie), readable but verified by signature. The sealing password is gone. Any code that unseals or inspects the WorkOS cookie is replaced with `descopeClient.validateSession()`, which returns decoded JWT claims. When calling a backend API, forward the `DS` cookie value as `Authorization: Bearer <DS>`; the API server validates it with `descopeClient.validateSession(token)`. No separate access-token endpoint, no provider-specific token issuance. If you need audience differentiation, use [JWT Templates](https://docs.descope.com/management/jwt-templates).
 
 ### Logout requires two steps
 
-Auth0's `express-openid-connect` [redirects to Auth0's `/v2/logout`](https://github.com/auth0/express-openid-connect#readme) (clears the Auth0 session), then back to the app. `@auth0/nextjs-auth0` does the same via its API route.
+WorkOS logout clears the sealed AuthKit session (and optionally redirects through a WorkOS logout URL).
 
 Descope logout ([backend](https://docs.descope.com/authorization/session-management/session-validation/backend#logout-current-session-using-backend-sdk) / [client](https://docs.descope.com/client-sdk/auth-helpers#logout)):
 1. Call `descopeClient.logout(refreshToken)` (server-side) or `sdk.logout()` (client-side) to invalidate the refresh token.
@@ -151,40 +149,44 @@ Descope logout ([backend](https://docs.descope.com/authorization/session-managem
 
 Clear cookies without calling logout → the refresh token stays valid on Descope's servers. Call logout without clearing cookies → the client holds a dead session token that fails validation but confuses client-side state.
 
-### One env var instead of five
+### One env var instead of four
 
-Auth0 needs `CLIENT_ID`, `CLIENT_SECRET`, `ISSUER_BASE_URL`/`AUTH0_DOMAIN`, `SECRET`, and sometimes `AUTH0_AUDIENCE`. See the [express-openid-connect configuration](https://github.com/auth0/express-openid-connect#readme) for the full list.
+WorkOS needs `WORKOS_API_KEY`, `WORKOS_CLIENT_ID`, `WORKOS_REDIRECT_URI`, and `WORKOS_COOKIE_PASSWORD` (4+).
 
-Descope needs `DESCOPE_PROJECT_ID` (or `NEXT_PUBLIC_DESCOPE_PROJECT_ID` for Next.js client-side). No client secret for frontend flows. The web component authenticates against Descope's API using the project ID. Backend SDKs [fetch the public key](https://docs.descope.com/authorization/session-management/session-validation/backend/offline-jwt-validation#finding-your-public-key) from Descope's JWKS endpoint (`https://api.descope.com/v2/keys/<project_id>`) using the same project ID. No secrets to rotate for the auth flow.
+Descope needs `DESCOPE_PROJECT_ID` (or `NEXT_PUBLIC_DESCOPE_PROJECT_ID` for Next.js client-side). No client secret for frontend flows, and no cookie-sealing password. The web component authenticates against Descope's API using the project ID. Backend SDKs [fetch the public key](https://docs.descope.com/authorization/session-management/session-validation/backend/offline-jwt-validation#finding-your-public-key) from Descope's JWKS endpoint (`https://api.descope.com/v2/keys/<project_id>`) using the same project ID. No secrets to rotate for the auth flow.
 
 For management operations (user CRUD, role management, FGA), add `DESCOPE_MANAGEMENT_KEY`.
 
-### Auth0 Actions/Rules → Descope Flows + JWT Templates
+### WorkOS has no imperative actions → Descope Flows + JWT Templates
 
-Auth0 uses [Actions](https://auth0.com/docs/customize/actions) (and legacy Rules/Hooks) to run custom code at specific points in the authentication pipeline: post-login, pre-registration, and others. Common uses include enriching tokens with custom claims, blocking logins based on business logic, and assigning roles.
+WorkOS does not run arbitrary developer code mid-authentication. Auth behavior is configured in the AuthKit dashboard (enabled methods, branding, Radar, RBAC) and read back through the session.
 
-Descope equivalent:
+Descope's customization model:
 - **Custom claims:** [JWT Templates](https://docs.descope.com/management/jwt-templates) to add static/dynamic claims to tokens, or [Flow actions > Custom Claims](https://docs.descope.com/flows/actions/custom-claims) for claims set during the auth flow.
-- **Custom logic during auth:** [Descope Flows](https://docs.descope.com/flows) are visual, drag-and-drop pipelines. Conditional branching, connectors to external services, and custom JS actions replace Auth0 Actions. Flows run on Descope's servers, not as arbitrary Node.js code.
-- **Post-login hooks:** Descope Flows can call external HTTP endpoints ([Connectors](https://docs.descope.com/customize/connectors)) for webhook-style behavior.
+- **Custom logic during auth:** [Descope Flows](https://docs.descope.com/flows) are visual, drag-and-drop pipelines. Conditional branching, connectors to external services, and custom JS actions run auth-time business logic on Descope's servers.
+- **Webhook-style hooks:** Descope Flows can call external HTTP endpoints ([Connectors](https://docs.descope.com/customize/connectors)).
 
-Auth0 Actions are imperative Node.js code. Descope Flows are declarative and visual, with escape hatches to custom code via Connectors and JS actions. You'll need to restructure auth-time business logic around the visual pipeline model.
+Where a WorkOS app encodes post-login business logic in application code that runs after `withAuth()`, decide whether it belongs in a Flow (auth-time) or stays in app code (post-validation). Logic that *must* happen before a session is issued moves into the Flow.
 
-### `authRequired: false` needs manual replication
+### Public routes need manual replication
 
-Auth0's `express-openid-connect` supports [`authRequired: false`](https://github.com/auth0/express-openid-connect#readme) globally: unauthenticated users browse freely, the middleware skips populating `req.oidc.user`. Descope equivalent: your session middleware catches validation errors and sets `req.isAuthenticated = false` instead of returning 401.
+`authkitMiddleware()` can be configured with unauthenticated/public paths so anonymous users browse freely while protected paths require a session. Descope equivalent: your session middleware catches validation errors and sets `req.isAuthenticated = false` (or skips the redirect) for public routes instead of returning 401.
 
-**— Feature Mapping: Auth0 → Descope —**
+**— Feature Mapping: WorkOS → Descope —**
 
 ### Social login / connection mapping
 
-Auth0 [Social Connections](https://auth0.com/docs/authenticate/identity-providers/social-identity-providers) (Google, GitHub, Facebook, etc.) are configured in the Auth0 dashboard and appear automatically on the Universal Login page.
+WorkOS social providers (Google, Microsoft, GitHub, etc.) are enabled in the WorkOS dashboard / AuthKit and appear automatically on the AuthKit login page.
 
 Descope equivalent: configure [social auth methods](https://docs.descope.com/authentication/social) in the Descope Console, then add them to a [Flow](https://docs.descope.com/flows). The Descope web component renders the configured providers. No code changes needed; configuration only.
 
-SAML/OIDC enterprise connections in Auth0 map to Descope's [SSO configuration](https://docs.descope.com/sso) (per-tenant SSO for B2B). Auth0 Organizations' per-org connections map to Descope's per-tenant SSO settings.
+WorkOS enterprise SSO connections (SAML/OIDC, per Organization) map to Descope's [SSO configuration](https://docs.descope.com/sso) (per-tenant SSO for B2B). A WorkOS Organization's connection maps to that tenant's SSO configuration.
 
-**SSO Setup Suite:** For apps that expose a self-service SSO settings page where tenant admins configure their IdP, the SSO Setup Suite (Console wizard) can replace `sso.configureSAMLByTenant()` / `configureOIDCByTenant()` calls entirely — tenant admins configure their own IdP through a guided wizard with no engineering involvement. Surface this before migrating any Management SDK SSO code. See `flows-and-widgets.md` → SSO Setup Suite.
+**SSO Setup Suite:** For apps that expose a self-service SSO settings page where tenant admins configure their IdP, the SSO Setup Suite (Console wizard) can replace `management.ssoApplication.*` calls entirely — tenant admins configure their own IdP through a guided wizard with no engineering involvement. Surface this before migrating any Management SDK SSO code. See `flows-and-widgets.md` → SSO Setup Suite.
+
+**Runtime SSO login — always use `sso.start` / `sso.exchange`.** When code initiates an enterprise SSO login (the equivalent of WorkOS's `sso.getAuthorizationUrl()` + `sso.getProfileAndToken()`), call the Descope SDK's `sso.start(tenant, redirectUrl, ...)` and `sso.exchange(code)`. Use these **regardless of the IdP's underlying protocol** — `sso.start` resolves the tenant-level SSO configuration (correct IdP, domain-based routing, connection settings). Do **not** use the generic `oauth.start` / `oauth.exchange` for enterprise SSO; those drive project-level social/OAuth providers. Rule of thumb: tenant/enterprise SSO → `sso.*`; social or generic OAuth login → `oauth.*`.
+
+**Don't rebuild per-provider SSO UI.** In Descope the IdP is defined as **tenant SSO configuration**, and a single `sso.start` call resolves it from the user's email domain or an explicit tenant ID/slug. Keep the login surface generic (collect an email or target a known tenant) and push provider-specific details into Console/tenant configuration — don't migrate separate "Sign in with Okta" / "Sign in with Azure AD" buttons.
 
 **SSO callback and ACS URLs:**
 - Social OAuth callback (Google, GitHub, etc.): `https://api.descope.com/v1/oauth/callback`
@@ -193,54 +195,76 @@ SAML/OIDC enterprise connections in Auth0 map to Descope's [SSO configuration](h
 
 `https://api.descope.com/oauth2/v1/callback` does not exist — do not use it as a callback URL when configuring an IdP.
 
-### RBAC: Auth0 → Descope
+### RBAC: WorkOS → Descope
 
-Auth0 RBAC: create permissions, create roles, assign roles to users. Roles/permissions can be added to access tokens via Auth0 Actions or the Authorization Extension.
+WorkOS roles come in two scopes: **environment-level roles** (available across all organizations) and **organization-scoped "custom roles"**. Permissions group under roles, and roles/permissions surface on the AuthKit session.
 
-Descope RBAC ([docs](https://docs.descope.com/authorization/role-based-access-control)): same concept, but permissions are always grouped into roles, and roles can be project-level or tenant-level. Roles/permissions are embedded in the JWT by default (no Action required). Descope SDK methods:
+Descope RBAC ([docs](https://docs.descope.com/authorization/role-based-access-control)): same concept, with two matching scopes — project-level and tenant-level. Roles/permissions are embedded in the JWT by default (no extra step). SDK methods:
 - `descopeClient.management.permission.create(name, description)` ([ref](https://docs.descope.com/authorization/role-based-access-control/with-sdks))
-- `descopeClient.management.role.create(name, description, permissionNames, tenantId)` ([ref](https://docs.descope.com/authorization/role-based-access-control/with-sdks))
-- Roles appear in the JWT `roles` array; permissions in `permissions` array.
+- `descopeClient.management.role.create(name, description, permissionNames, tenantId)` ([ref](https://docs.descope.com/authorization/role-based-access-control/with-sdks)) — pass `tenantId` for a **tenant-level** role (≈ WorkOS organization-scoped/custom role); omit it for a **project-level** role (≈ WorkOS environment-level role).
 
-Backend code checking Auth0's `req.auth.permissions.includes('read:messages')` changes to reading the `permissions` array from Descope's validated JWT claims.
+| WorkOS | Descope |
+|---|---|
+| `role` | `role` |
+| `permission` | `permission` |
+| Environment-level role | Project-level role |
+| Organization-scoped role ("custom role") | Tenant-scoped role |
+| `roleSlug` reference | Descope role **name** (not ID) |
+| IdP group → role mapping | Group-to-role mapping (SSO Configuration / SCIM) |
 
-### Multi-tenancy: Auth0 Organizations → Descope Tenants
+Roles must exist in the Console before assignment. Backend code checking WorkOS's `permissions.includes('read:messages')` changes to reading the `permissions` array from Descope's validated JWT claims — ideally via `validateTenantRoles(authInfo, tenantId, [...])` rather than parsing claims by hand.
 
-Auth0 [Organizations](https://auth0.com/docs/manage-users/organizations) group users by company. The `org_id` claim identifies the organization.
+### Multi-tenancy: WorkOS Organizations → Descope Tenants
 
-Descope [Tenants](https://docs.descope.com/b2b#multi-tenancy) are the equivalent. Users can belong to multiple tenants with different roles per tenant. The JWT includes a `tenants` object with per-tenant role/permission data ([ref](https://docs.descope.com/authorization/role-based-access-control#tenants-and-roles)).
+WorkOS [Organizations](https://workos.com/docs/user-management/organizations) group users by company and scope SSO, SCIM, roles, and domain policies. The `organizationId` identifies the organization.
+
+Descope [Tenants](https://docs.descope.com/b2b#multi-tenancy) are the equivalent. Most code that handles organizations is management/admin code that passes a WorkOS `organizationId` to the API — that simply becomes a Descope **tenant ID** passed to `management.tenant.*` / `management.user.*` calls. Only request-time session reads change shape: the JWT includes a `tenants` object with per-tenant role/permission data ([ref](https://docs.descope.com/authorization/role-based-access-control#tenants-and-roles)), plus `dct` for the active tenant.
 
 Key differences:
-- Auth0: `org_id` is a flat string claim. Descope: `tenants` is a nested object (`{ "tenantId": { "roles": [...], "permissions": [...] } }`).
-- Auth0 requires organization-scoped login via `organization` parameter. Descope routes by email domain or tenant-specific login URLs ([ref](https://docs.descope.com/sso/multi-sso)).
+- WorkOS: `organizationId` is a flat string. Descope: `tenants` is a nested object (`{ "tenantId": { "roles": [...], "permissions": [...] } }`); `dct` is the flat active-tenant string (the direct `organizationId` equivalent).
+- WorkOS routes by organization-scoped login. Descope routes by email domain, tenant name, or tenant-specific login URLs ([ref](https://docs.descope.com/sso/multi-sso)).
 - Descope supports tenant-level SSO enforcement (require SAML/OIDC for all users in a tenant) ([ref](https://docs.descope.com/management/tenant-management/tenant)).
 - Users are project-level entities in Descope; they're associated with tenants, not created per-tenant.
+- Organization `metadata` → tenant `customAttributes` (pre-define in the Console schema).
 - **Finding a user's tenants**: use `management.user.load(loginId)` and read `.userTenants` — it lists only that user's tenants. Avoid `management.tenant.loadAll()` + client-side filter; it scans every tenant in the project (O(n)).
-- Auth0's org-scoped login issues a JWT with one `org_id`. Descope's JWT contains **all** tenants the user belongs to at once. Switching tenants does not require re-authentication — implement it client-side (e.g. an `active_tenant` cookie) and read the active tenant from the `tenants` object in the JWT.
+- WorkOS's org-scoped login issues a session with one `organizationId`. Descope's JWT contains **all** tenants the user belongs to at once. Switching tenants does not require re-authentication — implement it client-side (e.g. an `active_tenant` cookie) and read the active tenant from the `tenants` object in the JWT.
 - When a tenant is created and the user is added via the Management SDK, the existing JWT is stale — the `tenants` claim was set at login and doesn't include the new tenant. The user must re-authenticate (clear `DS`/`DSR` cookies and redirect to login) to get a JWT with the updated tenant list. Without this, the app sees an empty `tenants` claim and may loop back to onboarding.
 
-### Invitation model: Auth0 invitations → Descope user.invite()
+Confirm the one-Organization-to-one-Tenant mapping before writing code — it ripples into SSO, SCIM, RBAC, and domain routing.
 
-Auth0 Organizations have a dedicated invitation system with invitation objects, URLs, and CRUD operations. An invited user doesn't exist until they accept.
+### Invitation model: WorkOS invitations → Descope user.invite()
 
-Descope's `management.user.invite()` creates a user record immediately in `"invited"` status and sends an invitation email. There is no separate invitation object to list, update, or revoke independently. To list pending invitations for a tenant, filter users by `status === "invited"`. To revoke an invitation, delete the user.
+WorkOS has a dedicated invitation system (invitation objects with their own lifecycle and IDs); an invited user is tracked as a pending invitation.
+
+Descope's `management.user.invite()` creates a user record immediately in `"invited"` status and sends an invitation email. There is no separate invitation object to list, update, or revoke independently. To list pending invitations for a tenant, filter users by `status === "invited"`. To revoke an invitation, delete the user. (Verify the WorkOS invitation API shape in use before mapping revoke/resend semantics.)
 
 ### MFA enrollment and factor management
 
-MFA enrollment is managed through Flows, not the Management SDK — there is no equivalent to Auth0 Guardian's `createEnrollmentTicket()`. Add an MFA step to a Flow in the Console; users enroll in-browser through the Flow component.
+WorkOS MFA is configured in AuthKit. In Descope, MFA enrollment is managed through Flows, not the Management SDK — add an MFA step to a Flow in the Console; users enroll in-browser through the Flow component.
 
 **Factor deletion SDK support varies by type:**
 - **Passkeys**: `descopeClient.management.user.removeAllPasskeys(loginId)` — SDK-supported
 - **TOTP (authenticator apps)**: no SDK method; deletion is Console-only (User Management → [user] → Delete TOTP Seed)
 - **SMS/OTP factors**: no documented SDK method — may require REST API calls
 
-### SCIM: HTTP API only, not in SDK
+### Directory Sync / SCIM: a lifecycle, not an import
 
-Auth0 exposes SCIM configuration via the Management SDK (`managementClient.connections.createScimConfiguration()`, etc.). Descope supports SCIM but only via the HTTP API (`https://api.descope.com/v1/mgmt/scim/*`), not the Node.js or Python SDKs. Implement with raw `fetch()` calls. Verify the request/response shapes against the current API — the endpoints are documented but not SDK-wrapped.
+WorkOS [Directory Sync](https://workos.com/docs/directory-sync) provisions users and groups from enterprise directories over SCIM, emitting `dsync.*` events. Descope supports SCIM provisioning, scoped per tenant.
+
+**Treat this as a continuing pipeline, not a one-time import** — enterprise directories keep pushing create/update/suspend/delete events after cutover, so every directory must be re-pointed at Descope before cutover or provisioning silently breaks.
+
+| WorkOS Directory Sync | Descope |
+|---|---|
+| SCIM endpoint + bearer token per directory | Descope SCIM endpoint + token per tenant |
+| Directory user create/update/deprovision | Tenant user provisioning lifecycle |
+| Directory groups | Group → role mapping in Descope |
+| `dsync.*` / directory webhooks | Descope provisioning events / connectors |
+
+Identify every directory, whether groups are synced, and whether groups map to roles. Descope SCIM is exposed via the HTTP API (`https://api.descope.com/v1/mgmt/scim/*`) where SDK coverage is thin — verify request/response shapes against the current API.
 
 ### Session refresh after profile changes
 
-Auth0's `appClient.updateSession()` lets you immediately reflect profile changes in the cached session without re-authentication. Descope has no equivalent — profile changes via the Management SDK don't update the JWT already in the browser.
+If a WorkOS app reflects profile changes immediately in the session, note that Descope has no equivalent push — profile changes via the Management SDK don't update the JWT already in the browser.
 
 To trigger an immediate client-side token refresh after a profile update:
 ```ts
@@ -253,57 +277,89 @@ The user can also wait for the next auto-refresh (default: ~5 min, driven by the
 
 **Session change event listeners** — instead of calling `refresh()` imperatively, subscribe to auth state changes via [docs.descope.com/client-sdk/auth-helpers#handling-authentication-state-changes](https://docs.descope.com/client-sdk/auth-helpers#handling-authentication-state-changes). Use event listeners when the session can change from multiple places (profile update, admin role grant, tenant assignment) and the UI needs to react consistently.
 
-**Update JWT endpoint** — for server-side custom claim updates without waiting for a client refresh: `POST /v1/mgmt/user/jwt/update`. This updates stored JWT custom claims for a specific user; it is not a session mutation and does not push an update to the browser. The user's next token refresh picks up the new claims. Verify the current endpoint behavior against Descope docs — this endpoint is less documented than the Management SDK methods.
+**Update JWT endpoint** — for server-side custom claim updates without waiting for a client refresh: `POST /v1/mgmt/user/jwt/update`. This updates stored JWT custom claims for a specific user; the user's next token refresh picks up the new claims. Verify the current endpoint behavior against Descope docs.
 
 **User Profile Widget** — if the app is building a profile edit page, the Widget handles profile updates and session refresh automatically with no custom SDK calls. See `flows-and-widgets.md` → Widgets.
 
 ### Management API mapping
 
-Auth0's [Management API](https://auth0.com/docs/api/management/v2) is REST-based, accessed with an M2M token.
+WorkOS's Management is accessed through the backend SDKs (`workos.userManagement.*`, `workos.organizations.*`, `workos.sso.*`) authenticated with `WORKOS_API_KEY`.
 
 Descope uses a Management SDK initialized with a `managementKey` ([Node SDK](https://github.com/descope/node-sdk), [Python SDK](https://github.com/descope/python-sdk), [Go SDK](https://github.com/descope/go-sdk)).
 
-| Operation | Auth0 | Descope (Node.js) |
+| Operation | WorkOS | Descope (Node.js) |
 |---|---|---|
-| Create user | `POST /api/v2/users` | `descopeClient.management.user.create(...)` ([ref](https://docs.descope.com/management/user-management/sdks)) |
-| Update user | `PATCH /api/v2/users/{id}` | `descopeClient.management.user.update(...)` |
-| Search users | `POST /api/v2/users` (with q param) | `descopeClient.management.user.search(...)` |
-| Delete user | `DELETE /api/v2/users/{id}` | `descopeClient.management.user.delete(...)` |
-| Load user | `GET /api/v2/users/{id}` | `descopeClient.management.user.load(...)` / `.loadByUserId(...)` |
-| List permissions | `GET /api/v2/resource-servers/{id}` | `descopeClient.management.permission.loadAll()` |
-| Create role | `POST /api/v2/roles` | `descopeClient.management.role.create(name, description, permissions, tenantId)` |
+| Create user | `workos.userManagement.createUser(...)` | `descopeClient.management.user.create(...)` ([ref](https://docs.descope.com/management/user-management/sdks)) |
+| Update user | `workos.userManagement.updateUser(...)` | `descopeClient.management.user.update(...)` |
+| List/search users | `workos.userManagement.listUsers(...)` | `descopeClient.management.user.search(...)` |
+| Delete user | `workos.userManagement.deleteUser(...)` | `descopeClient.management.user.delete(...)` |
+| Load user | `workos.userManagement.getUser(...)` | `descopeClient.management.user.load(...)` / `.loadByUserId(...)` |
+| Create organization | `workos.organizations.createOrganization(...)` | `descopeClient.management.tenant.create(...)` |
+| Create role | (dashboard / RBAC API) | `descopeClient.management.role.create(name, description, permissions, tenantId)` |
 
-Auth0 M2M tokens expire and must be rotated. Descope management keys are long-lived (rotatable via the Console).
+(Verify exact WorkOS method names against current docs.) Descope management keys are long-lived (rotatable via the Console).
 
-### FGA: Auth0 FGA (OpenFGA) → Descope ReBAC
+### FGA: WorkOS FGA (warrants) → Descope ReBAC
 
-Auth0 [Fine-Grained Authorization](https://fga.dev/) is built on [OpenFGA](https://openfga.dev/). Descope has its own [ReBAC](https://docs.descope.com/authorization/rebac) system with a similar model (types, relations, computed permissions) but a different API shape.
+WorkOS [Fine-Grained Authorization](https://workos.com/docs/fga) models resource types, relationships, and permissions and stores relationships as **warrants**. Descope has its own [ReBAC](https://docs.descope.com/authorization/rebac) system with a similar model (types, relations, computed permissions) but a different API shape.
 
 **Schema definition:**
 
-OpenFGA uses a YAML/JSON model with `type_definitions`. Descope uses a [DSL](https://docs.descope.com/authorization/rebac/define-schema) saved via `descopeClient.management.fga.saveSchema(schema)` ([ref](https://docs.descope.com/authorization/rebac/implement-schema)).
+WorkOS FGA defines resource types, relations, and permissions in its schema. Descope uses a [DSL](https://docs.descope.com/authorization/rebac/define-schema) saved via `descopeClient.management.fga.saveSchema(schema)` ([ref](https://docs.descope.com/authorization/rebac/implement-schema)).
+
+Descope ReBAC schema DSL syntax:
+
+```
+Syntax                             Description          Example
+---------------------------------  -------------------  ----------------------------
+type <name>                        Define a type        type user
+relation <name>: <type>            Define a relation    relation owner: user
+|                                  Union (OR) operator  user | group
+#                                  Relation reference   Group#member
+.                                  Traverse relation    parent.owner
+permission <name>: <expression>    Define a permission  permission can_edit: owner
+```
+
+Example translation:
+```
+# WorkOS FGA (resource types + relations + permissions)
+type document
+  relation owner
+  relation viewer
+  permission can_view = owner or viewer
+
+# Descope ReBAC DSL
+type document
+  relation owner: user
+  relation viewer: user
+  permission can_view: owner | viewer
+```
 
 **Operation mapping:**
 
-| Operation | Auth0 FGA (OpenFGA SDK) | Descope ReBAC (Node SDK) |
+| Operation | WorkOS FGA | Descope ReBAC (Node SDK) |
 |---|---|---|
-| Write tuple | `fgaClient.write({ writes: [{ user, relation, object }] })` | `descopeClient.management.fga.createRelations([{ resource, resourceType, relation, target, targetType }])` ([ref](https://docs.descope.com/authorization/rebac/create-relations)) |
-| Delete tuple | `fgaClient.write({ deletes: [...] })` | `descopeClient.management.fga.deleteRelations([...])` |
-| Check | `fgaClient.check({ user, relation, object })` | `descopeClient.management.fga.check([{ resource, resourceType, relation, target, targetType }])` ([ref](https://docs.descope.com/authorization/rebac/check-relations)) |
-| List objects | `fgaClient.listObjects({ user, relation, type })` | `descopeClient.management.authz.whatCanTargetAccessWithRelation(target, relation, namespace)` ([ref](https://docs.descope.com/authorization/rebac/check-relations)) |
-| Who has access | `fgaClient.listUsers({ object, relation })` | `descopeClient.management.authz.whoCanAccess(resource, relation, namespace)` |
+| Write relation | `fga.writeWarrant({ ... })` | `descopeClient.management.fga.createRelations([{ resource, resourceType, relation, target, targetType }])` ([ref](https://docs.descope.com/authorization/rebac/create-relations)) |
+| Delete relation | `fga.writeWarrant({ op: 'delete', ... })` | `descopeClient.management.fga.deleteRelations([...])` |
+| Check | `fga.check({ ... })` | `descopeClient.management.fga.check([{ resource, resourceType, relation, target, targetType }])` ([ref](https://docs.descope.com/authorization/rebac/check-relations)) |
+| Who has access | (FGA query) | `descopeClient.management.authz.whoCanAccess(resource, relation, namespace)` |
 
 **Key differences:**
-- OpenFGA tuples use `user`/`relation`/`object` (e.g., `user:alice`, `owner`, `doc:123`). Descope uses `target`/`targetType`/`relation`/`resource`/`resourceType`.
-- OpenFGA's `buildOpenFgaClient()` (from `@auth0/ai`) uses separate FGA credentials (`FGA_STORE_ID`, `FGA_CLIENT_ID`, `FGA_CLIENT_SECRET`, `FGA_API_URL`). Descope ReBAC uses the same `DESCOPE_PROJECT_ID` + `DESCOPE_MANAGEMENT_KEY`.
-- Auth0 FGA runs as a hosted OpenFGA instance. Descope ReBAC is integrated into the Descope platform.
-- The `@auth0/ai-langchain` package provides `FGARetriever` that wraps a LangChain retriever with FGA batch-check filtering. No Descope equivalent exists. Build a custom retriever that calls `descopeClient.management.fga.check()` for each candidate document.
+- WorkOS warrants use `subject`/`relation`/`resource`. Descope uses `target`/`targetType`/`relation`/`resource`/`resourceType`.
+- WorkOS FGA uses the same `WORKOS_API_KEY`. Descope ReBAC uses `DESCOPE_PROJECT_ID` + `DESCOPE_MANAGEMENT_KEY`.
+- The model translation requires a dedicated review — confirm resources, relationships/privileges, where checks run, and any hierarchical inheritance. (Verify exact WorkOS and Descope shapes against current docs.) **Effort: High.**
 
-### Token Vault / Connected Accounts → Descope Outbound Apps
+### Pipes → Descope Outbound Apps
 
-Auth0's [Token Vault](https://auth0.com/docs/secure/tokens/token-vault) stores third-party OAuth tokens (Google, GitHub, Slack) and exchanges them on demand. The `@auth0/ai-langchain` package wraps this with `withTokenVault()` for LangGraph tools. The `@auth0/nextjs-auth0` SDK's `enableConnectAccountEndpoint` auto-mounts `/auth/connect` for linking accounts.
+WorkOS **Pipes** store third-party OAuth tokens (Google, Slack, GitHub, etc.) for connected accounts and refresh them on demand. Descope's equivalent is [Outbound Apps](https://docs.descope.com/identity-federation/outbound-apps), which store third-party OAuth tokens and static API keys.
 
-Descope's equivalent: [Outbound Apps](https://docs.descope.com/identity-federation/outbound-apps). These store third-party OAuth tokens and static API keys. Tokens are retrieved via the Management API:
+Users connect accounts client-side:
+```
+sdk.outbound.connect(appId, { redirectURL, scopes })
+```
+([ref](https://docs.descope.com/identity-federation/outbound-apps/connect))
+
+Tokens are retrieved via the Management API:
 
 ```
 # Fetch token with specific scopes
@@ -317,112 +373,65 @@ Body: { "appId": "google-calendar", "userId": "U2abc..." }
 ```
 ([ref](https://docs.descope.com/identity-federation/outbound-apps/using-outbound-apps#fetching-outbound-apps-tokens))
 
-Users connect accounts via `sdk.outbound.connect(appId, { redirectURL, scopes })` on the client side ([ref](https://docs.descope.com/identity-federation/outbound-apps/connect)).
+Ask which providers are connected, where tokens are used (including AI agents and background jobs), and whether users must reconnect accounts or tokens can be migrated. AI-agent token storage maps to Outbound Apps; if the app uses WorkOS for MCP authorization, flag it for dedicated review (it may map to Descope Inbound Apps / OAuth app patterns) before generating any implementation code.
 
-**Key differences:**
-- Auth0 wraps token exchange into LangGraph tools via `@auth0/ai-langchain` with interrupt-based consent UI. Descope has no AI-framework SDK. You call the Outbound Apps API directly from your tool function.
-- Auth0's Token Vault uses `subjectTokenType` for federated token exchange. Descope's API uses `appId` + `userId` lookup.
-- Auth0's connected account management is scoped to `https://DOMAIN/me/` audience. Descope's is part of the Management API.
+### User migration: WorkOS export → Descope import
 
-### CIBA / Rich Authorization Requests (no Descope equivalent)
+WorkOS users don't automatically carry over. For production apps with existing users, this is a critical migration step.
 
-Auth0 supports [CIBA](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow) (Client-Initiated Backchannel Authentication) for async authorization. The agent sends a push notification to the user's device, waits for approval, then receives a scoped token. The `@auth0/ai` SDK wraps this via `withAsyncAuthorization()`.
+Descope has [migration guides](https://docs.descope.com/migrate) with two broad approaches:
+- **Full migration:** Export all users and organizations from WorkOS, then import them into Descope using the [Create User API](https://docs.descope.com/api/management/users/create-user) or [Batch Create User API](https://docs.descope.com/api/management/users/batch-create-users). Where password hashes can be exported, Descope accepts bcrypt hashes so users keep their passwords without a reset; otherwise plan a reset/passwordless path. See the [user format JSON guide](https://docs.descope.com/migrate/custom/user-format-json) for the expected shape. **Verify WorkOS's current user-export capability before committing to a no-reset path.**
+- **Phased migration:** Roll out per tenant/batch rather than all at once.
 
-Descope does not offer CIBA or Rich Authorization Requests (RAR) as a product feature. Migrations that use `withAsyncAuthorization()` require a custom approval mechanism. One option: the agent creates a pending approval record, the frontend polls for it, and the user approves via a Descope Flow or custom UI.
+Key fields to map: WorkOS `user.id` → Descope `loginId` (or `userId`), `email`, name fields, password hash (if exportable), and any user metadata → `customAttributes`.
 
-### @auth0/ai SDK (no Descope equivalent)
+Map each WorkOS **Organization** to a Descope **Tenant** and reproduce membership and tenant-scoped roles — get this mapping right first, since it ripples into SSO, SCIM, and RBAC. **If Directory Sync is in use, re-point SCIM at Descope before cutover** — a one-time import leaves provisioning broken the moment the directory pushes its next change. Active WorkOS sessions become invalid at cutover; plan for forced re-login.
 
-Auth0 publishes [`@auth0/ai`](https://github.com/auth0/ai-sdks), [`@auth0/ai-langchain`](https://github.com/auth0/ai-sdks), and [`@auth0/ai-vercel`](https://github.com/auth0/ai-sdks). These SDKs wrap AI agent tools with:
-- Token Vault credential injection (`withTokenVault()`)
-- CIBA async authorization (`withAsyncAuthorization()`)
-- FGA-aware RAG retrieval (`FGARetriever`, `FGAFilter`)
-- Interrupt-based consent UI (`TokenVaultInterrupt`, `AccessDeniedInterrupt`)
+### M2M authentication: WorkOS API keys → Descope Access Keys
 
-Descope has no AI-framework SDKs. Descope's agentic offerings focus on [MCP server authentication](https://www.descope.com/press-release/agentic-identity-hub) (OAuth 2.1, tool-level scopes, client registration) rather than LangChain/Vercel AI tool wrapping.
-
-For migration, each `@auth0/ai` wrapper must be reimplemented:
-- `withTokenVault()` → custom wrapper calling Descope Outbound Apps API
-- `withAsyncAuthorization()` → custom approval mechanism (see CIBA section above)
-- `FGARetriever` → custom retriever calling `descopeClient.management.fga.check()` per document
-- `TokenVaultInterrupt` → custom interrupt using LangGraph's `interrupt()` + frontend consent UI calling `sdk.outbound.connect()`
-
-### Fewer network round-trips at login
-
-Auth0's [authorization code flow](https://github.com/auth0/express-openid-connect#readme) (for server-rendered apps) requires at minimum 3 round-trips: browser to backend (get auth URL), browser to Auth0 (user signs in), Auth0 to backend callback (exchange code for tokens). The Encore sample added a fourth hop between the frontend and Go backend.
-
-Descope's [web component](https://docs.descope.com/client-sdk/descope-components#descope-component) handles sign-in in one step: the component loads in the browser, the user authenticates against Descope's API, and the component sets `DS`/`DSR` cookies. No backend round-trips for the auth ceremony. The backend is contacted only for subsequent API calls that need [token validation](https://docs.descope.com/authorization/session-management/session-validation/backend).
-
-### Auth0 vs Descope flow comparison
-
-```
-Auth0 (server-rendered):
-  Browser → /login → Auth0 hosted page → /callback → code exchange → session created → redirect
-
-Auth0 (Encore two-process):
-  Browser → Next.js /auth/login → Go backend Login → Auth0 URL
-  Browser → Auth0 hosted page → Next.js /callback → Go backend Callback → token exchange → cookie set
-
-Descope (all variants):
-  Browser → /login page → Descope web component renders → user authenticates → DS/DSR cookies set → redirect
-  (Backend participates only when validating tokens on subsequent requests)
-```
-
-### User migration: Auth0 export → Descope import
-
-Auth0 users don't automatically carry over. For production apps with existing users, this is a critical migration step.
-
-Descope has a dedicated [Auth0 migration guide](https://docs.descope.com/migrate/auth0) with two approaches:
-- **Full migration:** Export all users from Auth0 (via the Auth0 Management API or Dashboard export), then import them into Descope using the [Create User API](https://docs.descope.com/api/management/users/create-user) or [Batch Create User API](https://docs.descope.com/api/management/users/batch-create-users). Descope accepts bcrypt password hashes, so users can keep their existing passwords without a reset. Export as CSV or JSON; see the [user format JSON guide](https://docs.descope.com/migrate/custom/user-format-json) for the expected shape.
-- **Hybrid migration (just-in-time):** Keep Auth0 running alongside Descope during a transition period. New logins go through Descope; existing users are migrated on first login. This avoids a big-bang cutover but requires both systems running simultaneously.
-
-Key fields to map: Auth0 `user_id` → Descope `loginId` (or `userId`), `email`, `name`, `password` (as hash), `app_metadata` → `customAttributes`, `user_metadata` → `customAttributes`.
-
-If the Auth0 app uses Organizations, map each organization's member list to Descope tenant associations during import.
-
-### M2M authentication: Auth0 client credentials → Descope Access Keys
-
-Auth0's [Client Credentials Grant](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-credentials-flow) is used for machine-to-machine auth: a backend service authenticates with `CLIENT_ID` + `CLIENT_SECRET` and receives an access token scoped to an `audience`.
+WorkOS uses API keys (and client-credentials-style machine auth) for service-to-service calls.
 
 Descope's equivalent is [Access Keys](https://docs.descope.com/management/m2m-access-keys). An access key is exchanged for a JWT, which is then validated by the receiving service the same way a user session token is validated. Access keys can be scoped to tenants and roles, and can have IP restrictions and expiration times.
 
-| Auth0 | Descope |
+| WorkOS | Descope |
 |---|---|
-| Create M2M app in Dashboard | Create Access Key in Console → [Access Keys tab](https://app.descope.com/accessKeys) |
-| `CLIENT_ID` + `CLIENT_SECRET` | Access Key ID + Secret (returned once at creation) |
-| `POST /oauth/token` with `grant_type=client_credentials` | `descopeClient.auth.exchangeAccessKey(accessKey)` ([ref](https://docs.descope.com/management/m2m-access-keys)) |
-| Token scoped to `audience` | JWT with tenant/role claims (configure via Access Key settings) |
-| Token validated via `express-jwt` / JWKS | Token validated via `descopeClient.validateSession()` — same as user tokens |
+| Create API key in dashboard | Create Access Key in Console → [Access Keys tab](https://app.descope.com/accessKeys) |
+| API key secret | Access Key ID + Secret (returned once at creation) |
+| Authenticate machine call with API key | `descopeClient.auth.exchangeAccessKey(accessKey)` ([ref](https://docs.descope.com/management/m2m-access-keys)) |
+| Token validated server-side | Token validated via `descopeClient.validateSession()` — same as user tokens |
 
 Access keys can also be created programmatically via `descopeClient.management.accessKey.create()`.
 
-### Email templates: Auth0 → Descope messaging templates
+### Email templates: WorkOS → Descope messaging templates
 
-Auth0 email templates (verification, password reset, invitation, blocked account) are configured in the Auth0 Dashboard under Branding → Email Templates.
+WorkOS email/branding (verification, magic auth, invitations) is configured in the WorkOS dashboard / AuthKit branding.
 
 Descope uses [Messaging Templates](https://docs.descope.com/management/messaging-templates) configured per authentication method. Templates support HTML and dynamic content via `{{}}` placeholders.
 
-| Email type | Auth0 location | Descope location |
+| Email type | WorkOS location | Descope location |
 |---|---|---|
-| Magic Link / OTP | Dashboard → Branding → Email Templates | Console → Settings → Authentication Methods → [Magic Link](https://docs.descope.com/auth-methods/magic-link/settings) or OTP → select connector → + New Template |
-| Password Reset | Dashboard → Branding → Email Templates | Console → Settings → Authentication Methods → [Passwords](https://docs.descope.com/auth-methods/passwords/settings) → Reset Password Email |
-| User Invitation | Dashboard → Branding → Email Templates | Console → [Project Settings → Sign Ups and User Invitations](https://docs.descope.com/management/project-settings#general-settings) → select connector → + New Template |
-| Verification | Dashboard → Branding → Email Templates | Handled within Flows (email verification is a Flow step, not a standalone email) |
+| Magic Link / OTP | AuthKit branding / email settings | Console → Settings → Authentication Methods → [Magic Link](https://docs.descope.com/auth-methods/magic-link/settings) or OTP → select connector → + New Template |
+| Password Reset | AuthKit email settings | Console → Settings → Authentication Methods → [Passwords](https://docs.descope.com/auth-methods/passwords/settings) → Reset Password Email |
+| User Invitation | AuthKit / dashboard | Console → [Project Settings → Sign Ups and User Invitations](https://docs.descope.com/management/project-settings#general-settings) → select connector → + New Template |
+| Verification | AuthKit email settings | Handled within Flows (email verification is a Flow step, not a standalone email) |
 
 Descope also supports SMS and voice templates for OTP delivery, configured the same way via messaging connectors.
 
-### Webhooks / event streams: Auth0 Log Streams → Descope Audit Webhook
+### Webhooks / Audit Logs: WorkOS → Descope Audit Webhook
 
-Auth0 [Log Streams](https://auth0.com/docs/customize/log-streams) forward authentication events (login, failed login, signup, password change, etc.) to external services like Datadog, Splunk, or a custom webhook.
+WorkOS [Audit Logs](https://workos.com/docs/audit-logs) and [webhooks](https://workos.com/docs/events) forward events (`user.created`, `organization.*`, `dsync.*`, etc.) to external services or your own endpoint with a signing secret.
 
-Descope's equivalent is the [Audit Webhook Connector](https://docs.descope.com/connectors/connector-configuration-guides/network/audit-webhook). It streams audit events to your own HTTP endpoint. Configure it in the Console under Connectors → Audit Webhook with a base URL and authentication (Bearer, API Key, or Basic Auth).
+| WorkOS | Descope |
+|---|---|
+| Webhook endpoint + signing secret | Descope webhook/connector + signature validation |
+| `user.created` / `organization.*` / `dsync.*` events | Corresponding Descope events / connector triggers |
+| Audit Logs (compliance) | [Audit Webhook Connector](https://docs.descope.com/connectors/connector-configuration-guides/network/audit-webhook) |
 
-Descope also has a built-in [Audit Trail](https://docs.descope.com/audit) in the Console for viewing events, and supports streaming to third-party services via connectors.
-
-For Auth0 apps that rely on Log Streams for compliance or monitoring, set up the Audit Webhook Connector before cutover to avoid gaps in event logging.
+Descope's [Audit Webhook Connector](https://docs.descope.com/connectors/connector-configuration-guides/network/audit-webhook) streams audit events to your HTTP endpoint (Bearer, API Key, or Basic Auth). Descope also has a built-in [Audit Trail](https://docs.descope.com/audit) in the Console and supports streaming to third-party services via connectors. Search the codebase for webhook handlers; update event names, signature/validation logic, and payload handling. For apps that rely on WorkOS events/audit logs for compliance or monitoring, set up Descope audit/event forwarding **before** cutover to avoid gaps.
 
 ### Custom domains
 
-Auth0 supports [custom domains](https://auth0.com/docs/customize/custom-domains) so the login page appears on your own domain instead of `your-tenant.auth0.com`.
+WorkOS supports custom domains and domain verification so login appears on your own domain (and so enterprise SSO can be discovered by email domain).
 
 Descope supports [custom domains](https://docs.descope.com/how-to-deploy-to-production/custom-domain) as well:
 1. Create a CNAME record (e.g. `auth.example.com`) pointing to `cname.descope.com` (US) or `CNAME.euc1.descope.com` (EU).
@@ -430,22 +439,37 @@ Descope supports [custom domains](https://docs.descope.com/how-to-deploy-to-prod
 3. Add and verify the custom domain in Console.
 4. Pass the custom domain as `baseUrl` to the Descope SDK/component: `<AuthProvider projectId="..." baseUrl="https://auth.example.com">`.
 
-If the Auth0 app uses a custom domain, plan this before cutover so cookies and redirects work correctly on the production domain.
+Domain verification also drives tenant/domain routing — important for enterprise SSO discovery (routing a user to the right tenant's SSO connection by email domain). Plan this before cutover so cookies and redirects work correctly on the production domain.
 
-### Attack protection: Auth0 Attack Protection → Descope Flow-based security
+### Radar → Descope Flow-based security
 
-Auth0's [Attack Protection](https://auth0.com/docs/secure/attack-protection) includes bot detection, brute force protection, breached password detection, and suspicious IP throttling as built-in toggles.
+**Mechanism difference (read this first):** WorkOS [Radar](https://workos.com/docs/radar) is a dashboard toggle layered on top of AuthKit — it collects device-fingerprint signals and *automatically* blocks / challenges / notifies based on the actions you enable, with no app code. Descope has **no single equivalent toggle**. Instead you reproduce Radar's behavior by adding Descope's built-in fingerprinting/risk signals to your [Flow](https://docs.descope.com/flows) and branching on them. So "configuring Radar" becomes "designing the Flow."
 
-Descope handles these through [Flows](https://docs.descope.com/flows) and security connectors, giving more granular control but requiring explicit configuration:
+Descope surfaces risk signals as `riskInfo` inside a Flow. `riskInfo.botDetected` and `riskInfo.riskScore` require adding a **Fingerprint / Assess** action immediately after the login/signup screen; `riskInfo.impossibleTravel` and `riskInfo.trustedDevice` do not. For stronger detection, layer in fraud/CAPTCHA connectors (reCAPTCHA Enterprise, Turnstile, Telesign, Fingerprint, Forter, Sardine).
 
-| Auth0 feature | Descope equivalent |
-|---|---|
-| Bot Detection | Flow step using [Arkose Bot Manager connector](https://www.descope.com/blog/post/arkose-labs-connector), [Google reCAPTCHA Enterprise](https://docs.descope.com/connectors), or [Fingerprint](https://docs.descope.com/connectors) |
-| Brute Force Protection | Flow conditional logic + connector-based risk signals; rate limiting on Descope's infrastructure |
-| Breached Password Detection | [Have I Been Pwned integration](https://docs.descope.com/connectors) — blocks credentials found in known breaches |
-| Suspicious IP Throttling | Flow step using [AbuseIPDB connector](https://docs.descope.com/connectors) or IP-based conditional logic |
+| Radar action | What it does in WorkOS | Descope equivalent |
+|---|---|---|
+| **Block** | Auth fails even with valid credentials | Flow conditional after Fingerprint Assess: on high `riskInfo.riskScore` / `riskInfo.botDetected`, branch to a deny/failure screen and end the Flow without issuing a session |
+| **Challenge** | Sends an email/SMS OTP step-up | Risk-based step-up in the Flow: branch the high-risk path into an OTP/MFA step or a CAPTCHA connector before continuing |
+| **Notify** | Sends an informational email; sign-in still proceeds | On the risk branch, fire an email/messaging connector or an outbound webhook (or rely on Descope audit events) to alert the user/admin while letting the Flow continue |
 
-Auth0's attack protection is toggle-based (on/off in Dashboard). Descope's is composable — you add detection steps to your Flow and configure the response (block, challenge with MFA, allow with logging). More powerful but not configured by default.
+**Detection mapping** (verify current signal names against docs):
+- Bot detection → `riskInfo.botDetected` (needs Fingerprint Assess) + CAPTCHA connectors
+- Impossible travel → `riskInfo.impossibleTravel`
+- Unrecognized device → `riskInfo.trustedDevice` (invert: untrusted = unrecognized)
+- Brute force / repeat sign-up / stale accounts / managed lists / custom allow-deny → no single built-in signal; reproduce via `riskInfo.riskScore` thresholds, connectors, or custom Flow conditions
+
+Radar is toggle-based in WorkOS. Descope's is composable — you add detection steps to your Flow and configure the response (block, challenge with MFA, allow with logging). More powerful but not configured by default; the decisioning must be *rebuilt* in the Flow.
+
+### Admin Portal → SSO Setup Suite / Widgets
+
+WorkOS [Admin Portal](https://workos.com/docs/admin-portal) is a hosted self-serve UI where customer IT admins configure SSO, Directory Sync, and domain verification. Do not default to rebuilding it as custom code.
+
+- Generated portal links (`portal.generateLink(...)`) → SSO Setup Suite hosted/embedded flow or Tenant Profile Widget
+- SSO setup screens → SSO Setup Suite
+- Directory Sync / domain setup → corresponding Widgets
+
+Ask which admin workflows are hosted by WorkOS today before choosing a replacement. WorkOS Widgets (org switching, Directory Sync setup, SSO setup, domain verification, audit log streaming, API keys) should each be evaluated against Descope [Widgets](https://docs.descope.com/widgets) — if a Widget covers the workflow, prefer it over custom code. See `flows-and-widgets.md` → Widgets and SSO Setup Suite.
 
 ### Testing checklist (applies to all samples)
 
@@ -466,55 +490,15 @@ After migrating, verify:
 
 ---
 
-## Express.js
-
-
-**Changes:**
-- Removed [`express-openid-connect`](https://github.com/auth0/express-openid-connect). Added [`@descope/node-sdk`](https://github.com/descope/node-sdk) and `cookie-parser`.
-- Replaced `app.use(auth(config))` with custom middleware (~20 lines) that validates the `DS` cookie via [`validateSession()`](https://docs.descope.com/getting-started/nodejs#implement-session-validation).
-- Added `/login` route rendering an EJS page with [`<descope-wc>`](https://docs.descope.com/client-sdk/descope-components#descope-component).
-- Logout changed from GET redirect to Auth0's `/v2/logout` to POST calling [`descopeClient.logout()`](https://docs.descope.com/authorization/session-management/session-validation/backend#logout-current-session-using-backend-sdk) + cookie clearing.
-- `requiresAuth()` is a custom 3-line function instead of an [Auth0 SDK import](https://github.com/auth0/express-openid-connect#readme).
-
-**Notes:**
-- `express-openid-connect` auto-configured `baseURL` from env vars and handled CSRF for the callback. Descope needs none of that since there's no server-side OAuth flow.
-- Auth0's `req.oidc.user` comes from ID token claims. Descope's `authInfo.token` after [`validateSession()`](https://docs.descope.com/authorization/session-management/session-validation/backend#validate-session) holds decoded JWT claims of the session token.
-
-**Limitation:**
-- The Descope web component requires JavaScript. Auth0's redirect flow worked without client-side JS. For JS-free auth, use [Descope as an OIDC provider](https://docs.descope.com/getting-started/oidc-endpoints) and implement the redirect flow manually.
-
----
-
-## Flask / Python
-
-
-**Changes:**
-- Removed [`authlib`](https://docs.authlib.org/en/latest/client/flask.html); added [`descope`](https://github.com/descope/python-sdk).
-- Removed OAuth client registration (`oauth.register("auth0", ...)`) and redirect-based flow code.
-- Removed `/callback` route. No code exchange needed.
-- `/login` renders a template with the [Descope web component](https://docs.descope.com/client-sdk/descope-components#descope-component) instead of calling `oauth.auth0.authorize_redirect()`.
-- `/logout` changed from redirect to Auth0's `/v2/logout?returnTo=...&client_id=...` to [`descope_client.logout(refresh_token)`](https://docs.descope.com/authorization/session-management/session-validation/backend#logout-current-session-using-backend-sdk) + cookie deletion.
-- Home route reads `DS` cookie from `request.cookies`, validates with [`descope_client.validate_session()`](https://docs.descope.com/getting-started/python#implement-session-validation).
-
-**Notes:**
-- Auth0's authlib integration stores the full token response (`access_token`, `id_token`, `userinfo`) in Flask's server-side `session` ([authlib Flask OAuth docs](https://docs.authlib.org/en/latest/client/flask.html)). Descope doesn't use Flask sessions. State lives in client-side cookies. You can drop `session` from Flask imports; `APP_SECRET_KEY` becomes optional.
-- `validate_session` returns a dict-like object. JWT standard claims (`sub`, `name`, `email`) are present. Custom claims from [Descope's JWT Templates](https://docs.descope.com/management/jwt-templates) also appear here.
-- The `descope` Python SDK requires Python 3.7+. `authlib` supported older versions.
-
-**Limitation:**
-- Descope's Python SDK docs don't detail `validate_session()`'s return type beyond "jwt_response." It's a dict with JWT claims in practice, but official type annotations lag behind. Ref: [Descope Python SDK](https://github.com/descope/python-sdk), [Python quickstart](https://docs.descope.com/getting-started/python).
-
----
-
 ## Next.js (standalone)
 
 
 **Changes:**
-- [`@auth0/nextjs-auth0`](https://github.com/auth0/nextjs-auth0) → [`@descope/nextjs-sdk`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk).
-- `UserProvider` → [`AuthProvider`](https://docs.descope.com/client-sdk/descope-components#auth-provider) (takes `projectId` prop; Auth0's reads from env vars automatically).
-- `useUser()` → [`useSession()`](https://docs.descope.com/client-sdk/auth-helpers#booleans) + [`useUser()`](https://docs.descope.com/client-sdk/auth-helpers#core-sdk-functions) (Auth0 combines these; Descope separates session state from user data).
-- Removed `pages/api/auth/[...auth0].tsx` catch-all route. In [Auth0 v4 this became automatic middleware](https://github.com/auth0/nextjs-auth0/blob/main/V4_MIGRATION_GUIDE.md), but with Descope there's no server-side OIDC handling at all.
-- Added `pages/login.tsx` with [`<Descope>` component](https://docs.descope.com/client-sdk/descope-components#descope-component) rendering the `sign-up-or-in` flow.
+- [`authkit-nextjs`](https://github.com/workos/authkit-nextjs) → [`@descope/nextjs-sdk`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk).
+- AuthKit `<AuthKitProvider>` → [`AuthProvider`](https://docs.descope.com/client-sdk/descope-components#auth-provider) (takes `projectId` prop with the `NEXT_PUBLIC_` prefix).
+- `useAuth()` (user/session/loading combined) → [`useSession()`](https://docs.descope.com/client-sdk/auth-helpers#booleans) + [`useUser()`](https://docs.descope.com/client-sdk/auth-helpers#core-sdk-functions) (Descope separates session state from user data).
+- Removed the AuthKit callback route — Descope has no server-side OIDC handling; verify the client-side replacement.
+- Added `pages/login.tsx` with the [`<Descope>` component](https://docs.descope.com/client-sdk/descope-components#descope-component) rendering the `sign-up-or-in` flow.
   - **`onSuccess` is required for redirect** — the component does not auto-navigate after login. Without it, the user finishes auth and stays on the login page:
     ```tsx
     const router = useRouter()
@@ -524,17 +508,16 @@ After migrating, verify:
       onError={(e) => console.error(e)}
     />
     ```
-- `withPageAuthRequired` (client) replaced by manual `useSession()` check + redirect to `/login`. Auth0 v4 [deprecated `withPageAuthRequired`](https://github.com/auth0/nextjs-auth0/blob/main/V4_MIGRATION_GUIDE.md) in favor of `getSession()` anyway.
-- `withApiAuthRequired` replaced by server-side `session()` + manual 401 response. Descope's Next.js SDK exposes [`session()`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#server-side) for this.
-- Logout changed from `<a href="/api/auth/logout">` to a button calling [`sdk.logout()`](https://docs.descope.com/client-sdk/auth-helpers#logout) via [`useDescope()`](https://docs.descope.com/client-sdk/auth-helpers#core-sdk-functions).
+- `withAuth()` route protection (client) replaced by manual `useSession()` check + redirect to `/login`.
+- Server-side protection replaced by [`session()`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#server-side) + manual 401 response.
+- `authkitMiddleware()` → Descope [`authMiddleware()`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#middleware).
+- Logout changed from the AuthKit logout route to a button calling [`sdk.logout()`](https://docs.descope.com/client-sdk/auth-helpers#logout) via [`useDescope()`](https://docs.descope.com/client-sdk/auth-helpers#core-sdk-functions) + cookie clearing (two-step).
 
 **Notes:**
-- Auth0 provides `withPageAuthRequired` as both a client-side HOC and a `getServerSideProps` wrapper. Descope's Next.js SDK has no equivalent HOC. You check `isAuthenticated` from `useSession()` and redirect yourself. More verbose, more explicit.
+- AuthKit's `withAuth()` works on both server and client. Descope splits this: check `isAuthenticated` from `useSession()` in client components and redirect yourself; use `session()` server-side. More verbose, more explicit.
 - `NEXT_PUBLIC_` prefix is required on the project ID because [`AuthProvider`](https://docs.descope.com/client-sdk/descope-components#auth-provider) runs client-side.
-- **Client vs. server session access:** `session()` from `@descope/nextjs-sdk/server` is for server components, server actions, and API routes **only**. In React client components, use `useSession()` + `useUser()` from `@descope/nextjs-sdk/client`. Using `session()` in a client component compiles but throws at runtime (attempts to read cookies in a browser context). Scan for this pattern before finishing any Next.js migration.
-- Both CSR and SSR protected pages are preserved: client-side uses `useSession()`, server-side uses `session()` from the [Next.js SDK server helpers](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#server-side).
-- Auth0's `withApiAuthRequired` wraps the handler. Descope: call `session()` at handler top, return 401 yourself.
-- `User` interface: removed `nickname`, `email_verified`, `updated_at`; `sub` → `userId`.
+- **Client vs. server session access:** `session()` from `@descope/nextjs-sdk/server` is for server components, server actions, and API routes **only**. In React client components, use `useSession()` + `useUser()` from `@descope/nextjs-sdk/client`. Using `session()` in a client component compiles but throws at runtime (attempts to read cookies in a browser context). **Never hand-decode the session token in client code** — always read auth state through the hooks. Scan for this pattern before finishing any Next.js migration.
+- `User` interface: map WorkOS `user.id` → `userId`; profile fields (`email`, `firstName`/`lastName`, `profilePictureUrl`) come from the JWT Template / `useUser()`, not the raw token.
 
 ---
 
@@ -562,7 +545,7 @@ const session = await getServerSession()
 - **`session(config?)`** — reads the session from request headers/cookies in a Next.js server component or server action. No arguments required. Returns `AuthenticationInfo | undefined`.
 - **`getSession(req, config?)`** — reads from an explicit `NextApiRequest` object. Intended for API routes only.
 
-The correct replacement for the Auth0 `getServerSideSession()` pattern (server component, no req argument) is `session`, not `getServerSession`. The name was invented by analogy, not verified.
+The correct replacement for a server-component session read (no req argument) is `session`, not `getServerSession`. The name was invented by analogy, not verified.
 
 **Fix:** Verify exports before writing any import. For this SDK:
 ```ts
@@ -578,7 +561,7 @@ import { session as sdkSession } from "@descope/nextjs-sdk/server"
 
 ### Bug 2: Return type is `AuthenticationInfo`, not an `{isAuthenticated, claims, token}` shape
 
-The migration generated a `DescopeSession` interface shaped like Auth0's session object:
+The migration generated a `DescopeSession` interface shaped like the WorkOS `withAuth()` session object:
 ```ts
 interface DescopeSession {
   isAuthenticated: boolean   // ← does not exist
@@ -602,7 +585,7 @@ interface AuthenticationInfo {
 ```
 
 Key mismatches:
-- `isAuthenticated` — not present. `undefined` return means unauthenticated; a non-null object means authenticated.
+- `isAuthenticated` — not present. `undefined` return means unauthenticated; a non-null object means authenticated. (WorkOS's `withAuth()` exposes a boolean-ish shape; Descope does not.)
 - `claims` — not present. Decoded claims are on `token`.
 - `token` (as JWT string) — not present as `token`; the raw JWT is `jwt`.
 
@@ -681,7 +664,7 @@ This affected 20+ call sites across the project. The migration generated none of
 ### Summary: what to verify before generating Next.js + `@descope/nextjs-sdk` code
 
 1. **Export names:** Resolve `node_modules/@descope/nextjs-sdk/dist/types/server/*.d.ts` and confirm the exact function names before writing any import.
-2. **Return type:** `session()` returns `AuthenticationInfo | undefined` from `@descope/node-sdk`, not a boolean-flagged Auth0-style session object.
+2. **Return type:** `session()` returns `AuthenticationInfo | undefined` from `@descope/node-sdk`, not a boolean-flagged WorkOS-style session object.
 3. **isAuthenticated:** Does not exist on `AuthenticationInfo`. Unauthenticated = `undefined`; authenticated = non-null object.
 4. **claims vs token:** Decoded JWT claims are under `.token` (a `Token` object), not `.claims`. Raw JWT string is under `.jwt`.
 5. **Next.js version:** Check `package.json` for Next.js ≥ 15. If so, `cookies()` and `headers()` from `next/headers` are async — all consumers must be async.
@@ -693,142 +676,43 @@ This affected 20+ call sites across the project. The migration generated none of
 
 
 **Changes:**
-- [`@auth0/nextjs-auth0`](https://github.com/auth0/nextjs-auth0) v4 → [`@descope/nextjs-sdk`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk) + [`@descope/node-sdk`](https://github.com/descope/node-sdk) (two packages: client SDK for Next.js, node SDK for the API server).
-- `Auth0Client` from `@auth0/nextjs-auth0/server` → singleton `getDescopeClient()` using `@descope/node-sdk`.
-- Removed Auth0's catch-all middleware that [auto-handled `/auth/*` routes in v4](https://github.com/auth0/nextjs-auth0/blob/main/V4_MIGRATION_GUIDE.md). Replaced with Next.js middleware using Descope's [`authMiddleware()`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#middleware) to check the `DS` cookie and redirect unauthenticated users.
-- Express API server (`api-server.js`): replaced [`express-jwt`](https://github.com/auth0/express-jwt) + [`jwks-rsa`](https://github.com/auth0/node-jwks-rsa) with `@descope/node-sdk` [`validateSession()`](https://docs.descope.com/authorization/session-management/session-validation/backend#validate-session).
-- Added `/login` page with [`<Descope>` React component](https://docs.descope.com/client-sdk/descope-components#descope-component).
+- [`authkit-nextjs`](https://github.com/workos/authkit-nextjs) → [`@descope/nextjs-sdk`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk) (frontend) + [`@descope/node-sdk`](https://github.com/descope/node-sdk) (API server).
+- WorkOS backend client (`@workos-inc/node`) → singleton `getDescopeClient()` using `@descope/node-sdk`.
+- Removed AuthKit's middleware-handled `/auth/*` routes. Replaced with Next.js middleware using Descope's [`authMiddleware()`](https://github.com/descope/descope-js/tree/main/packages/sdks/nextjs-sdk#middleware) to check the `DS` cookie and redirect unauthenticated users.
+- Express API server (`api-server.js`): replaced WorkOS token validation (`express-jwt` + `jwks-rsa` against WorkOS JWKS) with `@descope/node-sdk` [`validateSession()`](https://docs.descope.com/authorization/session-management/session-validation/backend#validate-session).
+- Added `/login` page with the [`<Descope>` React component](https://docs.descope.com/client-sdk/descope-components#descope-component).
 
-**Access token proxying changes:**
-Auth0's `auth0.getAccessToken()` returns a separate access token (scoped to `AUTH0_AUDIENCE`) passed to the external API as a Bearer token. The API server validates it against Auth0's JWKS endpoint via [`express-jwt`](https://github.com/auth0/express-jwt).
+**Token proxying changes:**
+WorkOS's `getAccessToken()` returns an access token (distinct from the sealed session) passed to the external API as a Bearer token, validated against WorkOS's JWKS.
 
 Descope has no separate access token. The session token (DS cookie) is the token you pass to the API server. The Next.js API route reads `DS` from cookies and forwards it as `Authorization: Bearer <DS>`. The API server validates it with `descopeClient.validateSession(token)`.
 
-`AUTH0_AUDIENCE` and `AUTH0_SCOPE` env vars disappear. For audience validation with Descope, configure a custom `aud` claim in the Descope Console's [JWT Templates](https://docs.descope.com/management/jwt-templates) and pass the `audience` parameter to [`validateSession()`](https://docs.descope.com/getting-started/nodejs#implement-session-validation).
+For audience validation with Descope, configure a custom `aud` claim in the Descope Console's [JWT Templates](https://docs.descope.com/management/jwt-templates) and pass the `audience` parameter to [`validateSession()`](https://docs.descope.com/getting-started/nodejs#implement-session-validation).
 
 **Notes:**
-- Auth0 v4's `Auth0Client` manages OIDC discovery, token caching, and session cookies. Descope's `DescopeClient` validates JWTs against [cached public keys](https://docs.descope.com/authorization/session-management/session-validation/backend/offline-jwt-validation). The frontend ([Descope Flows](https://docs.descope.com/flows)) handles what `Auth0Client` used to do.
-- [`jwks-rsa`](https://github.com/auth0/node-jwks-rsa) fetches and caches JWKS from Auth0's `/.well-known/jwks.json`. Descope's Node SDK does the same from `https://api.descope.com/v2/keys/<project_id>` ([ref](https://docs.descope.com/authorization/session-management/session-validation/backend/offline-jwt-validation#finding-your-public-key)). No configuration needed.
+- AuthKit manages OIDC discovery, token caching, and sealed session cookies. Descope's `DescopeClient` validates JWTs against [cached public keys](https://docs.descope.com/authorization/session-management/session-validation/backend/offline-jwt-validation). The frontend ([Descope Flows](https://docs.descope.com/flows)) handles what AuthKit used to do.
+- `jwks-rsa` fetches and caches JWKS from WorkOS's `/.well-known/jwks.json`. Descope's Node SDK does the same from `https://api.descope.com/v2/keys/<project_id>` ([ref](https://docs.descope.com/authorization/session-management/session-validation/backend/offline-jwt-validation#finding-your-public-key)). No configuration needed.
 - Removing `express-jwt` + `jwks-rsa` cuts 2 dependencies and ~15 lines of JWKS config. The Descope replacement is ~15 lines of middleware calling `validateSession()`.
 
 **Limitation:**
-- The original API server validated the `audience` claim (ensuring the token targeted this API). Descope's `validateSession()` checks signature and expiry but skips audience by default. To replicate: (1) configure `aud` in [Descope's JWT Templates](https://docs.descope.com/management/jwt-templates), (2) pass `audience` to `validateSession()` ([Node SDK docs](https://docs.descope.com/getting-started/nodejs#implement-session-validation)). Easy to miss during migration.
+- If the original API server validated the `audience` claim, replicate it: (1) configure `aud` in [Descope's JWT Templates](https://docs.descope.com/management/jwt-templates), (2) pass `audience` to `validateSession()` ([Node SDK docs](https://docs.descope.com/getting-started/nodejs#implement-session-validation)). Descope's `validateSession()` checks signature and expiry but skips audience by default. Easy to miss during migration.
 
 ---
 
-## Go + Encore
+## Go
 
 
 **Changes:**
-- Backend gutted: 4 auth endpoints (Login, Callback, Logout, AuthHandler) at ~150 lines of Go → 1 endpoint (AuthHandler, ~25 lines) validating DS session tokens with the [Descope Go SDK](https://github.com/descope/go-sdk).
-- Removed `backend/auth/authenticator.go` (OIDC provider setup via [`go-oidc`](https://github.com/coreos/go-oidc), OAuth2 config, code exchange). Not needed.
-- Frontend removed 3 API routes (`/auth/login`, `/auth/logout`, `/callback`). Replaced with `/login` page containing [`<Descope>` component](https://docs.descope.com/client-sdk/descope-components#descope-component) and client-side `LogoutButton` using [`useDescope().logout()`](https://docs.descope.com/client-sdk/auth-helpers#logout).
-- `getRequestClient.ts` reads `DS` cookie instead of custom `auth-token` cookie.
-- Generated Encore client (`client.ts`) simplified: auth service methods (Login, Logout, Callback) removed since those backend endpoints are gone.
-
-**Two-process architecture:**
-The original split auth between Go backend (OIDC/code exchange/token verification) and Next.js frontend (redirect orchestration). With Descope, auth is client-side. The Go backend validates tokens only. The split is cleaner: backend is a pure API, frontend owns auth UX.
-
-Cookie name changed from `auth-token` (custom, set by callback route) to `DS` (Descope standard). `getRequestClient.ts` extracts this and passes it as Bearer token in the `Authorization` header. Encore's [`//encore:authhandler`](https://encore.dev/docs/go/primitives/defining-apis#access-controls) intercepts it.
+- WorkOS Go SDK ([`workos-go`](https://github.com/workos/workos-go)) → [Descope Go SDK](https://github.com/descope/go-sdk).
+- Server-side auth endpoints that handled the AuthKit redirect/callback code exchange collapse to a single handler that validates `DS` session tokens.
+- Frontend removes the AuthKit redirect/login/callback routes. Replaced with a `/login` page containing the [`<Descope>` component](https://docs.descope.com/client-sdk/descope-components#descope-component) and a client-side `LogoutButton` using [`useDescope().logout()`](https://docs.descope.com/client-sdk/auth-helpers#logout).
+- Request handling reads the `DS` cookie instead of a sealed WorkOS session cookie, and passes it as the Bearer token.
 
 **Notes:**
 - Go SDK constructor: `client.NewWithConfig(&client.Config{ProjectID: "..."})`. Session validation: [`descopeClient.Auth.ValidateSessionWithToken(ctx, token)`](https://docs.descope.com/getting-started/go#implement-session-validation) returns `(bool, *descope.Token, error)`. `Token.Claims` is `map[string]interface{}`. Ref: [Descope Go SDK](https://github.com/descope/go-sdk).
-- Encore's `//encore:authhandler` expects `(auth.UID, error)`. Descope's JWT `sub` claim maps to `auth.UID`. Same claim name as Auth0, different issuer.
-- `encore.cue` config: ClientID + ClientSecret + Domain + RedirectURL → ProjectID only.
-- `go.mod`: [`coreos/go-oidc/v3`](https://github.com/coreos/go-oidc) + `golang.org/x/oauth2` → [`descope/go-sdk`](https://github.com/descope/go-sdk). Fewer dependencies.
+- WorkOS `organizationId` → a Descope **tenant ID**: pass it to management calls (`descopeClient.Management.Tenant()` / user-tenant association); at request time read tenant context off the returned `*descope.Token` (`token.GetTenants()`, or the `dct` claim for the active tenant).
+- Config: WorkOS `WORKOS_API_KEY` + `WORKOS_CLIENT_ID` + `WORKOS_REDIRECT_URI` + `WORKOS_COOKIE_PASSWORD` → `DESCOPE_PROJECT_ID` only (+ `DESCOPE_MANAGEMENT_KEY` for management ops).
+- `go.mod`: `github.com/workos/workos-go` → [`github.com/descope/go-sdk`](https://github.com/descope/go-sdk). Fewer dependencies — no separate OIDC/OAuth2 libraries needed since auth is client-side.
 
 **Limitation:**
-- The Go SDK's exported type names (`client.DescopeClient`, `descope.Token`) aren't documented in Descope's official docs. The [Go quickstart](https://docs.descope.com/getting-started/go) shows usage patterns, not Go type signatures. Types in this migration are inferred from [Go SDK README](https://github.com/descope/go-sdk#readme) examples; verify against `go doc` output.
-- Encore's `//encore:service` init pattern (`initService()`) creates the Descope client at service startup. If Encore's lifecycle skips `initService`, the client won't exist. Same risk the original had with the OIDC authenticator.
-
----
-
-## Agentic AI Stacks (LangChain / LangGraph + FGA + Token Vault)
-
-
-Three sub-projects (`py-langchain`, `ts-langchain`, `ts-vercel-ai`) sharing the same architecture: a document RAG app with an AI agent that accesses third-party services (Google Calendar, Gmail, GitHub, Slack) and processes purchases.
-
-### Architecture overview
-
-| Layer | Auth0 component | Descope equivalent | Migration difficulty |
-|---|---|---|---|
-| Authentication (login/session) | `@auth0/nextjs-auth0` v4, `auth0-fastapi` | `@descope/nextjs-sdk`, Descope Python SDK + custom FastAPI JWT authorizer | Low: same patterns as the framework sections above |
-| Fine-grained authorization | Auth0 FGA (OpenFGA) via `@openfga/sdk` + `@auth0/ai` `FGARetriever` | Descope ReBAC via `management.fga.*` + custom retriever | Medium: API shape differs, no `FGARetriever` |
-| Third-party token storage | Auth0 Token Vault / Connected Accounts | Descope Outbound Apps | Medium: API differs, no AI-framework wrapper |
-| Async user approval | Auth0 CIBA via `@auth0/ai` `withAsyncAuthorization()` | No equivalent; custom implementation needed | High |
-| AI tool authorization wrappers | `@auth0/ai-langchain`, `@auth0/ai-vercel` | No equivalent; custom wrappers needed | High |
-
-### Auth0 integration points across sub-projects
-
-**py-langchain** (FastAPI + LangGraph Python):
-- `auth0-fastapi` provides `AuthConfig`, `AuthClient`, session middleware, `/api/auth/*` routes, `require_session` dependency
-- `auth0-ai` Python SDK provides `Auth0AI`, `with_token_vault()`, `with_async_authorization()`
-- `auth0-ai-langchain` provides `FGARetriever`, `get_access_token_from_token_vault()`
-- `openfga-sdk` for direct FGA tuple writes/deletes in document management
-- LangGraph receives credentials via `config["configurable"]["_credentials"]` (injected by FastAPI proxy route)
-- Frontend is a Vite React SPA; auth is cookie-based via `withCredentials: true` on axios
-
-**ts-langchain** (Next.js + LangGraph TS):
-- `@auth0/nextjs-auth0` v4 with `Auth0Client`, `enableConnectAccountEndpoint`, `getAccessToken()`, `getSession()`
-- `@auth0/ai-langchain` provides `Auth0AI`, `withTokenVault()`, `withAsyncAuthorization()`, `FGARetriever`, `getAccessTokenFromTokenVault()`
-- LangGraph custom auth handler (`auth.ts`) validates JWTs against Auth0 JWKS, attaches `getRawAccessToken()` to context
-- `langgraph-nextjs-api-passthrough` proxies requests with Auth0 access token + user object injected
-- Connected Accounts API uses `https://DOMAIN/me/v1/connected-accounts/accounts` with scoped tokens
-- Uses `AUTH0_CUSTOM_API_CLIENT_ID`/`SECRET` for Token Vault federated token exchange
-
-**ts-vercel-ai** (Next.js + Vercel AI SDK):
-- Same auth setup as ts-langchain but uses Vercel AI SDK instead of LangGraph
-- `@auth0/ai-vercel` replaces `@auth0/ai-langchain` for tool wrapping
-- Tool authorization patterns are identical; the runtime difference is Vercel AI SDK vs LangGraph
-
-### FGA schema (shared across all three)
-
-```
-type user
-type doc
-  relations
-    define owner: [user]
-    define viewer: [user, user:*]
-    define can_view: owner or viewer
-```
-
-Documents are created with `owner` relation. Sharing adds `viewer` relations. RAG retrieval filters via `can_view` check. Delete removes all relations.
-
-Descope ReBAC equivalent schema ([DSL format](https://docs.descope.com/authorization/rebac/define-schema)):
-```
-model AuthZ 1.0
-
-type user
-
-type doc
-  relation owner: user
-  relation viewer: user
-  permission can_view: owner or viewer
-```
-
-### Credential flow (all three sub-projects)
-
-```
-Frontend (browser)
-  → cookies sent with request
-    → Next.js/FastAPI middleware validates session
-      → extracts access_token + user from session
-        → injects into LangGraph config as _credentials
-          → tool reads _credentials to:
-            a) call Auth0 /userinfo (user_info tool)
-            b) exchange via Token Vault (google_calendar, gmail, github, slack tools)
-            c) get CIBA approval token (shop_online tool)
-            d) build FGA check query with user email (context_docs tool)
-```
-
-With Descope, step (a) changes to reading claims from the validated session token (no `/userinfo` call needed since claims are in the JWT). Steps (b-d) require custom implementations using Descope Outbound Apps API, a custom approval mechanism, and Descope ReBAC API respectively.
-
-### Migration strategy notes
-
-The authentication layer (login, session, middleware) follows the same patterns as the framework sections above. The complexity is in the four Auth0 product integrations layered on top.
-
-Recommended migration order:
-1. Swap auth layer first (auth0-fastapi/nextjs-auth0 to Descope SDKs). Low risk, proven patterns.
-2. Migrate FGA to Descope ReBAC. Moderate lift; the API shape changes but the capability is equivalent.
-3. Migrate Token Vault to Outbound Apps. Moderate lift; needs custom tool wrappers.
-4. Build custom CIBA replacement. Highest risk; no direct equivalent.
+- The Go SDK's exported type names (`client.DescopeClient`, `descope.Token`) aren't fully documented in Descope's official docs. The [Go quickstart](https://docs.descope.com/getting-started/go) shows usage patterns, not Go type signatures. Verify against [Go SDK README](https://github.com/descope/go-sdk#readme) examples and `go doc` output.

--- a/skills/workos-to-descope/references/implementation-nuances.md
+++ b/skills/workos-to-descope/references/implementation-nuances.md
@@ -222,7 +222,7 @@ Descope [Tenants](https://docs.descope.com/b2b#multi-tenancy) are the equivalent
 
 Key differences:
 - WorkOS: `organizationId` is a flat string. Descope: `tenants` is a nested object (`{ "tenantId": { "roles": [...], "permissions": [...] } }`); `dct` is the flat active-tenant string (the direct `organizationId` equivalent).
-- WorkOS routes by organization-scoped login. Descope routes by email domain, tenant name, or tenant-specific login URLs ([ref](https://docs.descope.com/sso/multi-sso)).
+- WorkOS routes by organization-scoped login. Descope uses **tenant routing** (home realm discovery) in two main ways: **domain-based** — an email domain on the tenant (non-SSO) or an SSO domain on the tenant's SSO config (SSO); or **explicit tenant slug** — tenant name/ID hardcoded in source ([ref](https://docs.descope.com/sso/multi-sso)).
 - Descope supports tenant-level SSO enforcement (require SAML/OIDC for all users in a tenant) ([ref](https://docs.descope.com/management/tenant-management/tenant)).
 - Users are project-level entities in Descope; they're associated with tenants, not created per-tenant.
 - Organization `metadata` → tenant `customAttributes` (pre-define in the Console schema).


### PR DESCRIPTION
## Related Issues

Fixes [Issue 15997](https://github.com/descope/etc/issues/15997)

## Description

Skill explaining how to migrate from using WorkOS to Descope as auth provider, including a feature migration map. Similar to the Auth0 skill but for WorkOS. 

## Testing 
Tested on the following sample apps:

- [Next B2B AuthKit Sample App](https://github.com/workos/next-b2b-starter-kit)
- [Vercel MCP Adapter + WorkOS AuthKit Sample App](https://github.com/workos/vercel-mcp-example)
- [Supabase + Authkit Sample App](https://github.com/workos/supabase-authkit-example)
