### PR TITLE
Rename Risks section to Trade-offs and considerations in migration skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "descope-skills",
   "description": "Descope authentication skills: integration, Auth0/Okta/WorkOS/Stytch migration, Terraform, FGA authorization schemas, security review, and BYOS custom UI",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "author": {
     "name": "Descope",
     "email": "support@descope.com"

--- a/skills/auth0-to-descope/SKILL.md
+++ b/skills/auth0-to-descope/SKILL.md
@@ -367,13 +367,13 @@ End with a brief checklist of the migration steps at the level a PM can track:
 
 ---
 
-#### Risks and Things to Decide
+#### Trade-offs and considerations
 
 Things that could affect timeline, user experience, or scope. Write each in plain English
 with three parts: **what it is**, **what breaks if it's ignored**, and **what to do**.
 Format each as a named callout:
 
-> **Risk: User profile data won't appear after login until a token template is configured**
+> **Consideration: User profile data won't appear after login until a token template is configured**
 > Descope session tokens don't include name, email, or profile photo by default. Any part of
 > the app that displays user information — profile pages, nav bars, greeting text — will show
 > blank values after migration until the token template is set up in the Descope console. This
@@ -381,14 +381,14 @@ Format each as a named callout:
 > **Action:** Configure the token template in the Descope console before running any tests.
 > Estimated time: 10 minutes.
 
-> **Risk: Password migration requires an Auth0 support request**
+> **Consideration: Password migration requires an Auth0 support request**
 > If the app supports password-based login, users' hashed passwords must be exported from
 > Auth0 and imported into Descope. Auth0 only releases these via a support ticket, which can
 > take several days to fulfill.
 > **Action:** Open the support ticket now, in parallel with development work. Without it,
 > password users will need to reset their passwords after cutover.
 
-Include only applicable risks.
+Include only applicable trade-offs and considerations.
 
 ---
 
@@ -445,7 +445,7 @@ After writing `MIGRATION-PLAN.md`, **stop and tell the user:**
 
 > `MIGRATION-PLAN.md` has been written to your working directory. It maps every auth
 > touchpoint found, lists what needs Console setup before the first test, and calls out
-> risks that could affect the timeline.
+> trade-offs and considerations that could affect the timeline.
 >
 > Take a look before we start making changes. When you're ready to proceed, say so.
 

--- a/skills/okta-cis-to-descope/SKILL.md
+++ b/skills/okta-cis-to-descope/SKILL.md
@@ -494,11 +494,11 @@ End with a brief PM-trackable checklist:
 
 ---
 
-#### Risks and Things to Decide
+#### Trade-offs and considerations
 
 Write each in plain English with three parts: **what it is**, **what breaks if it's ignored**, **what to do**.
 
-> **Risk: scp → scope claim rename (code change, always required)**
+> **Consideration: scp → scope claim rename (code change, always required)**
 > This is a JWT claim name change, separate from the Inbound vs. Federated App decision.
 > Okta access tokens carry scopes in `scp` (JSON array). Descope uses `scope` (space-separated
 > string or array). Any backend code reading `token.scp`, `claims["scp"]`, or `req.auth.scp`
@@ -508,31 +508,31 @@ Write each in plain English with three parts: **what it is**, **what breaks if i
 > and handle both string and array formats. This is separate from configuring Inbound Apps
 > (which is about *whether* scopes are enforced, not the claim name).
 
-> **Risk: User profile data won't appear after login until a JWT Template is configured**
+> **Consideration: User profile data won't appear after login until a JWT Template is configured**
 > Descope session tokens don't include `email` or `name` by default. Any UI that shows user
 > profile information will show blank values after migration.
 > **Action:** Configure the JWT Template in the Console before running any tests. (~10 minutes.)
 
-> **Risk: Password migration is blocked by Okta policy**
+> **Consideration: Password migration is blocked by Okta policy**
 > Okta does not release password hashes. Password users will need to reset their passwords after
 > cutover.
 > **Action:** Decide on a migration strategy (reset campaign, first-login flow step, or switch
 > to passwordless) before setting a cutover date.
 
-> **Risk: Passkeys and TOTP credentials cannot be migrated**
+> **Consideration: Passkeys and TOTP credentials cannot be migrated**
 > Okta does not expose passkey credentials or TOTP seeds. Users who enrolled these authenticators
 > in Okta must re-provision them after cutover — there is no way to migrate them silently.
 > **Action:** Add a re-enrollment step to the sign-in Flow conditioned on `freshlyMigrated: true`
 > and set user expectations before the cutover date.
 
-> **Risk: Inbound Apps vs. Federated Apps misclassification**
+> **Consideration: Inbound Apps vs. Federated Apps misclassification**
 > If the backend validates `scp` claims from Okta access tokens and Federated Apps are configured
 > instead of Inbound Apps, the backend receives tokens with no `scope` claim and all scope
 > checks fail — likely silently.
 > **Action:** Confirm before Console setup whether any backend service validates token scopes.
 > If yes, configure Inbound Apps with scope definitions matching the Okta Authorization Server.
 
-Include only applicable risks.
+Include only applicable trade-offs and considerations.
 
 ---
 
@@ -600,7 +600,7 @@ After writing `MIGRATION-PLAN.md`, **stop and tell the user:**
 
 > `MIGRATION-PLAN.md` has been written to your working directory. It maps every auth
 > touchpoint found, lists what needs Console setup before the first test, and calls out
-> risks that could affect the timeline.
+> trade-offs and considerations that could affect the timeline.
 >
 > Take a look before we start making changes. When you're ready to proceed, say so.
 

--- a/skills/stytch-to-descope/SKILL.md
+++ b/skills/stytch-to-descope/SKILL.md
@@ -500,34 +500,34 @@ End with a brief checklist of the migration steps at the level a PM can track:
 
 ---
 
-#### Risks and Things to Decide
+#### Trade-offs and considerations
 
 Things that could affect timeline, user experience, or scope. Write each in plain English
 with three parts: **what it is**, **what breaks if it's ignored**, and **what to do**.
 Format each as a named callout:
 
-> **Risk: Organization-to-tenant mapping affects almost every B2B feature**
+> **Consideration: Organization-to-tenant mapping affects almost every B2B feature**
 > Stytch Organizations should usually map to Descope Tenants. If this mapping is wrong, SSO, SCIM,
 > roles, permissions, domain routing, and user membership checks may all break.
 > **Action:** Confirm the organization model before writing migration code.
 
-> **Risk: SCIM is a lifecycle system, not just a user import**
+> **Consideration: SCIM is a lifecycle system, not just a user import**
 > Stytch's SCIM may create, update, suspend, and delete users or group memberships continuously.
 > A one-time import is not enough if enterprise directories keep syncing after cutover.
 > **Action:** Identify every SCIM workflow and re-point it at Descope before cutover.
 
-> **Risk: Admin Portal UI should not automatically become custom code**
+> **Consideration: Admin Portal UI should not automatically become custom code**
 > If the app uses the Stytch Admin Portal UI, the Descope equivalent may be the SSO Setup Suite or a
 > Widget rather than a custom settings page.
 > **Action:** Ask whether tenant admins currently self-configure SSO/SCIM/domain verification.
 
-> **Risk: User profile data won't appear after login until a token template is configured**
+> **Consideration: User profile data won't appear after login until a token template is configured**
 > Descope session tokens don't include name, email, or profile photo by default. Any UI that
 > displays user information will show blank values after migration until the token template is set
 > up in the Descope console. This is a one-time configuration step, not a code change.
 > **Action:** Configure the token template before running any tests. Estimated time: 10 minutes.
 
-Include only applicable risks.
+Include only applicable trade-offs and considerations.
 
 ---
 
@@ -590,7 +590,7 @@ After writing `MIGRATION-PLAN.md`, **stop and tell the user:**
 
 > `MIGRATION-PLAN.md` has been written to your working directory. It maps every auth
 > touchpoint found, lists what needs Console setup before the first test, and calls out
-> risks that could affect the timeline.
+> trade-offs and considerations that could affect the timeline.
 >
 > Take a look before we start making changes. When you're ready to proceed, say so.
 

--- a/skills/workos-to-descope/SKILL.md
+++ b/skills/workos-to-descope/SKILL.md
@@ -438,39 +438,39 @@ End with a brief checklist of the migration steps at the level a PM can track:
 
 ---
 
-#### Risks and Things to Decide
+#### Trade-offs and considerations
 
 Things that could affect timeline, user experience, or scope. Write each in plain English
 with three parts: **what it is**, **what breaks if it's ignored**, and **what to do**.
 Format each as a named callout:
 
-> **Risk: Organization-to-tenant mapping affects almost every B2B feature**
+> **Consideration: Organization-to-tenant mapping affects almost every B2B feature**
 > WorkOS Organizations should usually map to Descope Tenants. If this mapping is wrong, SSO, SCIM,
 > roles, permissions, domain routing, and user membership checks may all break.
 > **Action:** Confirm the organization model before writing migration code.
 
-> **Risk: SCIM is a lifecycle system, not just a user import**
+> **Consideration: SCIM is a lifecycle system, not just a user import**
 > Directory Sync may create, update, suspend, and delete users or group memberships continuously.
 > A one-time import is not enough if enterprise directories keep syncing after cutover.
 > **Action:** Identify every SCIM/directory workflow and re-point it at Descope before cutover.
 
-> **Risk: Admin Portal workflows should not automatically become custom code**
+> **Consideration: Admin Portal workflows should not automatically become custom code**
 > If the app uses the WorkOS Admin Portal, the Descope equivalent may be the SSO Setup Suite or a
 > Widget rather than a custom settings page.
 > **Action:** Ask whether tenant admins currently self-configure SSO/SCIM/domain verification.
 
-> **Risk: Audit logs can silently disappear**
+> **Consideration: Audit logs can silently disappear**
 > The app may keep working after migration even if audit logging is broken — creating compliance
 > and enterprise-customer issues.
 > **Action:** Set up Descope audit/event forwarding before production cutover.
 
-> **Risk: User profile data won't appear after login until a token template is configured**
+> **Consideration: User profile data won't appear after login until a token template is configured**
 > Descope session tokens don't include name, email, or profile photo by default. Any UI that
 > displays user information will show blank values after migration until the token template is set
 > up in the Descope console. This is a one-time configuration step, not a code change.
 > **Action:** Configure the token template before running any tests. Estimated time: 10 minutes.
 
-Include only applicable risks.
+Include only applicable trade-offs and considerations.
 
 ---
 
@@ -532,7 +532,7 @@ After writing `MIGRATION-PLAN.md`, **stop and tell the user:**
 
 > `MIGRATION-PLAN.md` has been written to your working directory. It maps every auth
 > touchpoint found, lists what needs Console setup before the first test, and calls out
-> risks that could affect the timeline.
+> trade-offs and considerations that could affect the timeline.
 >
 > Take a look before we start making changes. When you're ready to proceed, say so.
 


### PR DESCRIPTION
## Summary
- Renames the `#### Risks and Things to Decide` section header to `#### Trade-offs and considerations` in all four migration skills (Auth0, Okta CIS, Stytch, WorkOS), since moving to Descope shouldn't be framed as risky
- Renames the inline `> **Risk: ...**` callouts within that section to `> **Consideration: ...**`
- Updates related instructional text ("Include only applicable risks" → "...trade-offs and considerations"; "calls out risks that could affect the timeline" → "...trade-offs and considerations that could affect the timeline")
- Bumps `plugin.json` to `1.1.10` per the repo's version-bump convention (patch bump for edits to existing skills)

Product-terminology mentions of "risk" (e.g. Stytch's "Fraud & Risk" feature, Descope's `riskInfo`/`riskScore` fields, "Risk-based MFA") were left untouched since those refer to a product capability, not migration risk.

## Test plan
- [x] Verified diff only touches the intended header/callout text in the four migration `SKILL.md` files
- [x] Confirmed no other migration skills reference "Risks" as a section header