### PR TITLE
feat: add Cursor plugin manifest

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,20 +5,20 @@
     "email": "support@descope.com"
   },
   "metadata": {
-    "description": "Descope authentication, authorization, and security skills for Cursor",
-    "version": "1.1.2"
+    "description": "Descope authentication, authorization, migration, and security skills for Cursor",
+    "version": "1.1.9"
   },
   "plugins": [
     {
       "name": "descope-skills",
       "source": "./",
-      "description": "Skills for integrating Descope authentication and managing projects with Terraform",
+      "description": "Descope authentication skills: integration, Auth0/Okta/WorkOS/Stytch migration, Terraform, FGA authorization schemas, security review, and BYOS custom UI",
       "repository": "https://github.com/descope/skills.git",
       "author": {
         "name": "Descope",
         "email": "support@descope.com"
       },
-      "keywords": ["descope", "authentication", "terraform", "quickstart", "migration", "mfa", "security", "oauth", "sso", "passkey", "ci-cd", "deployment"],
+      "keywords": ["descope", "authentication", "terraform", "quickstart", "migration", "oauth", "sso", "passkey", "mfa", "fga", "authorization", "security", "byos", "ci-cd", "deployment"],
       "category": "authentication"
     }
   ]

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "descope-skills",
+  "owner": {
+    "name": "Descope",
+    "email": "support@descope.com"
+  },
+  "metadata": {
+    "description": "Descope authentication, authorization, and security skills for Cursor",
+    "version": "1.1.2"
+  },
+  "plugins": [
+    {
+      "name": "descope-skills",
+      "source": "./",
+      "description": "Skills for integrating Descope authentication and managing projects with Terraform",
+      "repository": "https://github.com/descope/skills.git",
+      "author": {
+        "name": "Descope",
+        "email": "support@descope.com"
+      },
+      "keywords": ["descope", "authentication", "terraform", "quickstart", "migration", "mfa", "security", "oauth", "sso", "passkey", "ci-cd", "deployment"],
+      "category": "authentication"
+    }
+  ]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,10 +1,12 @@
 {
   "name": "descope-skills",
-  "description": "Skills for integrating Descope authentication, managing projects with Terraform, and authoring FGA authorization schemas",
+  "displayName": "Descope Skills",
   "version": "1.1.2",
+  "description": "Skills for integrating Descope authentication, managing projects with Terraform, and authoring FGA authorization schemas",
   "author": {
     "name": "Descope",
-    "email": "support@descope.com"
+    "email": "support@descope.com",
+    "url": "https://www.descope.com"
   },
   "homepage": "https://docs.descope.com",
   "repository": "https://github.com/descope/skills",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "descope-skills",
   "displayName": "Descope Skills",
-  "version": "1.1.2",
-  "description": "Skills for integrating Descope authentication, managing projects with Terraform, and authoring FGA authorization schemas",
+  "version": "1.1.9",
+  "description": "Descope authentication skills: integration, Auth0/Okta/WorkOS/Stytch migration, Terraform, FGA authorization schemas, security review, and BYOS custom UI",
   "author": {
     "name": "Descope",
     "email": "support@descope.com",
@@ -11,5 +11,5 @@
   "homepage": "https://docs.descope.com",
   "repository": "https://github.com/descope/skills",
   "license": "MIT",
-  "keywords": ["descope", "authentication", "terraform", "quickstart", "migration", "oauth", "sso", "passkey", "mfa", "fga", "authorization", "security", "ci-cd", "deployment"]
+  "keywords": ["descope", "authentication", "terraform", "quickstart", "migration", "oauth", "sso", "passkey", "mfa", "fga", "authorization", "security", "byos", "ci-cd", "deployment"]
 }

--- a/README.md
+++ b/README.md
@@ -300,7 +300,15 @@ Add the marketplace and install the plugin:
 <details>
 <summary><b>Using Cursor</b></summary>
 
-The repo ships a Cursor plugin manifest (`.cursor-plugin/`), so it installs as a single `descope-skills` Cursor Marketplace plugin that bundles every skill under `skills/`.
+Install from the Cursor Marketplace. In Cursor, run:
+
+```
+/add-plugin descope-skills
+```
+
+Or open the Marketplace panel (or visit [cursor.com/marketplace](https://cursor.com/marketplace)), search for **Descope**, and install.
+
+The repo ships a Cursor plugin manifest (`.cursor-plugin/`), so it installs as a single `descope-skills` plugin that bundles every skill under `skills/`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ Add the marketplace and install the plugin:
 
 </details>
 
+<details>
+<summary><b>Using Cursor</b></summary>
+
+The repo ships a Cursor plugin manifest (`.cursor-plugin/`), so it installs as a single `descope-skills` Cursor Marketplace plugin that bundles every skill under `skills/`.
+
+</details>
+
 ## Usage
 
 Skills are automatically loaded by compatible AI agents once installed. Simply describe what you need:


### PR DESCRIPTION
## Description

Ships the repo as a **Cursor Marketplace plugin**, mirroring the existing Claude Code setup so Cursor users can install the Descope skills the same way.

Adds a root-level `.cursor-plugin/` directory:
- `plugin.json` — single `descope-skills` plugin manifest (parity with `.claude-plugin/plugin.json`)
- `marketplace.json` — marketplace with one entry, `source: "./"`, so the whole repo installs as one plugin and bundles every skill under `skills/` with **no duplication**

This follows the same convention the repo already uses for Claude Code (`.claude-plugin/`, `source: "./"`), rather than creating a separate plugin folder per skill. As new skills land under `skills/` (e.g. the Okta/WorkOS/Stytch migration skills, security review, and BYOS builder), they're picked up automatically — nothing per-skill to maintain.

The Cursor manifest's `name`, `description`, `version`, and `keywords` are kept in sync with `.claude-plugin/plugin.json`, so the description reflects the full skill set: auth integration, Auth0/Okta/WorkOS/Stytch migration, Terraform, FGA authorization schemas, security review, and BYOS custom UI.

Also adds a "Using Cursor" section to the README installation docs.

## Testing

- [x] Validated the plugin layout against the Cursor plugin template validator → **Validation passed** (hooks/mcp warnings are expected for a skills-only plugin)
- [x] Manifests are valid JSON
- [x] Cursor description/keywords/version match `.claude-plugin/plugin.json`

## Notes for reviewer

- No skill content changed — this is packaging only.
- The single-plugin / `source: "./"` shape intentionally matches the Claude Code plugin so all skills are picked up automatically.