### PR TITLE
feat(skill): Update descope-fga-schema skill to be agent-agnostic

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "descope-skills",
   "description": "Descope authentication skills: integration, Auth0/Okta/WorkOS/Stytch/PingOne migration, Terraform, FGA authorization schemas, security review, and BYOS custom UI",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "author": {
     "name": "Descope",
     "email": "support@descope.com"

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -13,12 +13,12 @@ Help the user design and apply Descope FGA schemas. The workflow is: understand 
 
 **If the tools are not found:** output only the message below, then end your turn. Do not generate a schema, do not say "here's what I'll apply once connected", do not do any design work, do not continue:
 
-> The Descope Management MCP is required. If not yet installed, install and authorize it, then restart Claude Code and re-run `/descope-fga-schema`.
-> If already installed, it may need authorization. Authorize the Descope MCP, then restart Claude Code and re-run `/descope-fga-schema`.
+> The Descope Management MCP is required. If not yet installed, install and authorize it, then restart your AI agent and re-run this request. See https://docs.descope.com/mcp/mcp-server#connecting for setup instructions.
+> If already installed, it may need authorization. Authorize the Descope MCP, then restart your AI agent and re-run this request.
 
 **If the tools are found:** call `GetFGASchema` immediately as a connectivity probe before doing any other work. If this call returns an authorization error, output only the message below and end your turn:
 
-> The Descope MCP is installed but not authorized. Authorize it, restart Claude Code, and re-run `/descope-fga-schema`.
+> The Descope MCP is installed but not authorized. Authorize it, restart your AI agent, and re-run this request. See https://docs.descope.com/mcp/mcp-server#connecting for setup instructions.
 
 All FGA operations go through MCP tool calls — never make raw HTTP requests yourself.
 

--- a/skills/descope-fga-schema/SKILL.md
+++ b/skills/descope-fga-schema/SKILL.md
@@ -13,12 +13,12 @@ Help the user design and apply Descope FGA schemas. The workflow is: understand 
 
 **If the tools are not found:** output only the message below, then end your turn. Do not generate a schema, do not say "here's what I'll apply once connected", do not do any design work, do not continue:
 
-> The Descope Management MCP is required. If not yet installed, install and authorize it, then restart your AI agent and re-run this request. See https://docs.descope.com/mcp/mcp-server#connecting for setup instructions.
-> If already installed, it may need authorization. Authorize the Descope MCP, then restart your AI agent and re-run this request.
+> The Descope Management MCP is required. If not yet installed, install and authorize it, then restart your AI agent and re-run `/descope-fga-schema`. See https://docs.descope.com/mcp/mcp-server#connecting for setup instructions.
+> If already installed, it may need authorization. Authorize the Descope MCP, then restart your AI agent and re-run `/descope-fga-schema`.
 
 **If the tools are found:** call `GetFGASchema` immediately as a connectivity probe before doing any other work. If this call returns an authorization error, output only the message below and end your turn:
 
-> The Descope MCP is installed but not authorized. Authorize it, restart your AI agent, and re-run this request. See https://docs.descope.com/mcp/mcp-server#connecting for setup instructions.
+> The Descope MCP is installed but not authorized. Authorize it, restart Claude Code, and re-run `/descope-fga-schema`.
 
 All FGA operations go through MCP tool calls — never make raw HTTP requests yourself.
 


### PR DESCRIPTION
## Related Issues

Related to https://github.com/descope/etc/issues/4621

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

This commit updates the descope-fga-schema SKILL because originally it was created to be specifically for Claude Code, so if for instance the agent doesn't find the Descope MCP to be installed when using this skill, then it would tell the user, no matter what, the answer as if the user is only ever using Claude -- so, if the user is using ChatGPT, the instructions wouldn't apply.

With this change, the skill will simply now point at our docs, which explain how to install our MCP server for a number of client options.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
